### PR TITLE
Fix auto-insert variable declaration in agent-shell

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -73,6 +73,10 @@
 (declare-function projectile-project-root "projectile")
 (declare-function projectile-project-p "projectile")
 
+;; Declare as special so byte-compilation doesn't turn `let' bindings into
+;; lexical bindings (which would not affect `auto-insert' behavior).
+(defvar auto-insert)
+
 (defcustom agent-shell-permission-icon "⚠"
   "Icon displayed when shell commands require permission to execute.
 
@@ -1146,8 +1150,6 @@ If the buffer's file has changed, prompt the user to reload it."
                            ;; Prevent auto-insert-mode
                            ;; See issue #170
                            (let ((auto-insert nil))
-                             ;; Silence unused warning.
-                             (identity auto-insert)
                              (find-file-noselect path)))))
           (when (and dir (not (file-exists-p dir)))
             (make-directory dir t))


### PR DESCRIPTION
This is a touch-up on #170, fixing the fix I had provided there
(commit f314f54).  That fix worked when agent-shell.el was evaluated
via C-c C-e, but not after byte-compilation in a fresh Emacs session.

* agent-shell.el (auto-insert): Declare as special variable to prevent
byte-compilation from treating let-bindings as lexical.
(agent-shell--on-fs-write-text-file-request): Remove identity call
that had been used to silence unused variable warning.