### PR TITLE
Fix customization group for agent-shell-anthropic-authentication

### DIFF
--- a/agent-shell-anthropic.el
+++ b/agent-shell-anthropic.el
@@ -66,7 +66,7 @@ For api key:
   (setq agent-shell-anthropic-authentication
         (agent-shell-make-anthropic-authentication :api-key (lambda () ... )))"
   :type 'alist
-  :group 'acp)
+  :group 'agent-shell)
 
 (defun agent-shell-anthropic-start-claude-code ()
   "Start an interactive Claude Code agent shell."


### PR DESCRIPTION
Change the customization group for the Anthropic API key setting from `acp` to `agent-shell` in `agent-shell-anthropic.el`