### PR TITLE
Support setting a preferred agent config

### DIFF
--- a/README.org
+++ b/README.org
@@ -292,7 +292,7 @@ Start a specific agent shell session directly:
 You can set a default agent to use for all new shells started via =agent-shell= like so:
 
 #+begin_src emacs-lisp
-(setq agent-shell-new-shell-config (agent-shell-anthropic-make-claude-code-config))
+(setq agent-shell-preferred-agent-config (agent-shell-anthropic-make-claude-code-config))
 #+end_src
 
 ** Running agents in Devcontainers / Docker containers (Experimental)
@@ -364,7 +364,6 @@ All of the above settings can be applied on a per-project basis using [[https://
 | agent-shell-container-command-runner     | Command prefix for executing commands in a container.                         |
 | agent-shell-cursor-command               | Command and parameters for the Cursor agent client.                           |
 | agent-shell-cursor-environment           | Environment variables for the Cursor agent client.                            |
-| agent-shell-default-config               | Default configuration to use for all new agent shells.                        |
 | agent-shell-display-action               | Display action for agent shell buffers.                                       |
 | agent-shell-embed-file-size-limit        | Maximum file size in bytes for embedding with ContentBlock::Resource.         |
 | agent-shell-file-completion-enabled      | Non-nil automatically enables file completion when starting shells.           |
@@ -375,6 +374,7 @@ All of the above settings can be applied on a per-project basis using [[https://
 | agent-shell-goose-command                | Command and parameters for the Goose client.                                  |
 | agent-shell-goose-environment            | Environment variables for the Goose client.                                   |
 | agent-shell-header-style                 | Style for agent shell buffer headers.                                         |
+| agent-shell-highlight-blocks             | Whether or not to highlight source blocks.                                    |
 | agent-shell-openai-authentication        | Configuration for OpenAI authentication.                                      |
 | agent-shell-openai-codex-command         | Command and parameters for the OpenAI Codex client.                           |
 | agent-shell-openai-codex-environment     | Environment variables for the OpenAI Codex client.                            |
@@ -383,10 +383,12 @@ All of the above settings can be applied on a per-project basis using [[https://
 | agent-shell-opencode-environment         | Environment variables for the OpenCode client.                                |
 | agent-shell-path-resolver-function       | Function for resolving remote paths on the local file-system, and vice versa. |
 | agent-shell-permission-icon              | Icon displayed when shell commands require permission to execute.             |
+| agent-shell-preferred-agent-config       | Default configuration to use for all new shells.                              |
 | agent-shell-qwen-authentication          | Configuration for Qwen Code authentication.                                   |
 | agent-shell-qwen-command                 | Command and parameters for the Qwen Code client.                              |
 | agent-shell-qwen-environment             | Environment variables for the Qwen Code client.                               |
 | agent-shell-screenshot-command           | The program to use for capturing screenshots.                                 |
+| agent-shell-section-functions            | Abnormal hook run after overlays are applied (experimental).                  |
 | agent-shell-show-config-icons            | Whether to show icons in agent config selection.                              |
 | agent-shell-show-welcome-message         | Non-nil to show welcome message.                                              |
 | agent-shell-text-file-capabilities       | Whether agents are initialized with read/write text file capabilities.        |

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -258,7 +258,7 @@ See `agent-shell-*-make-*-config' for details."
   :type '(repeat (alist :key-type symbol :value-type sexp))
   :group 'agent-shell)
 
-(defcustom agent-shell-new-shell-config nil
+(defcustom agent-shell-preferred-agent-config nil
   "Default configuration to use for all new shells.
 
 If this is set, `agent-shell' will unconditionally use this
@@ -309,7 +309,7 @@ If already in a shell, invoke `agent-shell-toggle'.
 With prefix argument NEW-SHELL, force start a new shell."
   (interactive "P")
   (if new-shell
-      (agent-shell-start :config (or agent-shell-new-shell-config
+      (agent-shell-start :config (or agent-shell-preferred-agent-config
                                      (agent-shell-select-config
                                       :prompt "Start new agent: ")
                                      (error "No agent config found")))
@@ -319,12 +319,12 @@ With prefix argument NEW-SHELL, force start a new shell."
           (agent-shell--display-buffer existing-shell)
         (if-let ((other-project-shell (seq-first (agent-shell-buffers))))
             (if (y-or-n-p "No shells in project.  Start a new one? ")
-                (agent-shell-start :config (or agent-shell-new-shell-config
+                (agent-shell-start :config (or agent-shell-preferred-agent-config
                                                (agent-shell-select-config
                                                 :prompt "Start new agent: ")
                                                (error "No agent config found")))
               (agent-shell--display-buffer other-project-shell))
-          (agent-shell-start :config (or agent-shell-new-shell-config
+          (agent-shell-start :config (or agent-shell-preferred-agent-config
                                          (agent-shell-select-config
                                           :prompt "Start new agent: ")
                                          (error "No agent config found"))))))))


### PR DESCRIPTION
For users that only use a single agent, they might not want to always have to be prompted to select
from one of a list of mostly-irrelevant-to-them agent configurations.

For these users, we provide a `agent-shell-preferred-agent-config` with which they can define a specific
agent configuration to unconditionally use for all new agent-shell sessions.

For example, the following will allow users to unconditionally use Claude Code by default:

```elisp
(setq agent-shell-preferred-agent-config (agent-shell-anthropic-make-claude-code-config))
```

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.