### PR TITLE
Include current prompt when switching from shell to viewport

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -358,7 +358,7 @@ Optionally set its PROMPT and RESPONSE."
     (agent-shell-viewport--initialize
      :prompt (car current)
      :response (cdr current))
-    (goto-char (point-min))
+    (goto-char (point-max))
     current))
 
 (defun agent-shell-viewport-next-item ()

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -713,7 +713,7 @@ Includes shells accessed via viewport buffers, preserving visited order."
                                           :shell-buffer (current-buffer))
                                          "Not in a shell viewport buffer")))
            (with-current-buffer viewport-buffer
-             (when (derived-mode-p 'agent-shell-viewport-view-mode)
+             (when (= (point-min) (point-max))
                (agent-shell-viewport-refresh)))
            (switch-to-buffer viewport-buffer)))
         (t


### PR DESCRIPTION
I often find myself starting a prompt in shell mode, then realising it will be easier to continue in viewport-mode. Currently after entering viewport mode via `C-c C-o`, the partial shell prompt is not sent to the viewport. So I have to switch back and manually copy it.

This PR automatically sends the current prompt to the viewport - assuming the viewport composer is empty.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
