### PR TITLE
add doom-specific installation steps to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,6 +64,26 @@ Finally, install =agent-shell= with:
     :vc (:url "https://github.com/xenodium/agent-shell"))
 #+end_src
 
+*** Doom Emacs
+
+If you are using Doom Emacs and would like to use the =package!= macro:
+
+#+begin_src emacs-lisp
+(package! shell-maker)
+(package! acp :recipe (:host github :repo "xenodium/acp.el"))
+(package! agent-shell :recipe (:host github :repo "xenodium/agent-shell"))
+#+end_src
+
+Run =doom sync= and restart.
+
+Include =require= before configuration:
+
+#+begin_src emacs-lisp
+(require 'acp)
+(require 'agent-shell)
+;; rest of config...
+#+end_src
+
 ** Configuration
 
 Configure authentication for the agent providers you want to use.


### PR DESCRIPTION
I'm not sure if you want to include this. But I saw the request [here](https://lobste.rs/s/6b0ud8/introducing_emacs_agent_shell_powered_by#c_0gkvha).