### PR TITLE
Fix maintenance of :tool-calls state

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3339,9 +3339,8 @@ MESSAGE-TEXT: Optional message to display after sending the response."
   ;; block-id must be the same as the one used as
   ;; agent-shell--update-fragment param by "session/request_permission".
   (agent-shell--delete-fragment :state state :block-id (format "permission-%s" tool-call-id))
-  (let ((updated-tool-calls (map-copy (map-elt state :tool-calls))))
-    (map-delete updated-tool-calls tool-call-id)
-    (map-put! state :tool-calls updated-tool-calls))
+  (map-put! state :tool-calls
+            (map-delete (map-elt state :tool-calls) tool-call-id))
   (when message-text
     (message "%s" message-text))
   ;; Jump to any remaining permission buttons, or go to end of buffer.


### PR DESCRIPTION
`map-delete` is not destructive; we need to use `map-put!` here in order for the deletion to have any persistent effect (as is clearly the intent).

Note that since `map-delete` is not destructive, the `map-copy` is also not doing anything, so that has been removed.

Thank you for contributing to agent-shell!

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for this change.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
