### PR TITLE
Use agent-shell--context in viewport mode

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -44,7 +44,7 @@
 (declare-function agent-shell--get-region "agent-shell")
 (declare-function agent-shell--insert-to-shell-buffer "agent-shell")
 (declare-function agent-shell--make-header "agent-shell")
-(declare-function agent-shell--relevant-text "agent-shell")
+(declare-function agent-shell--context "agent-shell")
 (declare-function agent-shell--shell-buffer "agent-shell")
 (declare-function agent-shell--start "agent-shell")
 (declare-function agent-shell--state "agent-shell")
@@ -91,7 +91,7 @@ Returns an alist with insertion details or nil otherwise:
       (pop-to-buffer-same-window current)))
   (when-let ((shell-buffer (or shell-buffer (agent-shell--shell-buffer)))
              (viewport-buffer (agent-shell-viewport--buffer :shell-buffer shell-buffer))
-             (text (or text (agent-shell--relevant-text) "")))
+             (text (or text (agent-shell--context) "")))
     (let ((insert-start nil)
           (insert-end nil))
       ;; Is there text to be inserted? Reject while busy.


### PR DESCRIPTION
## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.

---
<!-- Message of single commit: -->

Use new --context function in viewport mode

4d3bb6d removed `agent-shell--relevant-text` and moved callers to
`agent-shell--context`. Fix a missed instance in viewport mode.