### PR TITLE
Update GitHub Copilot ASCII art to match official CLI banner

### DIFF
--- a/agent-shell-github.el
+++ b/agent-shell-github.el
@@ -94,15 +94,15 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
             message)))
 
 (defun agent-shell-github--ascii-art ()
-  "GitHub Copilot ASCII art."
+  "GitHub Copilot ASCII art matching the official CLI banner."
   (let* ((is-dark (eq (frame-parameter nil 'background-mode) 'dark))
          (text (string-trim "
-  ██████╗  ██████╗  ██████╗  ██╗ ██╗       ██████╗  ████████╗
- ██╔════╝ ██╔═══██╗ ██╔══██╗ ██║ ██║      ██╔═══██╗ ╚══██╔══╝
- ██║      ██║   ██║ ██████╔╝ ██║ ██║      ██║   ██║    ██║
- ██║      ██║   ██║ ██╔═══╝  ██║ ██║      ██║   ██║    ██║
- ╚██████╗ ╚██████╔╝ ██║      ██║ ███████╗ ╚██████╔╝    ██║
-  ╚═════╝  ╚═════╝  ╚═╝      ╚═╝ ╚══════╝  ╚═════╝     ╚═╝
+  █████┐ █████┐ █████┐ ██┐██┐     █████┐ ██████┐
+ ██┌───┘██┌──██┐██┌─██┐██│██│    ██┌──██┐└─██┌─┘
+ ██│    ██│  ██│█████┌┘██│██│    ██│  ██│  ██│
+ ██│    ██│  ██│██┌──┘ ██│██│    ██│  ██│  ██│
+ └█████┐└█████┌┘██│    ██│██████┐└█████┌┘  ██│
+  └────┘ └────┘ └─┘    └─┘└─────┘ └────┘   └─┘
 " "\n")))
     (propertize text 'font-lock-face (if is-dark
                                          '(:foreground "#6e40c9" :inherit fixed-pitch)


### PR DESCRIPTION
## Summary

Update the ASCII art in `agent-shell-github--ascii-art` to match the block-letter COPILOT logo used by the official `copilot --banner` command.

## Checklist

- [x] I've read the README's Contributing section.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] My code follows the project style.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.

## Notes

This is a visual consistency improvement - the new ASCII art matches what users see when running `copilot --banner` in their terminal.