### PR TITLE
Fix reply in viewport mode

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -433,7 +433,7 @@ With EXISTING-ONLY, only return existing buffers without creating."
 (defun agent-shell-viewport-reply ()
   "Reply as a follow-up and compose another prompt/query."
   (interactive)
-  (unless (derived-mode-p 'agent-shell-viewport-edit-mode)
+  (unless (derived-mode-p 'agent-shell-viewport-view-mode)
     (user-error "Not in a shell viewport buffer"))
   (when (agent-shell-viewport--busy-p)
     (user-error "Busy, please wait"))


### PR DESCRIPTION
## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.

<!-- Message of single commit: -->

Allow viewport reply in view mode

I don't think it's possible to reply in edit mode.