### PR TITLE
Keep when-let from trying to bind boundp and fboundp

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2768,12 +2768,12 @@ If in a project, use project root."
   "Return the project name for this shell.
 
 If in a project, use project name."
-  (or (when-let ((boundp 'projectile-mode)
+  (or (when-let (((boundp 'projectile-mode))
                  projectile-mode
-                 (fboundp 'projectile-project-name)
+                 ((fboundp 'projectile-project-name))
                  (root (projectile-project-root)))
         (projectile-project-name root))
-      (when-let ((fboundp 'project-name)
+      (when-let (((fboundp 'project-name))
                  (project (project-current)))
         (project-name project))
       (file-name-nondirectory


### PR DESCRIPTION
The existing form breaks on systems without projectile installed because when-let is trying to bind boundp to projectile-mode which is undefined.

Thank you for contributing to agent-shell!

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.
