### PR TITLE
Make Header Image Loading Optional to Fix Conflict with Openwith Mode

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -217,6 +217,14 @@ Can be one of:
                  (const :tag "No header" nil))
   :group 'agent-shell)
 
+(defcustom agent-shell-use-header-images t
+  "If non-nil, load and display agent logo images in the header.
+When set to nil, the header will fallback to text-only mode even if
+`agent-shell-header-style' is set to \\='graphical. This is useful to avoid
+issues with external programs intercepting image loading (e.g. openwith)."
+  :type 'boolean
+  :group 'agent-shell)
+
 (defcustom agent-shell-show-welcome-message t
   "Non-nil to show welcome message."
   :type 'boolean
@@ -1945,7 +1953,7 @@ BINDINGS is a list of alists defining key bindings to display, each with:
       ((or 'none (pred null)) nil)
       ('text text-header)
       ('graphical
-       (if (display-graphic-p)
+       (if (and (display-graphic-p) agent-shell-use-header-images)
            ;; +------+
            ;; | icon | Top text line
            ;; |      | Bottom text line


### PR DESCRIPTION
* Description: This PR introduces a new customization variable agent-shell-use-header-images (defaulting to t) to control image loading in the agent-shell header.

* Problem: When using agent-shell with openwith-mode, the file handler intercepts the loading of agent logo images (PNGs) during the header rendering process. This causes an interruption in the execution flow, often leading to timeouts or hangs when the agent-shell buffer attempts to display the graphical header.

* Solution:

     - Added defcustom agent-shell-use-header-images.
     - Updated agent-shell--make-header to respect this variable.
     - Users can now set (setq agent-shell-use-header-images nil) to force the text-only header even in GUI mode, bypassing the image loading code and preventing the conflict with openwith.

 * Testing:

     - Enabled openwith-mode configured to open PNGs externally.
     - Set agent-shell-use-header-images to nil.
     - Verified that agent-shell loads correctly with a text header and no external viewer is triggered.
