### PR TITLE
fix: agent-shell-help-menu use existing new-shell binding

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3968,8 +3968,7 @@ Mark model using CURRENT-MODEL-ID."
     ("C" "Interrupt" agent-shell-interrupt :transient t)]
    ["Shell"
     ("b" "Toggle" agent-shell-toggle :transient t)
-    ("N" "New shell" (lambda ()
-                       (interactive) (agent-shell t)))]])
+    ("N" "New shell" agent-shell-new-shell)]])
 
 ;;; Transcript
 


### PR DESCRIPTION
Pulls out one of the byte-compilation fixes for Emacs 29 identified in #156:
```
agent-shell.el:3971:23: Warning: (lambda nil \...) quoted with ' rather than with #'
```