### PR TITLE
Do not transform project-name for kebab-case buffer-name format

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1837,7 +1837,7 @@ PROPERTIES should be a plist of property-value pairs."
         ('kebab-case
          (format "%s-agent @ %s"
                  (downcase (replace-regexp-in-string " " "-" agent-name))
-                 (downcase (replace-regexp-in-string " " "-" project-name))))
+                 project-name))
         ('default
          (format "%s Agent @ %s"
                  agent-name


### PR DESCRIPTION
Very minor change removing transform of `project-name` when formatting buffer-name using `kebab-case`.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
