### PR TITLE
Handle case where the tool-call command is nil

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1090,6 +1090,7 @@ COMMAND may be a shell command string or an argv vector."
   (cond ((stringp command) command)
         ((vectorp command)
          (combine-and-quote-strings (append command nil)))
+        ((not command) "nil")
         (t (error "Unexpected tool-call command type: %S" (type-of command)))))
 
 (cl-defun agent-shell--on-notification (&key state notification)


### PR DESCRIPTION
Fixes #297 

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [n/a] I've filed a feature request/discussion for a new feature.
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [n/a] I've added tests where applicable.
- [n/a] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.

## Description

When using agent-shell with Anthropic's Claude Code I was getting this error immediately upon issuing my first prompt:

```
Debugger entered--Lisp error: (error "Unexpected tool-call command type: symbol")
  error("Unexpected tool-call command type: %S" symbol)
```

It looks like `agent-shell--tool-call-command-to-string` emits this error when the passed `command` parameter is `nil`, which it evidently can be sometimes. This PR simply adds a graceful fallback when `command ` is `nil`.