### PR TITLE
Add experimental quiet mode for compact turn display

### DIFF
--- a/agent-shell-quiet.el
+++ b/agent-shell-quiet.el
@@ -1,0 +1,259 @@
+;;; agent-shell-quiet.el --- Quiet mode for compact turn display -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Alvaro Ramirez
+
+;; Author: Alvaro Ramirez https://xenodium.com
+;; URL: https://github.com/xenodium/agent-shell
+
+;; This package is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This package is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Report issues at https://github.com/xenodium/agent-shell/issues
+;;
+;; ✨ Please support this work https://github.com/sponsors/xenodium ✨
+
+;;; Commentary:
+;;
+;; Provides quiet mode for agent-shell.  When enabled, all thought
+;; process and tool call fragments within a turn are grouped under a
+;; single collapsible section, reducing vertical space.
+
+;;; Code:
+
+(require 'map)
+(require 'agent-shell-ui)
+
+(defvar agent-shell--state)
+
+(declare-function agent-shell--update-fragment "agent-shell")
+(declare-function agent-shell-viewport--buffer "agent-shell-viewport")
+(declare-function agent-shell-viewport--shell-buffer "agent-shell-viewport")
+
+(defcustom agent-shell-quiet-mode nil
+  "Whether to use quiet mode for agent turns.
+
+When non-nil, all thought process and tool call sections within a
+turn are grouped under a single collapsible section.  The section
+label shows the current thought summary.  Expanding reveals the
+individual tool calls and thought content as nested collapsible
+sections.
+
+When nil (the default), each thought and tool call is shown as a
+separate top-level collapsible section."
+  :type 'boolean
+  :group 'agent-shell)
+
+(defun agent-shell--quiet-mode-ensure-wrapper (state)
+  "Ensure a quiet-mode wrapper fragment exists for the current turn in STATE.
+Creates the wrapper on first call per turn and returns the quiet-group alist."
+  (let ((group (map-elt state :quiet-group)))
+    (unless (and group
+                 (equal (map-elt group :request-count)
+                        (map-elt state :request-count)))
+      ;; New turn — create a new quiet group
+      (setq group (list (cons :request-count (map-elt state :request-count))
+                        (cons :wrapper-block-id
+                              (format "quiet-%s" (map-elt state :request-count)))
+                        (cons :child-block-ids nil)
+                        (cons :label "Working…")))
+      (map-put! state :quiet-group group)
+      ;; Register invisibility spec in both buffers
+      (dolist (buf (list (map-elt state :buffer)
+                         (agent-shell-viewport--buffer
+                          :shell-buffer (map-elt state :buffer)
+                          :existing-only t)))
+        (when (and buf (buffer-live-p buf))
+          (with-current-buffer buf
+            (add-to-invisibility-spec 'agent-shell-quiet))))
+      ;; Create the wrapper fragment (collapsed by default)
+      (agent-shell--update-fragment
+       :state state
+       :block-id (map-elt group :wrapper-block-id)
+       :label-left (propertize (map-elt group :label)
+                               'font-lock-face 'font-lock-doc-markup-face)
+       :body " "
+       :expanded nil))
+    group))
+
+(defun agent-shell--quiet-mode-update-label (state label)
+  "Update the quiet-mode wrapper label to LABEL in STATE."
+  (when-let* ((group (map-elt state :quiet-group)))
+    (setf (map-elt group :label) label)
+    (agent-shell--update-fragment
+     :state state
+     :block-id (map-elt group :wrapper-block-id)
+     :label-left (propertize label 'font-lock-face 'font-lock-doc-markup-face))))
+
+(defun agent-shell--quiet-mode-register-child (state block-id)
+  "Register BLOCK-ID as a child of the current quiet group in STATE."
+  (when-let* ((group (map-elt state :quiet-group)))
+    (let ((children (map-elt group :child-block-ids)))
+      (unless (member block-id children)
+        (setf (map-elt group :child-block-ids)
+              (append children (list block-id)))))))
+
+(defun agent-shell--quiet-mode-style-child (start end collapsed)
+  "Apply quiet-mode styling to child fragment region from START to END.
+When COLLAPSED is non-nil, hide the region.  When nil, show it
+with indentation and reduced spacing.
+
+Uses the `agent-shell-quiet' invisible spec to avoid conflicting
+with fragment-level collapse which uses t."
+  (if collapsed
+      ;; Hide: set agent-shell-quiet only where invisible is currently nil,
+      ;; preserving fragment-internal invisible=t on collapsed bodies.
+      (save-excursion
+        (let ((pos start))
+          (while (< pos end)
+            (let* ((val (get-text-property pos 'invisible))
+                   (next (next-single-property-change pos 'invisible nil end)))
+              (unless val
+                (put-text-property pos next 'invisible 'agent-shell-quiet))
+              (setq pos next)))))
+    ;; Show: remove our invisible spec from the region,
+    ;; leaving t (fragment-internal collapse) untouched.
+    (save-excursion
+      (let ((pos start))
+        (while (< pos end)
+          (let* ((val (get-text-property pos 'invisible))
+                 (next (next-single-property-change pos 'invisible nil end)))
+            (when (eq val 'agent-shell-quiet)
+              (remove-text-properties pos next '(invisible nil)))
+            (setq pos next)))))
+    ;; Indent child fragments to show hierarchy
+    (put-text-property start end 'line-prefix "  ")
+    (put-text-property start end 'wrap-prefix "  ")
+    ;; Reduce preceding newlines: keep only 1 instead of 2
+    (save-excursion
+      (goto-char start)
+      (when (and (> start (point-min))
+                 (eq (char-before start) ?\n)
+                 (> (1- start) (point-min))
+                 (eq (char-before (1- start)) ?\n))
+        (put-text-property (1- start) start 'invisible 'agent-shell-quiet)))))
+
+(defun agent-shell--quiet-mode-hide-wrapper-body (buf qualified-wrapper-id)
+  "Hide the wrapper fragment's body padding in BUF.
+QUALIFIED-WRAPPER-ID identifies the wrapper.  The wrapper's body
+is just a placeholder space; we keep it invisible even when the
+wrapper is expanded so it doesn't add blank lines.
+
+This function exists because agent-shell-ui requires a non-nil body
+to show a collapse indicator (▶/▼).  If the UI supported a
+`:bodyless-collapsible' option on fragments, this workaround and
+the placeholder body in `agent-shell--quiet-mode-ensure-wrapper'
+could be removed entirely."
+  (when (and buf (buffer-live-p buf))
+    (with-current-buffer buf
+      (save-mark-and-excursion
+        (let ((inhibit-read-only t)
+              (buffer-undo-list t))
+          (goto-char (point-max))
+          (when-let* ((match (text-property-search-backward
+                              'agent-shell-ui-state nil
+                              (lambda (_ s)
+                                (equal (map-elt s :qualified-id) qualified-wrapper-id))
+                              t))
+                      (block-start (prop-match-beginning match))
+                      (block-end (prop-match-end match))
+                      (body-range (agent-shell-ui--nearest-range-matching-property
+                                   :property 'agent-shell-ui-section :value 'body
+                                   :from block-start :to block-end))
+                      (label-end (or (map-elt (agent-shell-ui--nearest-range-matching-property
+                                               :property 'agent-shell-ui-section :value 'label-right
+                                               :from block-start :to block-end)
+                                              :end)
+                                     (map-elt (agent-shell-ui--nearest-range-matching-property
+                                               :property 'agent-shell-ui-section :value 'label-left
+                                               :from block-start :to block-end)
+                                              :end))))
+            ;; Hide from end of label to end of body (the \n\n + " ")
+            (put-text-property label-end (map-elt body-range :end)
+                               'invisible 'agent-shell-quiet)))))))
+
+(defun agent-shell--quiet-mode-sync-children-visibility (state)
+  "Sync quiet-mode child visibility with wrapper collapsed state in STATE.
+Called after a child fragment is created/updated to ensure it matches
+the wrapper's visibility."
+  (when-let* ((group (map-elt state :quiet-group))
+              (wrapper-id (map-elt group :wrapper-block-id))
+              (request-count (map-elt state :request-count))
+              (namespace-id (format "%s" request-count))
+              (qualified-wrapper-id (format "%s-%s" namespace-id wrapper-id)))
+    ;; Process each buffer (shell + viewport)
+    (dolist (buf (list (map-elt state :buffer)
+                       (agent-shell-viewport--buffer
+                        :shell-buffer (map-elt state :buffer)
+                        :existing-only t)))
+      (when (and buf (buffer-live-p buf))
+        ;; Always keep wrapper body hidden (it's just a placeholder)
+        (agent-shell--quiet-mode-hide-wrapper-body buf qualified-wrapper-id)
+        (with-current-buffer buf
+          (save-mark-and-excursion
+            (let ((inhibit-read-only t)
+                  (buffer-undo-list t))
+              ;; Find wrapper state to check if collapsed
+              (goto-char (point-max))
+              (when-let* ((match (text-property-search-backward
+                                  'agent-shell-ui-state nil
+                                  (lambda (_ s)
+                                    (equal (map-elt s :qualified-id) qualified-wrapper-id))
+                                  t))
+                          (wrapper-state (get-text-property (prop-match-beginning match)
+                                                           'agent-shell-ui-state)))
+                (let ((wrapper-collapsed (map-elt wrapper-state :collapsed)))
+                  ;; Style all children based on wrapper collapsed state
+                (dolist (child-id (map-elt group :child-block-ids))
+                  (let ((qualified-child-id (format "%s-%s" namespace-id child-id)))
+                    (goto-char (point-max))
+                    (when-let* ((child-match (text-property-search-backward
+                                             'agent-shell-ui-state nil
+                                             (lambda (_ s)
+                                               (equal (map-elt s :qualified-id) qualified-child-id))
+                                             t)))
+                      (let ((start (prop-match-beginning child-match))
+                            (end (prop-match-end child-match)))
+                        (save-excursion
+                          (goto-char start)
+                          (skip-chars-backward "\n")
+                          (setq start (point)))
+                        (agent-shell--quiet-mode-style-child
+                         start end wrapper-collapsed))))))))))))))
+
+(defun agent-shell--quiet-mode-toggle-children (orig-fn)
+  "Advice around `agent-shell-ui-toggle-fragment-at-point' for quiet mode.
+After toggling a quiet wrapper, also toggle its child fragments.
+ORIG-FN is the original toggle function."
+  (let* ((state-before (get-text-property (point) 'agent-shell-ui-state))
+         (qualified-id (and state-before (map-elt state-before :qualified-id))))
+    (funcall orig-fn)
+    ;; After toggle, check if this was a quiet wrapper
+    (when (and agent-shell-quiet-mode
+               qualified-id
+               (string-match "^\\(.+\\)-quiet-\\(.+\\)$" qualified-id))
+      (let* ((shell-buf (cond
+                          ((derived-mode-p 'agent-shell-mode) (current-buffer))
+                          (t (agent-shell-viewport--shell-buffer))))
+             (shell-state (and shell-buf (buffer-live-p shell-buf)
+                               (buffer-local-value 'agent-shell--state shell-buf))))
+        (when shell-state
+          (agent-shell--quiet-mode-sync-children-visibility shell-state))))))
+
+(advice-add 'agent-shell-ui-toggle-fragment-at-point
+            :around #'agent-shell--quiet-mode-toggle-children)
+
+(provide 'agent-shell-quiet)
+
+;;; agent-shell-quiet.el ends here


### PR DESCRIPTION
## Summary

This is an **EXPERIMENTAL** mode to show what it would look like to conceal most of the steps between thoughts. In long running turns this shows only the most important agent thoughts and reduces visual noise considerably.

## What it does

When `agent-shell-quiet-mode` is enabled (`t`), all thought process and tool call fragments within a turn are grouped under collapsible sections instead of being shown individually. Each section:

- Shows the agent's current thought as a one-line label
- Animates a braille spinner (⠋⠙⠹…) while work is in progress
- Finalizes with ✓ when the phase completes
- Expands on click to reveal the individual tool calls underneath

When a new thought arrives after tool calls, a new collapsible group starts automatically — so long-running turns show multiple phases:

```
▶ ✓ Exploring the codebase...
▶ ⠹ Found the issue, now fixing...
```

## Implementation

- New file `agent-shell-quiet.el` with all quiet mode logic
- Uses `agent-shell-ui` fragments: a wrapper fragment per phase with child fragments for tool calls
- Spinner timer and state stored per-group on the state alist (multi-session safe)
- Late-completing tool calls are correctly associated with their originating group
- Toggle (expand/collapse) works via advice on `agent-shell-ui-toggle-fragment-at-point`

## Usage

```elisp
(setq agent-shell-quiet-mode t)
```

No other configuration needed. Set to `nil` to return to normal display.