### PR TITLE
Fall back to default devcontainer workspace folder if none given

### DIFF
--- a/README.org
+++ b/README.org
@@ -297,18 +297,16 @@ Use =agent-shell-container-command-runner= to prefix the command that starts the
 (setq agent-shell-container-command-runner '("devcontainer" "exec" "--workspace-folder" "."))
 #+end_src
 
-Note that any =:environment-variables= you may have passed to =acp-make-client= will not apply to the agent process running inside the container.
-It's expected to inject environment variables by means of your devcontainer configuration / Dockerfile.
+Note that any =:environment-variables= you may have passed to =acp-make-client= will not apply to the agent process running inside the container. It's expected to inject environment variables by means of your devcontainer configuration / Dockerfile.
 
 Next, set an =agent-shell-path-resolver-function= that resolves container paths in the local working directory, and vice versa.
-Agent shell provides the =agent-shell--resolve-devcontainer-path= function for use with devcontainers:
+Agent shell provides the =agent-shell--resolve-devcontainer-path= function for use with devcontainers specifically: it reads the =workspaceFolder= specified in =.devcontainer/devcontainer.json=, or uses the default value of =/workspaces/<repository-name>= otherwise.
 
 #+begin_src emacs-lisp
 (setq agent-shell-path-resolver-function #'agent-shell--resolve-devcontainer-path)
 #+end_src
 
-Note that this allows the agent to access files on your local file-system.
-While care has been taken to restrict access to files in the local working directory, it's probably possible for a malicious agent to circumvent this restriction.
+Note that this allows the agent to access files on your local file-system. While care has been taken to restrict access to files in the local working directory, it's probably possible for a malicious agent to circumvent this restriction.
 
 Optional: to prevent the agent running inside the container to access your local file-system altogether and to have it read/modify files inside the container directly, in addition to setting the resolver function, disable the "read/write text file" client capabilities:
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -721,14 +721,13 @@ LINE defaults to 1, LIMIT defaults to nil (read to end)."
   (funcall (or agent-shell-path-resolver-function #'identity) path))
 
 (defun agent-shell--get-devcontainer-workspace-path (cwd)
-  "Return devcontainer workspaceFolder for CWD; signal error if none found.
+  "Return devcontainer workspaceFolder for CWD, or default value if none found.
 
 See https://containers.dev for more information on devcontainers."
   (let ((devcontainer-config-file-name (expand-file-name ".devcontainer/devcontainer.json" cwd)))
     (condition-case _err
-        (or
-         (map-elt (json-read-file devcontainer-config-file-name) 'workspaceFolder)
-         (error "No workspace folder defined in %s" devcontainer-config-file-name))
+        (map-elt (json-read-file devcontainer-config-file-name) 'workspaceFolder
+                 (concat "/workspaces/" (file-name-nondirectory (directory-file-name cwd))))
       (file-missing (error "Not found: %s" devcontainer-config-file-name))
       (permission-denied (error "Not readable: %s" devcontainer-config-file-name))
       (json-string-format (error "No valid JSON: %s" devcontainer-config-file-name)))))


### PR DESCRIPTION
Changes `agent-shell--get-devcontainer-workspace-path`, which determines the path under which the current project is mounted inside a devcontainer. This path is used to resolve devcontainer paths on the local filesystem and vice versa.

Update: if no `workspaceFolder` setting is found in `.devcontainer/devcontainer.json`, do not signal an error. Instead, fall back to the default value for this setting, which is `/workspaces/<repository-name>`.

Fixes #94 

