### PR TITLE
Use brackets for status labels in terminal mode

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1517,9 +1517,11 @@ DESTINATION-DIR is required and must be provided."
                    (_ '("unknown" warning))))
          (label (car config))
          (face (cadr config))
-         (color (face-foreground face nil t)))
+         (color (face-foreground face nil t))
+         ;; Wrap the label in [ and ] in TUI which cannot render the box border.
+         (label-format (if (display-graphic-p) " %s " "[%s]")))
     (agent-shell--add-text-properties
-     (propertize (format " %s " label) 'font-lock-face 'default)
+     (propertize (format label-format label) 'font-lock-face 'default)
      'font-lock-face
      `(:foreground ,color :box (:color ,color)))))
 
@@ -1551,11 +1553,13 @@ Returns propertized labels in :status and :title propertized."
     `((:status . ,(let ((status (when (map-elt tool-call :status)
                                   (agent-shell--status-label (map-elt tool-call :status))))
                         (kind (when (map-elt tool-call :kind)
-                                (agent-shell--add-text-properties
-                                 (propertize (format " %s " (map-elt tool-call :kind))
-                                             'font-lock-face 'default)
-                                 'font-lock-face
-                                 `(:box t)))))
+                                ;; Wrap the label in [ and ] in TUI which cannot render the box border.
+                                (let* ((label-format (if (display-graphic-p) " %s " "[%s]")))
+                                  (agent-shell--add-text-properties
+                                   (propertize (format label-format (map-elt tool-call :kind))
+                                               'font-lock-face 'default)
+                                   'font-lock-face
+                                   `(:box t))))))
                     (concat
                      (when status
                        status)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -188,25 +188,43 @@
 
 (ert-deftest agent-shell--format-plan-test ()
   "Test `agent-shell--format-plan' function."
-  ;; Test homogeneous statuses
-  (should (equal (substring-no-properties (agent-shell--format-plan [((content . "Update state initialization")
-                                             (status . "pending"))
-                                            ((content . "Update session initialization")
-                                             (status . "pending"))]))
-                  (concat " pending   Update state initialization  \n"
-                          " pending   Update session initialization")))
+  (dolist (test-case '(;; Graphical display mode
+                       ( :graphic t
+                         :homogeneous-expected
+                         (concat " pending   Update state initialization  \n"
+                                 " pending   Update session initialization")
+                         :mixed-expected
+                         (concat " pending       First task \n"
+                                 " in progress   Second task\n"
+                                 " completed     Third task "))
+                       ;; Terminal display mode
+                       ( :graphic nil
+                         :homogeneous-expected
+                         (concat "[pending]  Update state initialization  \n"
+                                 "[pending]  Update session initialization")
+                         :mixed-expected
+                         (concat "[pending]      First task \n"
+                                 "[in progress]  Second task\n"
+                                 "[completed]    Third task "))))
+    (cl-letf (((symbol-function 'display-graphic-p)
+               (lambda (&optional _display) (plist-get test-case :graphic))))
+      ;; Test homogeneous statuses
+      (should (equal (substring-no-properties
+                      (agent-shell--format-plan [((content . "Update state initialization")
+                                                  (status . "pending"))
+                                                 ((content . "Update session initialization")
+                                                  (status . "pending"))]))
+                     (plist-get test-case :homogeneous-expected)))
 
-  ;; Test mixed statuses
-  (should (equal (substring-no-properties
-                  (agent-shell--format-plan [((content . "First task")
-                                              (status . "pending"))
-                                             ((content . "Second task")
-                                              (status . "in_progress"))
-                                             ((content . "Third task")
-                                              (status . "completed"))]))
-                 (concat " pending       First task \n"
-                         " in progress   Second task\n"
-                         " completed     Third task ")))
+      ;; Test mixed statuses
+      (should (equal (substring-no-properties
+                      (agent-shell--format-plan [((content . "First task")
+                                                  (status . "pending"))
+                                                 ((content . "Second task")
+                                                  (status . "in_progress"))
+                                                 ((content . "Third task")
+                                                  (status . "completed"))]))
+                     (plist-get test-case :mixed-expected)))))
 
   ;; Test empty entries
   (should (equal (agent-shell--format-plan []) "")))


### PR DESCRIPTION
Status labels now adapt to the display environment, using brackets [pending] in terminal mode and spaces with box styling in graphical mode for better rendering compatibility. Tests updated to cover both modes.

Here is a sample screenshot for the new TUI:

<img width="837" height="402" alt="image" src="https://github.com/user-attachments/assets/f1ee7175-4abb-406e-88cc-ac81defffcc5" />

-----

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [X] I've filed a feature request/discussion for this change (https://github.com/xenodium/agent-shell/issues/203)
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and I'm happy with its quality*.
