### PR TITLE
Fix Write tool diff preview for new files

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -922,7 +922,9 @@ Returns in the form:
                            (seq-find (lambda (item)
                                        (equal (map-elt item 'type) "diff"))
                                      acp-content))))
-              (old-text (map-elt diff-item 'oldText))
+              ;; oldText can be nil for Write tools creating new files, default to ""
+              ;; TODO: Currently don't have a way to capture overwrites
+              (old-text (or (map-elt diff-item 'oldText) ""))
               (new-text (map-elt diff-item 'newText))
               (file-path (map-elt diff-item 'path)))
     (append (list (cons :old old-text)


### PR DESCRIPTION
## Summary

This PR fixes the issue where Write tools creating new files showed no diff preview at all - only a one-line confirmation. This made it impossible to review what was being written without manually opening the file.

**Before:** Write tool creating new file shows no expandable diff
**After:** Write tool shows expandable diff preview with all content marked as additions (green + lines)

## Root Cause

When Write tools create new files, ACP sends `oldText` as `nil`. The `when-let*` form in `agent-shell--make-diff-info` requires all bindings to be non-nil, so when `old-text` is `nil`, the entire `when-let*` returns `nil` and no diff is generated.

## Solution

Default `oldText` to empty string (`""`) if `nil`:

```elisp
(old-text (or (map-elt diff-item 'oldText) ""))
```

Empty string is truthy so `when-let*` continues, and the diff command treats empty string as a 0-line file, correctly showing all new content as additions.

## Result

Write tools creating new files now show:
- Expandable diff preview with `╭─────────╮ │ changes │ ╰─────────╯` box
- All content marked as additions (green + lines)  
- `@@ -0,0 +1,N @@` header indicating new file
- Same UI/UX as Edit tools

## Limitation

File overwrites still show as all additions (not a proper diff) because the Write tool executes before we can capture the old content. Fixing this would require reading file content during the permission request phase. Added a TODO comment for this.

## Test Plan

- [x] Tested Write tool creating new file - shows diff preview
- [x] Confirmed diff shows all lines as additions with proper formatting
- [x] Verified existing Edit tool diffs still work correctly
- [x] Ran `M-x checkdoc` - no warnings
- [x] Ran `M-x byte-compile-file` - no warnings

Related: #99

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>