### PR TITLE
fix: use modern (Emacs 26+) nil-check semantics in `when-let`

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -648,7 +648,7 @@ For example, offer to kill associated shell session."
                                                         :existing-only t)
                                                        (current-buffer)))
                                               (agent-shell-buffers)))
-                   (_ (y-or-n-p "Kill shell session too?")))
+                   ((y-or-n-p "Kill shell session too?")))
           (mapc (lambda (shell-buffer)
                   (kill-buffer shell-buffer))
                 shell-buffers)))))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -633,7 +633,7 @@ Flow:
               ;; TODO: Make public in shell-maker.
               (shell-maker--current-request-id))
     (cond ((not (map-elt (agent-shell--state) :client))
-           (when-let ((_ (map-elt shell :buffer))
+           (when-let (((map-elt shell :buffer))
                       (viewport-buffer (agent-shell-viewport--buffer
                                         :shell-buffer (map-elt shell :buffer)
                                         :existing-only t)))
@@ -927,7 +927,7 @@ Flow:
             :expanded t
             :navigation 'never)
            (agent-shell-jump-to-latest-permission-button-row)
-           (when-let ((_ (map-elt state :buffer))
+           (when-let (((map-elt state :buffer))
                       (viewport-buffer (agent-shell-viewport--buffer
                                         :shell-buffer (map-elt state :buffer)
                                         :existing-only t)))
@@ -1228,7 +1228,7 @@ Returns in the form:
 
 DIFF should be in the form returned by `agent-shell--make-diff-info':
   ((:old . old-text) (:new . new-text) (:file . file-path))"
-  (when-let ((_ diff)
+  (when-let (diff
              (old-file (make-temp-file "old"))
              (new-file (make-temp-file "new")))
     (unwind-protect
@@ -1344,7 +1344,7 @@ For example, shut down ACP client."
     (acp-shutdown :client (map-elt (agent-shell--state) :client)))
   (agent-shell-heartbeat-stop
    :heartbeat (map-elt (agent-shell--state) :heartbeat))
-  (when-let ((_ (map-elt (agent-shell--state) :buffer))
+  (when-let (((map-elt (agent-shell--state) :buffer))
              (viewport-buffer (agent-shell-viewport--buffer
                                :shell-buffer (map-elt (agent-shell--state) :buffer)
                                :existing-only t))
@@ -1569,7 +1569,7 @@ variable (see makunbound)."))
                                                     (when-let* ((viewport-buffer (agent-shell-viewport--buffer
                                                                                   :shell-buffer shell-buffer
                                                                                   :existing-only t))
-                                                                (_ (get-buffer-window viewport-buffer)))
+                                                                ((get-buffer-window viewport-buffer)))
                                                       (with-current-buffer viewport-buffer
                                                         (agent-shell-viewport--update-header)))))
                                       :client-maker (map-elt config :client-maker)
@@ -1602,7 +1602,7 @@ variable (see makunbound)."))
 
 (cl-defun agent-shell--delete-fragment (&key state block-id)
   "Delete fragment with STATE and BLOCK-ID."
-  (when-let ((_ (map-elt state :buffer))
+  (when-let (((map-elt state :buffer))
              (viewport-buffer (agent-shell-viewport--buffer
                                :shell-buffer (map-elt state :buffer)
                                :existing-only t)))
@@ -1626,7 +1626,7 @@ Dialog can have LABEL-LEFT, LABEL-RIGHT, and BODY.
 Optional flags: APPEND text to existing content, CREATE-NEW block,
 NAVIGATION for navigation style, EXPANDED to show block expanded
 by default."
-  (when-let ((_ (map-elt state :buffer))
+  (when-let (((map-elt state :buffer))
              (viewport-buffer (agent-shell-viewport--buffer
                                :shell-buffer (map-elt state :buffer)
                                :existing-only t)))
@@ -2420,13 +2420,13 @@ normalized server configs."
            (mapcar (lambda (server)
                      (let ((normalized (copy-alist server)))
                        (when-let ((args (map-elt normalized 'args))
-                                  (_ (listp args)))
+                                  ((listp args)))
                          (map-put! normalized 'args (apply #'vector args)))
                        (when-let ((env (map-elt normalized 'env))
-                                  (_ (listp env)))
+                                  ((listp env)))
                          (map-put! normalized 'env (apply #'vector env)))
                        (when-let ((headers (map-elt normalized 'headers))
-                                  (_ (listp headers)))
+                                  ((listp headers)))
                          (map-put! normalized 'headers (apply #'vector headers)))
                        normalized))
                    agent-shell-mcp-servers))))
@@ -2577,7 +2577,7 @@ Returns an alist with:
 
 MAX-WIDTH specifies the maximum width in pixels for the image (default 200).
 If FILE-PATH is not an image, returns nil."
-  (when-let* ((_ (display-graphic-p))
+  (when-let* (((display-graphic-p))
               (metadata (agent-shell--read-file-content :file-path file-path :shallow t))
               (mime-type (map-elt metadata :mime-type))
               ;; Check if it's an image type
@@ -2628,7 +2628,7 @@ If FILE-PATH is not an image, returns nil."
                    prompt)
      :file-path agent-shell--transcript-file)
 
-    (when-let ((_ (map-elt shell :buffer))
+    (when-let (((map-elt shell :buffer))
                (viewport-buffer (agent-shell-viewport--buffer
                                  :shell-buffer (map-elt shell :buffer)
                                  :existing-only t)))


### PR DESCRIPTION
Relates to #156.

agent-shell uses a lot of the following pattern to logically gate certain blocks:

```elisp
(when ((_ (some-condition-p)))
  ...)
```

Logically, this is correct. However, on Emacs 29, this results in some byte-compilation errors
related to `_` actually not **technically** remaining unused under the hood after macro expansion. Examples [here](https://github.com/jinnovation/agent-shell/actions/runs/20465509231/job/58808136922#step:4:112):
```
agent-shell.el:636:24: Warning: variable ‘_’ not left unused
agent-shell.el:930:24: Warning: variable ‘_’ not left unused
agent-shell.el:1231:15: Warning: variable ‘_’ not left unused
agent-shell.el:1347:15: Warning: variable ‘_’ not left unused
agent-shell.el:1572:66: Warning: variable ‘_’ not left unused
agent-shell.el:1605:15: Warning: variable ‘_’ not left unused
agent-shell.el:1629:15: Warning: variable ‘_’ not left unused
agent-shell.el:2423:36: Warning: variable ‘_’ not left unused
agent-shell.el:2426:36: Warning: variable ‘_’ not left unused
agent-shell.el:2429:36: Warning: variable ‘_’ not left unused
agent-shell.el:2580:16: Warning: variable ‘_’ not left unused
agent-shell.el:2631:17: Warning: variable ‘_’ not left unused

```

As it turns out, the following semantics for `if-let` and friends have been valid since Emacs
26 ([citation](https://emacs.stackexchange.com/a/64913)):

```elisp
(when (((some-condition-p)))
  ...)
```

From `if-let*` docs:

```
An element can additionally be of the form (VALUEFORM), which is evaluated and checked for nil;
i.e. SYMBOL can be omitted if only the test result is of interest.  It can also be of the form
SYMBOL, then the binding of SYMBOL is checked for nil.
```

This PR updates all use of the "underscore assignment" pattern in agent-shell to take advantage of
the aforementioned semantics.