### PR TITLE
Deduplicate file link

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3644,8 +3644,7 @@ When NO-ERROR is non-nil, return nil and continue without error."
          (processed-text (if (map-elt region :file)
                              (let ((file-link (agent-shell-ui-add-action-to-text
                                                (format "%s:%d-%d"
-                                                       (file-relative-name (map-elt region :file)
-                                                                           (agent-shell-cwd))
+                                                       (map-elt region :file)
                                                        (map-elt region :line-start)
                                                        (map-elt region :line-end))
                                                (lambda ()


### PR DESCRIPTION
Because `:file` is already in relative path:
https://github.com/xenodium/agent-shell/blob/c6533461bd03c080b322c6c687a9aed97c6dcc80/agent-shell.el#L3900
Calling `file-relative-name` again would cause duplicate path e.g., `X/Y/X/Y/xxx.py`