### PR TITLE
feat: introduce various hooks to support extension packages

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -645,9 +645,13 @@ Flow:
                               (cons :kind (map-elt update 'kind))
                               (cons :command (map-nested-elt update '(rawInput command)))
                               (cons :description (map-nested-elt update '(rawInput description)))
-                              (cons :content (map-elt update 'content)))
+                              (cons :content (map-elt update 'content))
+                              (cons :locations (map-elt update 'locations))
+                              (cons :rawInput (map-elt update 'rawInput)))
                         (when-let ((diff (agent-shell--make-diff-info (map-elt update 'content))))
                           (list (cons :diff diff)))))
+               ;; Run extension hooks after state update but before UI update
+               (run-hook-with-args 'agent-shell-tool-call-update-functions state update)
                (let ((tool-call-labels (agent-shell-make-tool-call-label
                                         state (map-elt update 'toolCallId))))
                  (agent-shell--update-dialog-block

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -417,6 +417,22 @@ BUFFER defaults to current buffer.
 Returns nil if buffer is not an agent-shell buffer."
   (map-elt (agent-shell-get-state buffer) :client))
 
+(defun agent-shell-tool-call-get (tool-call-id &optional buffer)
+  "Get tool call data for TOOL-CALL-ID from BUFFER's agent shell state.
+BUFFER defaults to current buffer.
+Returns the tool call alist or nil if not found."
+  (when-let ((state (agent-shell-get-state buffer)))
+    (map-nested-elt state (list :tool-calls tool-call-id))))
+
+(defun agent-shell-tool-call-put (tool-call-id data &optional buffer)
+  "Store tool call DATA for TOOL-CALL-ID in BUFFER's agent shell state.
+BUFFER defaults to current buffer.
+DATA should be an alist that will be merged with existing data.
+Returns non-nil on success."
+  (when-let ((state (agent-shell-get-state buffer)))
+    (agent-shell--save-tool-call state tool-call-id data)
+    t))
+
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
 When FORCE is non-nil, skip confirmation prompt."

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -433,6 +433,15 @@ Returns non-nil on success."
     (agent-shell--save-tool-call state tool-call-id data)
     t))
 
+(defun agent-shell-resolve-path (path)
+  "Resolve PATH using configured path resolver.
+This applies any path transformations configured via
+`agent-shell-path-resolver-function'.
+
+Extensions should use this instead of `agent-shell--resolve-path'
+to ensure consistent path handling across the system."
+  (agent-shell--resolve-path path))
+
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
 When FORCE is non-nil, skip confirmation prompt."

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -487,6 +487,17 @@ function to send responses at the appropriate time."
            :tool-call-id tool-call-id)
           t)))))
 
+(defun agent-shell-delete-dialog-block (block-id &optional buffer)
+  "Delete dialog block BLOCK-ID from BUFFER.
+BUFFER defaults to current buffer.
+Returns non-nil on success.
+
+This function is intended for use by extensions that create custom
+dialog blocks and need to clean them up later."
+  (when-let ((state (agent-shell-get-state buffer)))
+    (agent-shell--delete-dialog-block :state state :block-id block-id)
+    t))
+
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
 When FORCE is non-nil, skip confirmation prompt."

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -400,6 +400,23 @@ Returns an empty string if no icon should be displayed."
   (interactive)
   (message "agent-shell v%s" agent-shell--version))
 
+;;; Extension API
+
+(defun agent-shell-get-state (&optional buffer)
+  "Get agent shell state from BUFFER (defaults to current buffer).
+Returns nil if buffer is not an agent-shell buffer.
+Note: The returned state should be treated as read-only by extensions."
+  (with-current-buffer (or buffer (current-buffer))
+    (when (and (boundp 'agent-shell--state)
+               (derived-mode-p 'agent-shell-mode))
+      agent-shell--state)))
+
+(defun agent-shell-get-client (&optional buffer)
+  "Get ACP client from BUFFER's agent shell state.
+BUFFER defaults to current buffer.
+Returns nil if buffer is not an agent-shell buffer."
+  (map-elt (agent-shell-get-state buffer) :client))
+
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
 When FORCE is non-nil, skip confirmation prompt."


### PR DESCRIPTION
Hey @xenodium 👋 as [discussed here](https://github.com/xenodium/agent-shell/issues/68#issuecomment-3406904395), I've taken a stab at exposing an API for the pieces I needed to implement the "follow edits" feature I'd built previously as a separate package. With the changes in this PR, I had enough hooks to implement a standalone extension package: https://github.com/cmacrae/agent-shell-follow-edits

Let me know what you think, if you're happy supporting this API, or something close to it that you're happier with, that'd be great :)

---

<details><summary>Checklist</summary>

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [x] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable. (other hooks don't seem to have tests, but i'm happy to add some if you'd prefer :))
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.
</details>