### PR TITLE
Prevent agent-shell from adding context from agent-shell buffers

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3733,17 +3733,18 @@ If CAP is non-nil, truncate at CAP."
 
 Context could be either a region or error at point or files.
 The sources checked are controlled by `agent-shell-context-sources'."
-  (seq-some
-   (lambda (source)
-     (pcase source
-       ('files (agent-shell--get-files-context
-                :files (agent-shell--buffer-files :obvious t)))
-       ('region (agent-shell--get-region-context
-                 :deactivate t :no-error t))
-       ('error (agent-shell--get-flymake-error-context))
-       ('line (agent-shell--get-current-line-context))
-       ((pred functionp) (funcall source))))
-   agent-shell-context-sources))
+  (unless (derived-mode-p 'agent-shell-mode)
+    (seq-some
+     (lambda (source)
+       (pcase source
+         ('files (agent-shell--get-files-context
+                  :files (agent-shell--buffer-files :obvious t)))
+         ('region (agent-shell--get-region-context
+                   :deactivate t :no-error t))
+         ('error (agent-shell--get-flymake-error-context))
+         ('line (agent-shell--get-current-line-context))
+         ((pred functionp) (funcall source))))
+     agent-shell-context-sources)))
 
 (cl-defun agent-shell--get-region (&key deactivate)
   "Get the active region as an alist.


### PR DESCRIPTION
This PR solves a problem when toggling agent-shell. Context from the agent-shell buffer is added:

https://github.com/user-attachments/assets/9b541170-bdc5-48dd-8eff-b73af789f134

## Checklist
- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] ~I've filed a feature request/discussion for this change~.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] ~I've added tests where applicable~.
- [ ] ~I've updated documentation where necessary~.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.


