### PR TITLE
agent-shell.el(require): Add `image`

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -67,6 +67,7 @@
 (require 'agent-shell-heartbeat)
 (require 'agent-shell-viewport)
 (require 'agent-shell-droid)
+(require 'image)
 
 (declare-function projectile-current-project-files "projectile")
 (declare-function projectile-project-root "projectile")


### PR DESCRIPTION
Without it `image-supported-file-p` calls fail.

Thank you for contributing to agent-shell!

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change. (**N/A?** It's a very small bugfix change.)
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`. (~**NB:** `byte-compile-file` has an Error on trunk. I think only because I didn't add `.` to my load-path.~ Yes red herring. `load-path` fixed it.)
- [x] *I've reviewed all code in PR myself and I'm happy with its quality*.

<details>

<summary>Ignore. This was just a missing entry in my `load-path`</summary>

`byte-compile-file` Error on trunk:

```
Compiling file /Users/timvisher/git/xenodium/agent-shell/agent-shell.el at Mon Jan 19 14:30:36 2026
agent-shell.el:61:11: Error: Cannot open load file: No such file or directory, agent-shell-github
```

</details>

I'm betting that this has something to do with me running TTY Emacs rather than GUI Emacs. It would surprise me a little if GUI Emacs doesn't already `(require 'image)` just as part of starting. It's also quite uncommon to find a user that runs TTY Emacs full time.