### PR TITLE
Implement basic CI: byte-compile + package-lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+---
+name: test
+on:
+  push:
+    branches:
+  pull_request:
+    branches:
+      - "main"
+jobs:
+  build-and-test:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+        - 29.3
+        - release-snapshot
+    env:
+      EMACS_VERSION: ${{ matrix.emacs_version }}
+    steps:
+    - name: Setup Emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+    - uses: actions/checkout@v6
+    - name: Byte-compile + package-lint
+      id: byte-compile-lint
+      run: |
+        emacs --version
+        make compile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+DEPS = shell-maker acp package-lint
+
+INIT_PACKAGES="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (package-initialize) \
+  (dolist (pkg '(${DEPS})) \
+    (unless (package-installed-p pkg) \
+      (unless (assoc pkg package-archive-contents) \
+	(package-refresh-contents)) \
+      (package-install pkg))) \
+  (unless package-archive-contents (package-refresh-contents)) \
+  )"
+
+.PHONY: compile
+compile:
+	emacs -Q --eval ${INIT_PACKAGES} -batch -L . -L tests \
+          --eval "(setq byte-compile-error-on-warn t)" \
+	  -f batch-byte-compile agent-shell*.el; \
+	  (ret=$$? ; rm *.elc && exit $$ret)
+
+.PHONY: package-lint
+package-lint:
+	emacs -Q --eval ${INIT_PACKAGES} -batch -L . -f package-lint-batch-and-exit agent-shell.el

--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -43,8 +43,11 @@
 (declare-function agent-shell--make-header "agent-shell")
 (declare-function agent-shell--relevant-text "agent-shell")
 (declare-function agent-shell--shell-buffer "agent-shell")
+(declare-function agent-shell--current-shell "agent-shell")
 (declare-function agent-shell--start "agent-shell")
 (declare-function agent-shell--state "agent-shell")
+(declare-function agent-shell--get-region "agent-shell")
+(declare-function agent-shell--display-buffer "agent-shell")
 (declare-function agent-shell-interrupt "agent-shell")
 (declare-function agent-shell-next-permission-button "agent-shell")
 (declare-function agent-shell-previous-permission-button "agent-shell")
@@ -53,6 +56,12 @@
 (declare-function agent-shell-ui-backward-block "agent-shell")
 (declare-function agent-shell-ui-forward-block "agent-shell")
 (declare-function agent-shell-ui-mode "agent-shell")
+
+(declare-function agent-shell-buffers "agent-shell")
+(declare-function agent-shell-other-buffer "agent-shell")
+(declare-function agent-shell-cycle-session-mode "agent-shell")
+(declare-function agent-shell-set-session-mode "agent-shell")
+(declare-function agent-shell-set-session-model "agent-shell")
 
 (defvar agent-shell-header-style)
 (defvar agent-shell-prefer-viewport-interaction)
@@ -526,6 +535,10 @@ If START-AT-TOP is non-nil, position at point-min regardless of direction."
            (with-current-buffer viewport-buffer
              (agent-shell-viewport--update-header))))))))
 
+;; Continuously fetching position can get expensive. Cache it.
+(defvar-local agent-shell-viewport--position-cache nil
+  "Cached position value (CURRENT . TOTAL).")
+
 (cl-defun agent-shell-viewport--position (&key force-refresh)
   "Return the position in history of the shell buffer.
 
@@ -556,6 +569,37 @@ When FORCE-REFRESH is non-nil, recalculate and update cache."
                             :no-error t)))
     (with-current-buffer shell-buffer
       shell-maker--busy)))
+
+(defvar agent-shell-viewport-edit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'agent-shell-viewport-compose-send)
+    (define-key map (kbd "C-c C-k") #'agent-shell-viewport-compose-cancel)
+    (define-key map (kbd "C-<tab>") #'agent-shell-viewport-cycle-session-mode)
+    (define-key map (kbd "C-c C-m") #'agent-shell-viewport-set-session-mode)
+    (define-key map (kbd "C-c C-v") #'agent-shell-viewport-set-session-model)
+    (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
+    map)
+  "Keymap for `agent-shell-viewport-edit-mode'.")
+
+(defvar agent-shell-viewport-view-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'agent-shell-viewport-interrupt)
+    (define-key map (kbd "n") #'agent-shell-viewport-next-item)
+    (define-key map (kbd "p") #'agent-shell-viewport-previous-item)
+    (define-key map (kbd "<tab>") #'agent-shell-viewport-next-item)
+    (define-key map (kbd "<backtab>") #'agent-shell-viewport-previous-item)
+    (define-key map (kbd "f") #'agent-shell-viewport-next-page)
+    (define-key map (kbd "b") #'agent-shell-viewport-previous-page)
+    (define-key map (kbd "r") #'agent-shell-viewport-reply)
+    (define-key map (kbd "q") #'bury-buffer)
+    (define-key map (kbd "C-<tab>") #'agent-shell-viewport-cycle-session-mode)
+    (define-key map (kbd "v") #'agent-shell-viewport-set-session-model)
+    (define-key map (kbd "m") #'agent-shell-viewport-set-session-mode)
+    (define-key map (kbd "o") #'agent-shell-other-buffer)
+    (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
+    map)
+  "Keymap for `agent-shell-viewport-view-mode'.")
+
 
 (defun agent-shell-viewport--update-header ()
   "Update header and mode line based on `agent-shell-header-style'.
@@ -647,22 +691,11 @@ For example, offer to kill associated shell session."
                                                         :shell-buffer shell-buffer
                                                         :existing-only t)
                                                        (current-buffer)))
-                                              (agent-shell-buffers)))
-                   (_ (y-or-n-p "Kill shell session too?")))
-          (mapc (lambda (shell-buffer)
-                  (kill-buffer shell-buffer))
-                shell-buffers)))))
-
-(defvar agent-shell-viewport-edit-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-c") #'agent-shell-viewport-compose-send)
-    (define-key map (kbd "C-c C-k") #'agent-shell-viewport-compose-cancel)
-    (define-key map (kbd "C-<tab>") #'agent-shell-viewport-cycle-session-mode)
-    (define-key map (kbd "C-c C-m") #'agent-shell-viewport-set-session-mode)
-    (define-key map (kbd "C-c C-v") #'agent-shell-viewport-set-session-model)
-    (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
-    map)
-  "Keymap for `agent-shell-viewport-edit-mode'.")
+                                              (agent-shell-buffers))))
+          (when (y-or-n-p "Kill shell session too?")
+            (mapc (lambda (shell-buffer)
+                    (kill-buffer shell-buffer))
+                  shell-buffers))))))
 
 (define-derived-mode agent-shell-viewport-edit-mode text-mode "Agent Shell Viewport (Edit)"
   "Major mode for composing agent shell prompts.
@@ -675,24 +708,6 @@ For example, offer to kill associated shell session."
     (erase-buffer))
   (add-hook 'kill-buffer-hook #'agent-shell-viewport--clean-up nil t))
 
-(defvar agent-shell-viewport-view-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-c") #'agent-shell-viewport-interrupt)
-    (define-key map (kbd "n") #'agent-shell-viewport-next-item)
-    (define-key map (kbd "p") #'agent-shell-viewport-previous-item)
-    (define-key map (kbd "<tab>") #'agent-shell-viewport-next-item)
-    (define-key map (kbd "<backtab>") #'agent-shell-viewport-previous-item)
-    (define-key map (kbd "f") #'agent-shell-viewport-next-page)
-    (define-key map (kbd "b") #'agent-shell-viewport-previous-page)
-    (define-key map (kbd "r") #'agent-shell-viewport-reply)
-    (define-key map (kbd "q") #'bury-buffer)
-    (define-key map (kbd "C-<tab>") #'agent-shell-viewport-cycle-session-mode)
-    (define-key map (kbd "v") #'agent-shell-viewport-set-session-model)
-    (define-key map (kbd "m") #'agent-shell-viewport-set-session-mode)
-    (define-key map (kbd "o") #'agent-shell-other-buffer)
-    (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
-    map)
-  "Keymap for `agent-shell-viewport-view-mode'.")
 
 (define-derived-mode agent-shell-viewport-view-mode text-mode "Agent Shell Viewport (View)"
   "Major mode for viewing agent shell prompts (read-only).

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -43,6 +43,7 @@
 (eval-when-compile
   (require 'cl-lib))
 (require 'dired)
+(require 'image)
 (require 'json)
 (require 'map)
 (unless (require 'markdown-overlays nil 'noerror)
@@ -631,10 +632,10 @@ Flow:
               ;; TODO: Make public in shell-maker.
               (shell-maker--current-request-id))
     (cond ((not (map-elt (agent-shell--state) :client))
-           (when-let ((_ (map-elt shell :buffer))
-                      (viewport-buffer (agent-shell-viewport--buffer
-                                        :shell-buffer (map-elt shell :buffer)
-                                        :existing-only t)))
+           (when-let* ((shell-buffer (map-elt shell :buffer))
+                       (viewport-buffer (agent-shell-viewport--buffer
+                                         :shell-buffer shell-buffer
+                                         :existing-only t)))
              (with-current-buffer viewport-buffer
                (agent-shell-viewport-view-mode)
                (agent-shell-viewport--initialize
@@ -925,10 +926,10 @@ Flow:
             :expanded t
             :navigation 'never)
            (agent-shell-jump-to-latest-permission-button-row)
-           (when-let ((_ (map-elt state :buffer))
-                      (viewport-buffer (agent-shell-viewport--buffer
-                                        :shell-buffer (map-elt state :buffer)
-                                        :existing-only t)))
+           (when-let* ((shell-buffer (map-elt state :buffer))
+                       (viewport-buffer (agent-shell-viewport--buffer
+                                         :shell-buffer shell-buffer
+                                         :existing-only t)))
              (with-current-buffer viewport-buffer
                (agent-shell-jump-to-latest-permission-button-row)))
            (map-put! state :last-entry-type "session/request_permission"))
@@ -1226,7 +1227,7 @@ Returns in the form:
 
 DIFF should be in the form returned by `agent-shell--make-diff-info':
   ((:old . old-text) (:new . new-text) (:file . file-path))"
-  (when-let ((_ diff)
+  (when-let (((identity diff))
              (old-file (make-temp-file "old"))
              (new-file (make-temp-file "new")))
     (unwind-protect
@@ -1342,11 +1343,11 @@ For example, shut down ACP client."
     (acp-shutdown :client (map-elt (agent-shell--state) :client)))
   (agent-shell-heartbeat-stop
    :heartbeat (map-elt (agent-shell--state) :heartbeat))
-  (when-let ((_ (map-elt (agent-shell--state) :buffer))
-             (viewport-buffer (agent-shell-viewport--buffer
-                               :shell-buffer (map-elt (agent-shell--state) :buffer)
-                               :existing-only t))
-             (buffer-live-p viewport-buffer))
+  (when-let* ((shell-buffer (map-elt (agent-shell--state) :buffer))
+              (viewport-buffer (agent-shell-viewport--buffer
+                                :shell-buffer shell-buffer
+                                :existing-only t))
+              (buffer-live-p viewport-buffer))
     (kill-buffer viewport-buffer)))
 
 (cl-defun agent-shell--capture-screenshot (&key destination-dir)
@@ -1567,7 +1568,7 @@ variable (see makunbound)."))
                                                     (when-let* ((viewport-buffer (agent-shell-viewport--buffer
                                                                                   :shell-buffer shell-buffer
                                                                                   :existing-only t))
-                                                                (_ (get-buffer-window viewport-buffer)))
+                                                                ((get-buffer-window viewport-buffer)))
                                                       (with-current-buffer viewport-buffer
                                                         (agent-shell-viewport--update-header)))))
                                       :client-maker (map-elt config :client-maker)
@@ -1600,10 +1601,10 @@ variable (see makunbound)."))
 
 (cl-defun agent-shell--delete-fragment (&key state block-id)
   "Delete fragment with STATE and BLOCK-ID."
-  (when-let ((_ (map-elt state :buffer))
-             (viewport-buffer (agent-shell-viewport--buffer
-                               :shell-buffer (map-elt state :buffer)
-                               :existing-only t)))
+  (when-let* ((shell-buffer (map-elt state :buffer))
+              (viewport-buffer (agent-shell-viewport--buffer
+                                :shell-buffer shell-buffer
+                                :existing-only t)))
     (with-current-buffer viewport-buffer
       (agent-shell-ui-delete-fragment :namespace-id (map-elt state :request-count) :block-id block-id :no-undo t)))
   (with-current-buffer (map-elt state :buffer)
@@ -1624,10 +1625,10 @@ Dialog can have LABEL-LEFT, LABEL-RIGHT, and BODY.
 Optional flags: APPEND text to existing content, CREATE-NEW block,
 NAVIGATION for navigation style, EXPANDED to show block expanded
 by default."
-  (when-let ((_ (map-elt state :buffer))
-             (viewport-buffer (agent-shell-viewport--buffer
-                               :shell-buffer (map-elt state :buffer)
-                               :existing-only t)))
+  (when-let* ((shell-buffer (map-elt state :buffer))
+              (viewport-buffer (agent-shell-viewport--buffer
+                                :shell-buffer shell-buffer
+                                :existing-only t)))
     (with-current-buffer viewport-buffer
       (let ((inhibit-read-only t))
         ;; TODO: Investigate why save-restriction isn't enough
@@ -2418,13 +2419,13 @@ normalized server configs."
            (mapcar (lambda (server)
                      (let ((normalized (copy-alist server)))
                        (when-let ((args (map-elt normalized 'args))
-                                  (_ (listp args)))
+                                  ((listp args)))
                          (map-put! normalized 'args (apply #'vector args)))
                        (when-let ((env (map-elt normalized 'env))
-                                  (_ (listp env)))
+                                  ((listp env)))
                          (map-put! normalized 'env (apply #'vector env)))
                        (when-let ((headers (map-elt normalized 'headers))
-                                  (_ (listp headers)))
+                                  ((listp headers)))
                          (map-put! normalized 'headers (apply #'vector headers)))
                        normalized))
                    agent-shell-mcp-servers))))
@@ -2575,7 +2576,7 @@ Returns an alist with:
 
 MAX-WIDTH specifies the maximum width in pixels for the image (default 200).
 If FILE-PATH is not an image, returns nil."
-  (when-let* ((_ (display-graphic-p))
+  (when-let* (((display-graphic-p))
               (metadata (agent-shell--read-file-content :file-path file-path :shallow t))
               (mime-type (map-elt metadata :mime-type))
               ;; Check if it's an image type
@@ -2626,10 +2627,10 @@ If FILE-PATH is not an image, returns nil."
                    prompt)
      :file-path agent-shell--transcript-file)
 
-    (when-let ((_ (map-elt shell :buffer))
-               (viewport-buffer (agent-shell-viewport--buffer
-                                 :shell-buffer (map-elt shell :buffer)
-                                 :existing-only t)))
+    (when-let* ((shell-buffer (map-elt shell :buffer))
+                (viewport-buffer (agent-shell-viewport--buffer
+                                  :shell-buffer shell-buffer
+                                  :existing-only t)))
       (with-current-buffer viewport-buffer
         (agent-shell-viewport-view-mode)
         (agent-shell-viewport--initialize
@@ -3966,8 +3967,7 @@ Mark model using CURRENT-MODEL-ID."
     ("C" "Interrupt" agent-shell-interrupt :transient t)]
    ["Shell"
     ("b" "Toggle" agent-shell-toggle :transient t)
-    ("N" "New shell" (lambda ()
-                       (interactive) (agent-shell t)))]])
+    ("N" "New shell" agent-shell-new-shell)]])
 
 ;;; Transcript
 


### PR DESCRIPTION
> [!NOTE]
> I'm splitting out some of the direct code changes into separate PRs. Feel free to focus review in this PR on the CI itself.

The latest release of agent-shell introduced some byte-compilation errors on startup in my Emacs environment. A snippet:

```
agent-shell-viewport.el:663:39: Warning: the function ‘agent-shell-other-buffer’ is not known to be defined.
agent-shell-viewport.el:650:48: Warning: the function ‘agent-shell-buffers’ is not known to be defined.
agent-shell-viewport.el:523:8: Warning: the function ‘agent-shell-cycle-session-mode’ is not known to be defined.
agent-shell-viewport.el:508:8: Warning: the function ‘agent-shell-set-session-mode’ is not known to be defined.
agent-shell-viewport.el:494:8: Warning: the function ‘agent-shell-set-session-model’ is not known to be defined.
agent-shell-viewport.el:488:29: Warning: the function ‘agent-shell--current-shell’ is not known to be defined.
agent-shell-viewport.el:427:28: Warning: the function ‘agent-shell--get-region’ is not known to be defined.
agent-shell-viewport.el:94:8: Warning: the function ‘agent-shell--display-buffer’ is not known to be defined.
```

To combat these in the future, this PR proposes some lightweight PR here that byte-compiles and runs package-lint -- both in "strict" mode that treats warnings as errors. In a subsequent PR, we can explore running all unit tests as part of CI as well.

This CI approach draws inspiration from both the lightweight CI approach taken in purcell/package-lint [here](https://github.com/purcell/package-lint/blob/master/Makefile) and in my own approach in jinnovation/kele.el [here](https://github.com/jinnovation/kele.el/blob/main/.github/workflows/test.yaml).