### PR TITLE
fix agent names in prompt when agent-shell-show-config-icons is nil

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -537,7 +537,7 @@ Returns an empty string if no icon should be displayed."
                                                     "Unknown Agent"))
                                   (icon (when agent-shell-show-config-icons
                                           (agent-shell--config-icon :config config))))
-                              (cons (format "%s%s%s" icon (when icon " ") display-name)
+                              (cons (concat icon (when icon " ") display-name)
                                     config)))
                           configs))
          (selected-name (completing-read (or prompt "Select agent: ") choices nil t)))


### PR DESCRIPTION
Previously nil was converted to string "nil", so the display was showing
"nilnilCodex" instead of "Codex"
