### PR TITLE
fix: Simplify language detection

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3809,12 +3809,7 @@ Available values:
     (let ((start (region-beginning))
           (end (region-end))
           (content (buffer-substring-no-properties (region-beginning) (region-end)))
-          (language (cond ((listp mode-name)
-                           (downcase (car mode-name)))
-                          ((stringp mode-name)
-                           (downcase mode-name))
-                          (t
-                           "")))
+          (language (string-remove-suffix "-mode" (string-remove-suffix "-ts-mode" (symbol-name major-mode))))
           (file (when-let ((buffer-file-name (buffer-file-name)))
                   (file-relative-name buffer-file-name (agent-shell-cwd)))))
       (when deactivate


### PR DESCRIPTION
I use `delight` to hide some minor modes, which means that `mode-name` is a mode-line format string and doesn't play well with the existing language detection functionality. Switching to `major-mode` seems to be more robust.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [ ] *I've reviewed all code in PR myself and I'm happy with its quality*.