### PR TITLE
fix: SVG header width to respect max-image-size

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1897,7 +1897,7 @@ BINDINGS is a list of alists defining key bindings to display, each with:
                   (icon-text-y text-height)
                   ;; Bindings positioned right after the bottom text (2 text lines) plus spacing
                   (bindings-y (+ (* 3 text-height) row-spacing))
-                  (svg (svg-create (frame-pixel-width) total-height))
+                   (svg (svg-create (agent-shell--safe-svg-width 1200) total-height))
                   (icon-filename
                    (if (map-nested-elt state '(:agent-config :icon-name))
                        (agent-shell--fetch-agent-icon (map-nested-elt state '(:agent-config :icon-name)))
@@ -2545,7 +2545,30 @@ Returns an alist with:
                   (cons :mime-type mime-type)
                   (cons :base64-p is-binary))
             (unless shallow
-              (list (cons :content content))))))
+               (list (cons :content content))))))
+
+(defun agent-shell--safe-svg-width (fallback-width)
+  "Calculate a safe width for SVG images that respects `max-image-size'.
+FALLBACK-WIDTH is used if frame-pixel-width is not available.
+Returns a width in pixels that won't exceed max-image-size limits."
+  (let* ((frame-width (if (display-graphic-p) (frame-pixel-width) fallback-width))
+         (max-size (bound-and-true-p max-image-size))
+         (safe-width frame-width))
+    (when max-size
+      (cond
+       ;; max-image-size is a number (megapixels)
+       ((numberp max-size)
+        (let* ((max-pixels (* max-size 1024 1024))  ; Convert MB to pixels
+               (max-width (floor max-pixels 100))) ; Assume height ~100px for headers
+          (setq safe-width (min frame-width max-width))))
+       ;; max-image-size is a cons (width . height)
+       ((consp max-size)
+        (let ((max-width (car max-size)))
+          (when max-width
+            (setq safe-width (min frame-width max-width))))))
+      ;; Ensure minimum reasonable width
+      (setq safe-width (max safe-width 400)))
+    safe-width))
 
 (cl-defun agent-shell--load-image (&key file-path (max-width 200))
   "Load image from FILE-PATH and return the image object.


### PR DESCRIPTION
## Summary
- Add `agent-shell--safe-svg-width()` helper function that respects `max-image-size`
- Handle both numeric MB limits and cons `(width . height)` forms
- Provide fallback width of 1200px and minimum of 400px  
- Update SVG creation to use safe width instead of raw `frame-pixel-width`
- Prevents "Invalid image size" errors when frame width exceeds limits

## Problem
`agent-shell-manager-goto` was failing with "Invalid image size" errors because the SVG header used `(frame-pixel-width)` directly, which could exceed Emacs' `max-image-size` limit (default: 10MB).

## Solution  
The new `agent-shell--safe-svg-width()` function:
- Respects `max-image-size` setting (both number and cons forms)
- Calculates safe width based on estimated header height (~100px)
- Provides fallback width of 1200px if frame width unavailable
- Ensures minimum width of 400px for usability

## Testing
- ✅ With default max-image-size (10MB): 1920px frame width passes through unchanged
- ✅ With restrictive max-image-size (0.1MB): 1920px gets clamped to 1048px  
- ✅ Minimum width guarantee ensures usability even with very restrictive limits

Fixes the issue where `agent-shell-manager-goto` would fail due to SVG image size exceeding `max-image-size` limits.