### PR TITLE
Add initial support for devcontainer

### DIFF
--- a/README.org
+++ b/README.org
@@ -182,6 +182,31 @@ Start an agent shell session:
 - =M-x agent-shell-google-start-gemini= - Start a Gemini agent session
 - =M-x agent-shell-goose-start-agent= - Start a Goose agent session
 
+** Running agents in Devcontainers / Docker containers
+
+=agent-shell= provides rudimentary support for running agents in containers.
+
+Adapt the command that starts the agent so it is executed inside the container; for example:
+
+#+begin_src emacs-lisp
+(setq agent-shell-anthropic-claude-command '("devcontainer" "exec" "--workspace-folder" "." "claude-code-acp"))
+#+end_src
+
+Note that any =:environment-variables= you may have passed to =acp-make-client= will not apply to the agent process running inside the container.
+It's expected to inject environment variables by means of your devcontainer configuration / Dockerfile.
+
+Next, set an =agent-shell-path-resolver-function= that resolves container paths in the local working directory, and vice versa.
+Agent shell provides the =agent-shell--resolve-devcontainer-path= function for use with devcontainers:
+
+#+begin_src emacs-lisp
+(setq agent-shell-path-resolver-function #'agent-shell--resolve-devcontainer-path)
+#+end_src
+
+Note that this allows the agent to access files on your local file-system.
+While care has been taken to restrict access to files in the local working directory, it's probably possible for a malicious agent to circumvent this restriction.
+
+All of the above settings can be applied on a per-project basis using [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html][directory-local variables]].
+
 ** Keybindings
 
 - =C-c C-c= - Interrupt current agent operation

--- a/README.org
+++ b/README.org
@@ -205,7 +205,7 @@ Agent shell provides the =agent-shell--resolve-devcontainer-path= function for u
 Note that this allows the agent to access files on your local file-system.
 While care has been taken to restrict access to files in the local working directory, it's probably possible for a malicious agent to circumvent this restriction.
 
-Optional: to prevent access of your local file-system altogether and to have the agent read/modify files inside the container directly, in addition to setting the resolver function, disable the "read/write text file" client capabilities:
+Optional: to prevent the agent running inside the container to access your local file-system altogether and to have it read/modify files inside the container directly, in addition to setting the resolver function, disable the "read/write text file" client capabilities:
 
 #+begin_src emacs-lisp
 (setq agent-shell-text-file-capabilities nil)

--- a/README.org
+++ b/README.org
@@ -182,7 +182,7 @@ Start an agent shell session:
 - =M-x agent-shell-google-start-gemini= - Start a Gemini agent session
 - =M-x agent-shell-goose-start-agent= - Start a Goose agent session
 
-** Running agents in Devcontainers / Docker containers
+** Running agents in Devcontainers / Docker containers (Experimental)
 
 =agent-shell= provides rudimentary support for running agents in containers.
 

--- a/README.org
+++ b/README.org
@@ -205,6 +205,12 @@ Agent shell provides the =agent-shell--resolve-devcontainer-path= function for u
 Note that this allows the agent to access files on your local file-system.
 While care has been taken to restrict access to files in the local working directory, it's probably possible for a malicious agent to circumvent this restriction.
 
+Optional: to prevent access of your local file-system altogether and to have the agent read/modify files inside the container directly, in addition to setting the resolver function, disable the "read/write text file" client capabilities:
+
+#+begin_src emacs-lisp
+(setq agent-shell-text-file-capabilities nil)
+#+end_src
+
 All of the above settings can be applied on a per-project basis using [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html][directory-local variables]].
 
 ** Keybindings

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -575,11 +575,11 @@ For example:
     (if (string-prefix-p cwd path)
         (string-replace cwd devcontainer-path path)
       (if agent-shell-text-file-capabilities
-          (if (string-prefix-p devcontainer-path path)
-              (let ((local-path (expand-file-name (string-replace devcontainer-path cwd path))))
-                (or
-                 (and (file-in-directory-p local-path cwd) local-path)
-                 (error "Resolves to path outside of working directory: %s" path)))
+          (if-let* ((is-dev-container (string-prefix-p devcontainer-path path))
+                    (local-path (expand-file-name (string-replace devcontainer-path cwd path))))
+              (or
+               (and (file-in-directory-p local-path cwd) local-path)
+               (error "Resolves to path outside of working directory: %s" path))
             (error "Unexpected path outside of workspace folder: %s" path))
         (error "Refuse to resolve to local filesystem with text file capabilities disabled: %s" path)))))
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -70,7 +70,9 @@ returns the resolved path. Set to nil to disable mapping."
   :group 'agent-shell)
 
 (defcustom agent-shell-text-file-capabilities t
-  "Whether agents are initialized with read/write text file capabilities."
+  "Whether agents are initialized with read/write text file capabilities.
+
+See `acp-make-initialize-request' for details."
   :type 'boolean
   :group 'agent-shell)
 
@@ -549,7 +551,9 @@ LINE defaults to 1, LIMIT defaults to nil (read to end)."
   (funcall (or agent-shell-path-resolver-function #'identity) path))
 
 (defun agent-shell--get-devcontainer-workspace-path (cwd)
-  "Return devcontainer workspaceFolder for CWD; signal error if none found."
+  "Return devcontainer workspaceFolder for CWD; signal error if none found.
+
+See https://containers.dev for more information on devcontainers."
   (let ((devcontainer-config-file-name (expand-file-name ".devcontainer/devcontainer.json" cwd)))
     (condition-case _err
         (or
@@ -560,7 +564,12 @@ LINE defaults to 1, LIMIT defaults to nil (read to end)."
       (json-string-format (error "No valid JSON: %s" devcontainer-config-file-name)))))
 
 (defun agent-shell--resolve-devcontainer-path (path)
-  "Resolve PATH from a devcontainer in the local filesystem, and vice versa."
+  "Resolve PATH from a devcontainer in the local filesystem, and vice versa.
+
+For example:
+
+- /workspace/README.md => /home/xenodium/projects/kitchen-sink/README.md
+- /home/xenodium/projects/kitchen-sink/README.md => /workspace/README.md"
   (let* ((cwd (agent-shell-cwd))
          (devcontainer-path (agent-shell--get-devcontainer-workspace-path cwd)))
     (if (string-prefix-p cwd path)


### PR DESCRIPTION
Introduces a new customization option `agent-shell-map-path-function` to allow for mapping paths in ACP requests.

By default, maps paths from a devcontainer to the local filesystem, or vice versa, when there is a `.devcontainer/devcontainer.json` file in your project root / working directory, which specifies a `workspaceFolder`. If such a file is detected, we assume devcontainers are used and paths should be mapped.

If you prefer not to use a project's devcontainer setup at all, just set `agent-shell-map-path-function` to `nil` locally (for example, in dir-local variables).

Note that the new customization option is not not, in fact, devcontainer specific -- just its default setting is. You could set `agent-shell-map-path-function` to a function that maps paths between your local filesystem and, say, a remote SSH box via TRAMP even.

Note that this PR does not deal with starting the agent in a devcontainer -- you'll still need to use a handcrafted `client-maker` for that. For example, mine looks like this:

```lisp
(defun agent-shell-start-claude-code-agent ()
  "Start an interactive Claude Code agent shell."
  (interactive)
  (agent-shell--start
   ;; ...
   :client-maker (lambda ()
                   (acp-make-client
                    :command "devcontainer"
                    :command-params '("exec" "--workspace-folder" "." "claude-code-acp")))))

```

Resolves #18