### PR TITLE
Use project-name for buffer names

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1571,8 +1571,7 @@ variable (see makunbound)"))
                              new-session
                              (concat (map-elt config :buffer-name)
                                      " Agent @ "
-                                     (file-name-nondirectory
-                                      (string-remove-suffix "/" default-directory)))
+                                     (agent-shell--project-name))
                              (map-elt config :mode-line-name))))
     (with-current-buffer shell-buffer
       ;; Initialize buffer-local state
@@ -2764,6 +2763,21 @@ If in a project, use project root."
            (project-root proj)))
        default-directory
        (error "No CWD available"))))
+
+(defun agent-shell--project-name ()
+  "Return the project name for this shell.
+
+If in a project, use project name."
+  (or (when (and (boundp 'projectile-mode)
+                 projectile-mode
+                 (fboundp 'projectile-project-name))
+        (when-let* ((project (projectile-project-root)))
+          (projectile-project-name project)))
+      (when (fboundp 'project-name)
+        (when-let* ((proj (project-current)))
+          (project-name proj)))
+      (file-name-nondirectory
+       (string-remove-suffix "/" default-directory))))
 
 (defun agent-shell--current-shell ()
   "Current shell for viewport or shell buffer."


### PR DESCRIPTION
Buffer names now use project-name.  By default this is just the last directory component, but it's configurable by the user or by the project implementation if they want to refer to their projects with a different name.

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and I'm happy with its quality*.
