### PR TITLE
Return nil for "no header" style

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1330,7 +1330,7 @@ STATE should contain :agent-config with :icon-name, :buffer-name, and
                               (propertize (string-remove-suffix "/" (abbreviate-file-name default-directory))
                                           'font-lock-face 'font-lock-string-face))))
     (pcase agent-shell-header-style
-      ((or 'none (pred null)) "")
+      ((or 'none (pred null)) nil)
       ('text text-header)
       ('graphical
        (if (display-graphic-p)


### PR DESCRIPTION
Previously 'no header' style returned an empty string, which will be shown as a blank line. Return nil to hide a header line.

```elisp
(setq agent-shell-header-style nil) ;; no header
```

Before:
<img width="1192" height="894" alt="image" src="https://github.com/user-attachments/assets/c95ff224-ec30-4325-a6bc-3e482c004799" />

After:
<img width="1192" height="894" alt="image" src="https://github.com/user-attachments/assets/5a2bb613-31c3-4f06-bdd1-16504bb8d43d" />



