### PR TITLE
Display command text in tool_call fragments

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -971,7 +971,11 @@ otherwise returns COMMAND unchanged."
                       :block-id .toolCallId
                       :label-left (map-elt tool-call-labels :status)
                       :label-right (map-elt tool-call-labels :title)
-                      :body (string-trim body-text)
+                      :body (concat
+                             (when-let ((cmd (map-nested-elt state `(:tool-calls ,.toolCallId :command))))
+                               (unless (string-empty-p cmd)
+                                 (propertize (format "$ %s\n\n" cmd) 'font-lock-face 'font-lock-comment-face)))
+                             (string-trim body-text))
                       :expanded agent-shell-tool-use-expand-by-default))))
                (map-put! state :last-entry-type "tool_call_update"))
               ((equal (map-elt update 'sessionUpdate) "available_commands_update")


### PR DESCRIPTION
## Problem

When ACP sends `tool_call` updates, agent-shell stores the command (from `rawInput.command`) but never displays it in the UI. Only the title, status, and output are shown. This means users don't see *what* command was executed—just the result.

Compare to Copilot CLI which shows:
```
○ Find files with prime-length filenames
  $ find ~/.emacs.d -type f | while read f; do...
   └ 12 lines...
```

agent-shell currently shows only the title and output, missing the `$ find...` line.

## Root cause

In `agent-shell.el`, the command is stored at line 813:
```elisp
(cons :command (map-nested-elt update '(rawInput command)))
```

But in the `tool_call_update` handler (~line 974), only the body text is passed without the command:
```elisp
:body (string-trim body-text)
```

The `:command` is used only for transcript logging (line 955), not UI display.

## Fix

Prepend the command to the body when rendering tool_call_update fragments:
```elisp
:body (concat
       (when-let ((cmd (map-nested-elt state \`(:tool-calls ,.toolCallId :command))))
         (unless (string-empty-p cmd)
           (propertize (format "$ %s\n\n" cmd) 'font-lock-face 'font-lock-comment-face)))
       (string-trim body-text))
```

## Testing

Tested with Copilot CLI via ACP. Tool calls now display the command above the output, styled as a comment.