### PR TITLE
Fix tool call title duplication with special shell characters

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1003,7 +1003,7 @@ otherwise returns COMMAND unchanged."
                           (when-let* ((title (or (map-nested-elt state `(:tool-calls ,.toolCallId :title)) ""))
                                       (command (or (map-nested-elt update '(rawInput command))
                                                    (map-nested-elt state `(:tool-calls ,.toolCallId :command))))
-                                      (should-upgrade-title (not (string-match command title))))
+                                      (should-upgrade-title (not (string-match-p (regexp-quote command) title))))
                             (list (cons :title (concat command " " title))))
                           (when-let ((diff (agent-shell--make-diff-info :tool-call update)))
                             (list (cons :diff diff)))))


### PR DESCRIPTION
Use `regexp-quote` to escape regex metacharacters when checking if command is already in title.

Without this, commands containing `[`, `]`, `*`, `+`, etc. cause `string-match` to fail, resulting in the command being prepended repeatedly.

```elisp
(string-match "ls *.txt" "ls *.txt")     => nil  ;; broken
(string-match-p (regexp-quote "ls *.txt") "ls *.txt") => 0  ;; fixed
```