### PR TITLE
guard permission title rendering when command/title are missing

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3405,7 +3405,7 @@ For example:
                    map))
          (title (let* ((title (map-nested-elt request '(params toolCall title)))
                        (command (map-nested-elt request '(params toolCall rawInput command)))
-                       (command-first-line (when command
+                       (command-first-line (when (stringp command)
                                              (if (string-match "\n" command)
                                                  (concat (substring command 0 (match-beginning 0)) "...")
                                                command))))
@@ -3413,7 +3413,10 @@ For example:
                   ;; permission/tool call title, so it's hard to know
                   ;; what the permission is actually allowing.
                   ;; Display command if needed.
-                  (if (string-match-p (regexp-quote (or command "")) title)
+                  (if (and (stringp title)
+                           (stringp command)
+                           (not (string-empty-p command))
+                           (string-match-p (regexp-quote command) title))
                       title
                     (or command-first-line title))))
          (diff-button (when diff


### PR DESCRIPTION
Permission prompt rendering could throw when a tool call arrives without a
string `title` (or with a missing/empty `rawInput.command`).

This happens in codex for example:
```json
{
    "direction": "incoming",
    "kind": "request",
    "object": {
      "jsonrpc": "2.0",
      "id": 1,
      "method": "session/request_permission",
      "params": {
        "toolCall": {
          "kind": "execute",
          "status": "pending",
          "title": "Run rm 1.txt",
          "content": [
            {
              "type": "content",
              "content": [
                {
                  "type": "text",
                  "text": "Do you want me to run `rm 1.txt` outside the read-only sandbox so the file is removed?\nProposed Amendment: rm\n1.txt"
                }
              ]
            }
          ],
          "rawInput": {
            "command": "",
            "cwd": "/home/user/dir/",
            "parsed_cmd": {
              "cmd": "rm 1.txt",
              "type": "unknown"
            },
            "proposed_execpolicy_amendment": null,
            "reason": "Do you want me to run `rm 1.txt` outside the read-only sandbox so the file is removed?",
            "turn_id": 4
          }
        },
        "options": [
          {
            "optionId": "approved-for-session",
            "name": "Always",
            "kind": "allow_always"
          },
          {
            "optionId": "approved",
            "name": "Yes",
            "kind": "allow_once"
          },
          {
            "optionId": "abort",
            "name": "No, provide feedback",
            "kind": "reject_once"
          }
        ]
      }
    }
  }
```
