### PR TITLE
Make status-label color respect new theme

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1517,13 +1517,11 @@ DESTINATION-DIR is required and must be provided."
                    (_ '("unknown" warning))))
          (label (car config))
          (face (cadr config))
-         (color (face-foreground face nil t))
          ;; Wrap the label in [ and ] in TUI which cannot render the box border.
          (label-format (if (display-graphic-p) " %s " "[%s]")))
     (agent-shell--add-text-properties
      (propertize (format label-format label) 'font-lock-face 'default)
-     'font-lock-face
-     `(:foreground ,color :box (:color ,color)))))
+     'font-lock-face (list face '(:box t)))))
 
 (defun agent-shell--shorten-paths (text &optional include-project)
   "Shorten file paths in TEXT relative to project root.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -188,24 +188,24 @@
 
 (ert-deftest agent-shell--format-plan-test ()
   "Test `agent-shell--format-plan' function."
-  (dolist (test-case '(;; Graphical display mode
+  (dolist (test-case `(;; Graphical display mode
                        ( :graphic t
                          :homogeneous-expected
-                         (concat " pending   Update state initialization  \n"
-                                 " pending   Update session initialization")
+                         ,(concat " pending   Update state initialization  \n"
+                                  " pending   Update session initialization")
                          :mixed-expected
-                         (concat " pending       First task \n"
-                                 " in progress   Second task\n"
-                                 " completed     Third task "))
+                         ,(concat " pending       First task \n"
+                                  " in progress   Second task\n"
+                                  " completed     Third task "))
                        ;; Terminal display mode
                        ( :graphic nil
                          :homogeneous-expected
-                         (concat "[pending]  Update state initialization  \n"
-                                 "[pending]  Update session initialization")
+                         ,(concat "[pending]  Update state initialization  \n"
+                                  "[pending]  Update session initialization")
                          :mixed-expected
-                         (concat "[pending]      First task \n"
-                                 "[in progress]  Second task\n"
-                                 "[completed]    Third task "))))
+                         ,(concat "[pending]      First task \n"
+                                  "[in progress]  Second task\n"
+                                  "[completed]    Third task "))))
     (cl-letf (((symbol-function 'display-graphic-p)
                (lambda (&optional _display) (plist-get test-case :graphic))))
       ;; Test homogeneous statuses


### PR DESCRIPTION
**Problem**: After changing the light/dark theme (e.g., via `modus-themes-toggle`), the color of the status label remain the same as the previous theme.

It makes the text less readable because the color contrast is low between the background and the text.

**Root Cause:** The `font-lock-face` uses the exact color value. The face won't change if the underlying face is changed.

**Fix**: Set `font-lock-face` to uses the face with a box. This way, when changing the theme, the face can change with the underlying face.

**Tested**:
- Tested in GUI Emacs. Seeing the color is changed relatively after `modus-themes-toggle`.
- Fixed unit test. (I might had broken it in e11a66bf8b5bc9c3bc3274049075a4d16fa27bf2)

Thank you for contributing to agent-shell!

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [X] I've filed a feature request/discussion for this change (https://github.com/xenodium/agent-shell/issues/207).
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and I'm happy with its quality*.
