### PR TITLE
Add agent-shell-send-dwim to transient menu

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4455,6 +4455,7 @@ Mark model using CURRENT-MODEL-ID."
    ["Insert"
     ("!" "Shell command" agent-shell-insert-shell-command-output :transient t)
     ("@" "File" agent-shell-insert-file :transient t)
+    ("d" "Dwim" agent-shell-send-dwim :transient t)
     ]]
   [["Session"
     ("m" "Cycle modes" agent-shell-cycle-session-mode :transient t)


### PR DESCRIPTION
Small change to add `d` to agent-shell-help-menu.

Right now, most of my workflow goes through agent-shell-help-menu with:

```
  (use-package agent-shell
    :bind ("C-c C-'" . agent-shell-help-menu))
```

This seems like a reasonable addition? I know I can bind it myself but it seems like something others might want.