### PR TITLE
feat: support function-based container command runner configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -396,10 +396,39 @@ configurations across every agent that you use.
 
 =agent-shell= provides rudimentary support for running agents and shell commands in containers.
 
-Use =agent-shell-container-command-runner= to prefix the command that starts the agent, or a shell command that should be run so it is executed inside the container; for example:
+Use =agent-shell-container-command-runner= to prefix the command that starts the agent, or a shell command that should be run so it is executed inside the container.
+
+*** Static command list
 
 #+begin_src emacs-lisp
 (setq agent-shell-container-command-runner '("devcontainer" "exec" "--workspace-folder" "."))
+#+end_src
+
+*** Function-based configuration
+
+For dynamic per-agent containers, provide a function that takes the current agent-shell buffer and returns the command list:
+
+#+begin_src emacs-lisp
+(setq agent-shell-container-command-runner
+      (lambda (buffer)
+        (let ((config (agent-shell-get-config buffer)))
+          (pcase (map-elt config :identifier)
+            ('claude-code '("docker" "exec" "claude-dev" "--"))
+            ('gemini-cli '("docker" "exec" "gemini-dev" "--"))
+            (_ '("devcontainer" "exec" "."))))))
+#+end_src
+
+*** Per-session containers
+
+You can use different containers for different shell sessions, even of the same agent type:
+
+#+begin_src emacs-lisp
+(setq agent-shell-container-command-runner
+      (lambda (buffer)
+        ;; Different container based on project
+        (if (string-match "project-a" (buffer-name buffer))
+            '("docker" "exec" "project-a-dev" "--")
+          '("docker" "exec" "project-b-dev" "--"))))
 #+end_src
 
 Note that any =:environment-variables= you may have passed to =acp-make-client= will not apply to the agent process running inside the container. It's expected to inject environment variables by means of your devcontainer configuration / Dockerfile.

--- a/agent-shell-anthropic.el
+++ b/agent-shell-anthropic.el
@@ -117,6 +117,7 @@ Example usage to set a custom Anthropic API base URL:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'claude-code
    :mode-line-name "Claude Code"
    :buffer-name "Claude Code"
    :shell-prompt "Claude Code> "

--- a/agent-shell-auggie.el
+++ b/agent-shell-auggie.el
@@ -94,6 +94,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'auggie
    :mode-line-name "Auggie"
    :buffer-name "Auggie"
    :shell-prompt "Auggie> "

--- a/agent-shell-cursor.el
+++ b/agent-shell-cursor.el
@@ -57,6 +57,7 @@ starting the Cursor agent process."
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'cursor
    :mode-line-name "Cursor"
    :buffer-name "Cursor"
    :shell-prompt "Cursor> "

--- a/agent-shell-droid.el
+++ b/agent-shell-droid.el
@@ -101,6 +101,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'droid
    :mode-line-name "Droid"
    :buffer-name "Droid"
    :shell-prompt "Droid> "

--- a/agent-shell-github.el
+++ b/agent-shell-github.el
@@ -57,6 +57,7 @@ starting the GitHub Copilot agent process."
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'copilot
    :mode-line-name "Copilot"
    :buffer-name "Copilot"
    :shell-prompt "Copilot> "

--- a/agent-shell-google.el
+++ b/agent-shell-google.el
@@ -119,6 +119,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (when (and (boundp 'agent-shell-google-key) agent-shell-google-key)
     (user-error "Please migrate to use agent-shell-google-authentication and eval (setq agent-shell-google-key nil)"))
   (agent-shell-make-agent-config
+   :identifier 'gemini-cli
    :mode-line-name "Gemini CLI"
    :buffer-name "Gemini CLI"
    :shell-prompt "Gemini> "

--- a/agent-shell-goose.el
+++ b/agent-shell-goose.el
@@ -98,6 +98,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'goose
    :mode-line-name "Goose"
    :buffer-name "Goose"
    :shell-prompt "Goose> "

--- a/agent-shell-mistral.el
+++ b/agent-shell-mistral.el
@@ -105,6 +105,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'mistral-vibe
    :mode-line-name "Mistral Vibe"
    :buffer-name "Mistral Vibe"
    :shell-prompt "Vibe> "

--- a/agent-shell-openai.el
+++ b/agent-shell-openai.el
@@ -111,6 +111,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (when (and (boundp 'agent-shell-openai-key) agent-shell-openai-key)
     (user-error "Please migrate to use agent-shell-openai-authentication and eval (setq agent-shell-openai-key nil)"))
   (agent-shell-make-agent-config
+   :identifier 'codex
    :mode-line-name "Codex"
    :buffer-name "Codex"
    :shell-prompt "Codex> "

--- a/agent-shell-opencode.el
+++ b/agent-shell-opencode.el
@@ -99,6 +99,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'opencode
    :mode-line-name "OpenCode"
    :buffer-name "OpenCode"
    :shell-prompt "OpenCode> "

--- a/agent-shell-qwen.el
+++ b/agent-shell-qwen.el
@@ -96,6 +96,7 @@ Example usage to set custom environment variables:
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
+   :identifier 'qwen-code
    :mode-line-name "Qwen Code"
    :buffer-name "Qwen Code"
    :shell-prompt "qwen> "

--- a/tests/agent-shell-runner-tests.el
+++ b/tests/agent-shell-runner-tests.el
@@ -1,0 +1,63 @@
+;;; agent-shell-runner-tests.el --- Tests for agent-shell command runner functionality -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'agent-shell)
+
+;;; Code:
+
+(ert-deftest agent-shell--build-command-for-execution-test ()
+  "Test `agent-shell--build-command-for-execution' function."
+
+  ;; Test 1: No container runner configured (nil)
+  (let ((agent-shell-container-command-runner nil))
+    (should (equal (agent-shell--build-command-for-execution
+                    '("claude-code-acp"))
+                   '("claude-code-acp"))))
+
+  ;; Test 2: Static list runner
+  (let ((agent-shell-container-command-runner
+         '("devcontainer" "exec" "--workspace-folder" ".")))
+    (should (equal (agent-shell--build-command-for-execution
+                    '("claude-code-acp"))
+                   '("devcontainer" "exec" "--workspace-folder" "." "claude-code-acp"))))
+
+  ;; Test 3, 4 & 5: Function runner with different agent identifiers
+  (let ((agent-shell-container-command-runner
+         (lambda (buffer)
+           (let ((config (agent-shell-get-config buffer)))
+             (pcase (map-elt config :identifier)
+               ('claude-code '("docker" "exec" "claude-dev" "--"))
+               ('gemini-cli '("docker" "exec" "gemini-dev" "--"))
+               (_ '("devcontainer" "exec" ".")))))))
+    (let ((test-cases '(((:identifier . claude-code)
+                         (:command . ("claude-code-acp"))
+                         (:expected-prefix . ("docker" "exec" "claude-dev" "--")))
+                        ((:identifier . gemini-cli)
+                         (:command . ("gemini"))
+                         (:expected-prefix . ("docker" "exec" "gemini-dev" "--")))
+                        ((:identifier . unknown-agent)
+                         (:command . ("some-agent"))
+                         (:expected-prefix . ("devcontainer" "exec" "."))))))
+      (seq-doseq (test-case test-cases)
+        (let* ((identifier (map-elt test-case :identifier))
+               (command (map-elt test-case :command))
+               (expected-prefix (map-elt test-case :expected-prefix))
+               (test-buffer (generate-new-buffer (format "*test-%s*" identifier))))
+          (unwind-protect
+              (with-current-buffer test-buffer
+                (setq-local agent-shell--state
+                            (list (cons :agent-config
+                                        `((:identifier . ,identifier)))))
+                (should (equal (agent-shell--build-command-for-execution command)
+                               (append expected-prefix command))))
+            (kill-buffer test-buffer))))))
+
+  ;; Test 6: Complex command with multiple arguments
+  (let ((agent-shell-container-command-runner
+         '("docker" "exec" "my-container")))
+    (should (equal (agent-shell--build-command-for-execution
+                    '("shell" "-c" "echo test"))
+                   '("docker" "exec" "my-container" "shell" "-c" "echo test")))))
+
+(provide 'agent-shell-runner-tests)
+;;; agent-shell-runner-tests.el ends here


### PR DESCRIPTION
This PR adds support for dynamic, per-agent container configuration by allowing `agent-shell-container-command-runner` to accept either a static command list or a function that takes the agent-shell buffer and returns a command list.

This enables running different agents in different containers based on the agent's `:identifier` field, while maintaining backward compatibility with the existing static list configuration.

## Changes

  - Allow `agent-shell-container-command-runner` to be a function
  - Add `:identifier` field to all agent configs
  - Extract command wrapping logic into `agent-shell--wrap-command-for-container`
  - Add tests for this configuration setting
  - Update documentation with examples

The commit history reflects the chronological development sequence; I recommend squashing when merging, but I'm flexible if you prefer a different approach.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [x] I've filed a feature request/discussion for this change: #176 
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.
