### PR TITLE
fix: restore color coding for usage indicator

### DIFF
--- a/agent-shell-usage.el
+++ b/agent-shell-usage.el
@@ -212,9 +212,14 @@ Only returns an indicator if enabled and usage data is available."
                        ((>= percentage 37.5) "▃")
                        ((>= percentage 25) "▂")
                        ((> percentage 0) "▁")
-                       (t nil))))  ; Return nil for no usage
+                       (t nil)))  ; Return nil for no usage
+           (face (cond
+                  ((>= percentage 85) 'error)         ; Red for critical
+                  ((>= percentage 60) 'warning)       ; Yellow/orange for warning
+                  (t 'success))))                     ; Green for normal
       (when indicator
         (propertize indicator
+                    'face face
                     'help-echo (agent-shell--format-usage usage))))))
 
 (provide 'agent-shell-usage)


### PR DESCRIPTION
Just adds back the color coding that was inadvertently removed. I figure this can just go in, while you think further about whether to switch the bar gauge to something else.

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
