### PR TITLE
Fix error when viewing proposed diffs

### DIFF
--- a/agent-shell-diff.el
+++ b/agent-shell-diff.el
@@ -143,8 +143,8 @@ Arguments:
                 (dolist (binding bindings)
                   (define-key map (kbd (map-elt binding :key)) (map-elt binding :command)))
                 (use-local-map map)))))
-      (pop-to-buffer diff-buffer '(display-buffer-use-some-window
-                                   display-buffer-same-window)))))
+      (pop-to-buffer diff-buffer '((display-buffer-use-some-window
+                                    display-buffer-same-window))))))
 
 (defun agent-shell-diff--make-diff (old new)
   "Create a unified diff between OLD and NEW strings.


### PR DESCRIPTION
The display-buffer ACTION argument should be of the form (FUNCTIONS . ALIST), where FUNCTIONS is a list of action functions. As given, the argument was resulted in a type error.

I'm happy to go back and file a ticket if necessary, but my understanding was that was only required for new features.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.
