### PR TITLE
feat: add factory droid capability

### DIFF
--- a/README.org
+++ b/README.org
@@ -101,6 +101,16 @@ uv tool install mistral-vibe
 
 See https://github.com/mistralai/mistral-vibe for details.
 
+*** Factory Droid
+
+For Factory Droid, install the =droid-acp= client:
+
+#+begin_src bash
+npm install -g droid-acp
+#+end_src
+
+See https://github.com/yaonyan/droid-acp for details.
+
 ** Installation
 
 =agent-shell= is powered by built-in =comint-shell=, via [[https://github.com/xenodium/shell-maker][shell-maker]], available on [[https://melpa.org/#/shell-maker][MELPA]].
@@ -335,6 +345,7 @@ Start a specific agent shell session directly:
 - =M-x agent-shell-cursor-start-agent= - Start a Cursor agent session
 - =M-x agent-shell-mistral-start-vibe= - Start a Mistral Vibe agent session
 - =M-x agent-shell-qwen-start= - Start a Qwen Code agent session
+- =M-x agent-shell-droid-start-agent= - Start a Factory Droid agent session
 
 *** Setting a default agent for all new shells
 

--- a/agent-shell-droid.el
+++ b/agent-shell-droid.el
@@ -1,0 +1,177 @@
+;;; agent-shell-droid.el --- Factory Droid agent configurations -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Alvaro Ramirez
+
+;; Author: Alvaro Ramirez https://xenodium.com
+;; URL: https://github.com/xenodium/agent-shell
+
+;; This package is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This package is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This file includes Factory Droid specific configurations relying on the
+;; droid-acp client: https://github.com/yaonyan/droid-acp
+;;
+
+;;; Code:
+
+(eval-when-compile
+  (require 'cl-lib))
+(require 'shell-maker)
+(require 'acp)
+
+(declare-function agent-shell--indent-string "agent-shell")
+(declare-function agent-shell-make-agent-config "agent-shell")
+(declare-function agent-shell--make-acp-client "agent-shell")
+(declare-function agent-shell--dwim "agent-shell")
+
+(cl-defun agent-shell-droid-make-authentication (&key api-key none)
+  "Create Factory Droid authentication configuration.
+
+API-KEY is the Droid API key string or function that returns it.
+NONE when non-nil disables API key authentication (e.g., when droid-acp
+is already logged in or uses an alternative auth flow).
+
+Only one of API-KEY or NONE should be provided, never both."
+  (when (and api-key none)
+    (error "Cannot specify both :api-key and :none - choose one"))
+  (unless (or api-key none)
+    (error "Must specify either :api-key or :none"))
+  (cond
+   (api-key `((:api-key . ,api-key)))
+   (none `((:none . t)))))
+
+(defcustom agent-shell-droid-authentication
+  (agent-shell-droid-make-authentication :none t)
+  "Configuration for Factory Droid authentication.
+For API key (string):
+
+  (setq agent-shell-droid-authentication
+        (agent-shell-droid-make-authentication :api-key \"your-key\"))
+
+For API key (function):
+
+  (setq agent-shell-droid-authentication
+        (agent-shell-droid-make-authentication :api-key (lambda () ...)))
+
+For no authentication (e.g., using `droid-acp` built-in login):
+
+  (setq agent-shell-droid-authentication
+        (agent-shell-droid-make-authentication :none t))"
+  :type 'alist
+  :group 'agent-shell)
+
+(defcustom agent-shell-droid-command
+  '("droid-acp")
+  "Command and parameters for the Factory Droid ACP client.
+
+The first element is the command name, and the rest are command parameters."
+  :type '(repeat string)
+  :group 'agent-shell)
+
+(defcustom agent-shell-droid-environment
+  nil
+  "Environment variables for the Factory Droid ACP client.
+
+This should be a list of environment variables to be used when
+starting the Droid client process.
+
+Example usage to set custom environment variables:
+
+  (setq agent-shell-droid-environment
+        (`agent-shell-make-environment-variables'
+         \"MY_VAR\" \"some-value\"
+         \"MY_OTHER_VAR\" \"another-value\"))"
+  :type '(repeat string)
+  :group 'agent-shell)
+
+(defun agent-shell-droid-make-agent-config ()
+  "Create a Factory Droid agent configuration.
+
+Returns an agent configuration alist using `agent-shell-make-agent-config'."
+  (agent-shell-make-agent-config
+   :mode-line-name "Droid"
+   :buffer-name "Droid"
+   :shell-prompt "Droid> "
+   :shell-prompt-regexp "Droid> "
+   :welcome-function #'agent-shell-droid--welcome-message
+   :client-maker (lambda (buffer)
+                   (agent-shell-droid-make-client :buffer buffer))
+   :install-instructions "See https://github.com/yaonyan/droid-acp for installation."))
+
+(defun agent-shell-droid-start-agent ()
+  "Start an interactive Factory Droid agent shell."
+  (interactive)
+  (agent-shell--dwim :config (agent-shell-droid-make-agent-config)
+                     :new-shell t))
+
+(cl-defun agent-shell-droid-make-client (&key buffer)
+  "Create a Factory Droid client using BUFFER as context.
+
+Uses `agent-shell-droid-authentication' for authentication configuration."
+  (unless buffer
+    (error "Missing required argument: :buffer"))
+  (let ((api-key (agent-shell-droid-key)))
+    (agent-shell--make-acp-client :command (car agent-shell-droid-command)
+                                  :command-params (cdr agent-shell-droid-command)
+                                  :environment-variables (append (cond ((map-elt agent-shell-droid-authentication :none)
+                                                                        nil)
+                                                                       (api-key
+                                                                        (list (format "FACTORY_API_KEY=%s" api-key)))
+                                                                       (t
+                                                                        (error "Missing Factory Droid authentication (see agent-shell-droid-authentication)")))
+                                                                 agent-shell-droid-environment)
+                                  :context-buffer buffer)))
+
+(defun agent-shell-droid-key ()
+  "Get the Factory Droid API key."
+  (cond ((stringp (map-elt agent-shell-droid-authentication :api-key))
+         (map-elt agent-shell-droid-authentication :api-key))
+        ((functionp (map-elt agent-shell-droid-authentication :api-key))
+         (condition-case _err
+             (funcall (map-elt agent-shell-droid-authentication :api-key))
+           (error
+            (error "API key not found.  Check out `agent-shell-droid-authentication'"))))
+        (t
+         nil)))
+
+(defun agent-shell-droid--welcome-message (config)
+  "Return Factory Droid welcome message using `shell-maker' CONFIG."
+  (let ((art (agent-shell--indent-string 4 (agent-shell-droid--ascii-art)))
+        (message (string-trim-left (shell-maker-welcome-message config) "\n")))
+    (concat "\n\n"
+            art
+            "\n\n"
+            message)))
+
+(defun agent-shell-droid--ascii-art ()
+  "Factory Droid ASCII art."
+  (let* ((is-dark (eq (frame-parameter nil 'background-mode) 'dark))
+         (text (string-trim "
+  ______         _                     _____            _     _
+ |  ____|       | |                   |  __ \\          (_)   | |
+ | |__ __ _  ___| |_ ___  _ __ _   _  | |  | |_ __ ___  _  __| |
+ |  __/ _` |/ __| __/ _ \\| '__| | | | | |  | | '__/ _ \\| |/ _` |
+ | | | (_| | (__| || (_) | |  | |_| | | |__| | | | (_) | | (_| |
+ |_|  \\__,_|\\___|\\__\\___/|_|   \\__, | |_____/|_|  \\___/|_|\\__,_|
+                                __/ |
+                               |___/
+" "\n")))
+    (propertize text 'font-lock-face (if is-dark
+                                         '(:foreground "#8b949e" :inherit fixed-pitch)
+                                       '(:foreground "#444" :inherit fixed-pitch)))))
+
+(provide 'agent-shell-droid)
+
+;;; agent-shell-droid.el ends here

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -64,6 +64,7 @@
 (require 'agent-shell-qwen)
 (require 'agent-shell-heartbeat)
 (require 'agent-shell-viewport)
+(require 'agent-shell-droid)
 
 (declare-function projectile-current-project-files "projectile")
 (declare-function projectile-project-root "projectile")
@@ -279,6 +280,7 @@ Goose, Cursor, and others."
         (agent-shell-cursor-make-agent-config)
         (agent-shell-google-make-gemini-config)
         (agent-shell-goose-make-agent-config)
+        (agent-shell-droid-make-agent-config)
         (agent-shell-mistral-make-config)
         (agent-shell-openai-make-codex-config)
         (agent-shell-opencode-make-agent-config)


### PR DESCRIPTION
using https://github.com/yaonyan/droid-acp we can make Factory Droid work via ACP. The agent is documented at https://factory.ai/

I just coded this for myself, happy to close the PR and maintain my fork with this change: I just thought that maybe other users would benefit of that.

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
   No sorry, just thought it would be nice to add support for one more agent. If it is not welcome just close it and I will mantain my fork with your further changes.
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
   I have seen only gemini has tests, so to keep my life easy I didn't add them. But I am using the agent :)
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and I'm happy with its quality*.
