### PR TITLE
feat: Add support for model configuration by name

### DIFF
--- a/agent-shell-anthropic.el
+++ b/agent-shell-anthropic.el
@@ -80,6 +80,18 @@ when starting a new shell."
   :type '(choice (const nil) string)
   :group 'agent-shell)
 
+(defcustom agent-shell-anthropic-default-model-name
+  nil
+  "Default Anthropic model name.
+
+Must be one of the model names displayed under \"Available models\"
+when starting a new shell. For example: \"Opus\", \"Sonnet\", \"Haiku\".
+
+Cannot be used together with `agent-shell-anthropic-default-model-id'.
+If both are set, an error will be raised."
+  :type '(choice (const nil) string)
+  :group 'agent-shell)
+
 (defcustom agent-shell-anthropic-default-session-mode-id
   nil
   "Default Anthropic session mode ID.
@@ -113,6 +125,57 @@ Example usage to set a custom Anthropic API base URL:
   :type '(repeat string)
   :group 'agent-shell)
 
+(defun agent-shell-anthropic--find-model-id-by-name (name models)
+  "Find model ID for model with NAME in MODELS list.
+
+MODELS is a list of model alists with :name and :model-id keys.
+Returns the model-id if found, nil otherwise."
+  (when (and name models)
+    (let ((model (seq-find (lambda (m)
+                            (string-equal (downcase (or (map-elt m :name) ""))
+                                         (downcase name)))
+                          models)))
+      (when model
+        (map-elt model :model-id)))))
+
+(defun agent-shell-anthropic--resolve-default-model-id ()
+  "Resolve the default model ID from name or ID configuration.
+
+Returns the model ID to use.  Only one of
+`agent-shell-anthropic-default-model-name' or
+`agent-shell-anthropic-default-model-id' should be configured.
+If both are set, an error is raised.
+
+When a model name is configured, this function will attempt
+to resolve it to a model ID once models are available in the
+session state.  If the name cannot be resolved, an error is
+raised."
+  ;; Error if both are configured to avoid confusion
+  (when (and agent-shell-anthropic-default-model-name
+             agent-shell-anthropic-default-model-id)
+    (error "Both `agent-shell-anthropic-default-model-name' and `agent-shell-anthropic-default-model-id' are configured. Please use only one"))
+  (cond
+   ;; If model name is specified and we have session models, resolve it
+   ((and agent-shell-anthropic-default-model-name
+         (boundp 'agent-shell--state)
+         (map-nested-elt agent-shell--state '(:session :models)))
+    (let ((resolved-id (agent-shell-anthropic--find-model-id-by-name
+                       agent-shell-anthropic-default-model-name
+                       (map-nested-elt agent-shell--state '(:session :models)))))
+      (unless resolved-id
+        (error "Model name '%s' not found in available models"
+               agent-shell-anthropic-default-model-name))
+      resolved-id))
+   ;; If only model name is specified but models aren't loaded yet, return marker
+   (agent-shell-anthropic-default-model-name
+    ;; This tells agent-shell to call us again after session init
+    'resolve-by-name)
+   ;; Otherwise use the model ID directly
+   (agent-shell-anthropic-default-model-id
+    agent-shell-anthropic-default-model-id)
+   ;; No default specified
+   (t nil)))
+
 (defun agent-shell-anthropic-make-claude-code-config ()
   "Create a Claude Code agent configuration.
 
@@ -127,7 +190,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-anthropic--claude-code-welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-anthropic-make-claude-client :buffer buffer))
-   :default-model-id (lambda () agent-shell-anthropic-default-model-id)
+   :default-model-id #'agent-shell-anthropic--resolve-default-model-id
    :default-session-mode-id (lambda () agent-shell-anthropic-default-session-mode-id)
    :install-instructions "See https://github.com/zed-industries/claude-agent-acp for installation."))
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1022,16 +1022,27 @@ Flow:
                                (agent-shell--handle :command command :shell-buffer shell-buffer))))
           ;; Send ACP request to set default model (optional)
           ((and (map-nested-elt (agent-shell--state) '(:agent-config :default-model-id))
-                (funcall (map-nested-elt (agent-shell--state)
-                                         '(:agent-config :default-model-id)))
                 (not (map-elt (agent-shell--state) :set-model)))
-           (agent-shell--set-default-model
-            :shell-buffer shell-buffer
-            :model-id (funcall (map-nested-elt (agent-shell--state)
-                                               '(:agent-config :default-model-id)))
-            :on-model-changed (lambda ()
-                                (map-put! (agent-shell--state) :set-model t)
-                                (agent-shell--handle :command command :shell-buffer shell-buffer))))
+           (let ((model-id-or-marker (funcall (map-nested-elt (agent-shell--state)
+                                                              '(:agent-config :default-model-id)))))
+             (cond
+              ;; If we get 'resolve-by-name, models aren't loaded yet - skip for now
+              ((eq model-id-or-marker 'resolve-by-name)
+               ;; Mark that we haven't set the model yet so we'll retry after models are loaded
+               (map-put! (agent-shell--state) :set-model nil)
+               (agent-shell--handle :command command :shell-buffer shell-buffer))
+              ;; If we have an actual model ID, set it
+              (model-id-or-marker
+               (agent-shell--set-default-model
+                :shell-buffer shell-buffer
+                :model-id model-id-or-marker
+                :on-model-changed (lambda ()
+                                    (map-put! (agent-shell--state) :set-model t)
+                                    (agent-shell--handle :command command :shell-buffer shell-buffer))))
+              ;; No model to set
+              (t
+               (map-put! (agent-shell--state) :set-model t)
+               (agent-shell--handle :command command :shell-buffer shell-buffer)))))
           ;; Send ACP request to set default session mode (optional)
           ((and (map-nested-elt (agent-shell--state) '(:agent-config :default-session-mode-id))
                 (funcall (map-nested-elt (agent-shell--state) '(:agent-config :default-session-mode-id)))
@@ -3966,7 +3977,7 @@ Returns a buffer object or nil."
                        ;; to get latest input.
                        (buffer-substring
                         (or (marker-position comint-accum-marker)
-	                    (process-mark (get-buffer-process (current-buffer))))
+                        (process-mark (get-buffer-process (current-buffer))))
                         (point-max)))))
     (unless (string-empty-p (string-trim input))
       input)))

--- a/tests/agent-shell-anthropic-tests.el
+++ b/tests/agent-shell-anthropic-tests.el
@@ -4,6 +4,12 @@
 (require 'agent-shell)
 (require 'agent-shell-anthropic)
 
+(defvar agent-shell-anthropic-default-model-name)
+(defvar agent-shell-anthropic-default-model-id)
+
+(declare-function agent-shell-anthropic--find-model-id-by-name "agent-shell-anthropic")
+(declare-function agent-shell-anthropic--resolve-default-model-id "agent-shell-anthropic")
+
 (ert-deftest agent-shell-anthropic-make-claude-client-test ()
   "Test agent-shell-anthropic-make-claude-client function."
   ;; Mock executable-find to always return the command path
@@ -78,6 +84,98 @@
             (should (member "EXISTING_VAR=existing_value" env-vars)))
         (when (buffer-live-p test-buffer)
           (kill-buffer test-buffer))))))
+
+(ert-deftest agent-shell-anthropic-find-model-id-by-name-test ()
+  "Test agent-shell-anthropic--find-model-id-by-name function."
+  (let ((mock-models '(((:name . "Default (recommended)")
+                        (:model-id . "claude-3-5-sonnet-20241022")
+                        (:description . "Use the default model"))
+                       ((:name . "Sonnet")
+                        (:model-id . "claude-3-6-sonnet-20250115")
+                        (:description . "Sonnet 4.6"))
+                       ((:name . "Opus")
+                        (:model-id . "claude-3-6-opus-20250109")
+                        (:description . "Opus 4.6"))
+                       ((:name . "Opus 4.1")
+                        (:model-id . "claude-opus-4-1-legacy")
+                        (:description . "Opus 4.1 Legacy"))
+                       ((:name . "Haiku")
+                        (:model-id . "claude-3-6-haiku-20250107")
+                        (:description . "Haiku 4.5")))))
+
+    ;; Test exact match
+    (should (string= (agent-shell-anthropic--find-model-id-by-name "Opus" mock-models)
+                     "claude-3-6-opus-20250109"))
+
+    ;; Test case-insensitive match
+    (should (string= (agent-shell-anthropic--find-model-id-by-name "opus" mock-models)
+                     "claude-3-6-opus-20250109"))
+    (should (string= (agent-shell-anthropic--find-model-id-by-name "OPUS" mock-models)
+                     "claude-3-6-opus-20250109"))
+
+    ;; Test other models
+    (should (string= (agent-shell-anthropic--find-model-id-by-name "Sonnet" mock-models)
+                     "claude-3-6-sonnet-20250115"))
+    (should (string= (agent-shell-anthropic--find-model-id-by-name "Haiku" mock-models)
+                     "claude-3-6-haiku-20250107"))
+
+    ;; Test non-existent model
+    (should (null (agent-shell-anthropic--find-model-id-by-name "NonExistent" mock-models)))
+
+    ;; Test nil inputs
+    (should (null (agent-shell-anthropic--find-model-id-by-name nil mock-models)))
+    (should (null (agent-shell-anthropic--find-model-id-by-name "Opus" nil)))
+    (should (null (agent-shell-anthropic--find-model-id-by-name nil nil)))))
+
+(ert-deftest agent-shell-anthropic-resolve-default-model-id-test ()
+  "Test agent-shell-anthropic--resolve-default-model-id function."
+  ;; Test when only model ID is configured
+  (let ((agent-shell-anthropic-default-model-name nil)
+        (agent-shell-anthropic-default-model-id "test-model-id")
+        (agent-shell--state nil))
+    (should (string= (agent-shell-anthropic--resolve-default-model-id) "test-model-id")))
+
+  ;; Test when only model name is configured but no state yet
+  (let ((agent-shell-anthropic-default-model-name "Opus")
+        (agent-shell-anthropic-default-model-id nil)
+        (agent-shell--state nil))
+    (should (eq (agent-shell-anthropic--resolve-default-model-id) 'resolve-by-name)))
+
+  ;; Test when model name is configured and state has models
+  (let ((agent-shell-anthropic-default-model-name "Opus")
+        (agent-shell-anthropic-default-model-id nil)
+        (agent-shell--state '((:session . ((:models . (((:name . "Opus")
+                                                        (:model-id . "claude-opus-id")
+                                                        (:description . "Opus model"))
+                                                       ((:name . "Sonnet")
+                                                        (:model-id . "claude-sonnet-id")
+                                                        (:description . "Sonnet model")))))))))
+    (should (string= (agent-shell-anthropic--resolve-default-model-id) "claude-opus-id")))
+
+  ;; Test when model name doesn't match any model - should error
+  (let ((agent-shell-anthropic-default-model-name "NonExistent")
+        (agent-shell-anthropic-default-model-id nil)
+        (agent-shell--state '((:session . ((:models . (((:name . "Opus")
+                                                        (:model-id . "claude-opus-id")
+                                                        (:description . "Opus model")))))))))
+    (should-error (agent-shell-anthropic--resolve-default-model-id)
+                  :type 'error))
+
+  ;; Test when neither name nor ID is configured
+  (let ((agent-shell-anthropic-default-model-name nil)
+        (agent-shell-anthropic-default-model-id nil)
+        (agent-shell--state nil))
+    (should (null (agent-shell-anthropic--resolve-default-model-id))))
+
+  ;; Test error when both name and ID are configured
+  (let ((agent-shell-anthropic-default-model-name "Sonnet")
+        (agent-shell-anthropic-default-model-id "some-model-id")
+        (agent-shell--state '((:session . ((:models . (((:name . "Opus")
+                                                        (:model-id . "claude-opus-id"))
+                                                       ((:name . "Sonnet")
+                                                        (:model-id . "claude-sonnet-id")))))))))
+    (should-error (agent-shell-anthropic--resolve-default-model-id)
+                  :type 'error)))
 
 (provide 'agent-shell-anthropic-tests)
 ;;; agent-shell-anthropic-tests.el ends here


### PR DESCRIPTION
Previously, users had to configure the default Anthropic model using technical model IDs like "us.anthropic.claude-opus-4-5-20251101-v1:0", which are:
- Hard to remember and type correctly
- Not user-friendly
- Subject to change across model versions
- Difficult to discover without looking at server responses

This change allows users to configure models using human-readable names like "Opus", "Sonnet", or "Haiku" instead, making the configuration more intuitive and maintainable.

- Add `agent-shell-anthropic-default-model-name` custom variable for specifying models by name (e.g., "Opus", "Sonnet", "Haiku")
- Implement model name resolution that maps names to IDs after session initialization when available models are known
- Add validation to prevent confusing configurations where both name and ID are set - raises clear error messages
- Handle deferred model setting for name-based configuration, retrying after session initialization when models are available
- Add comprehensive tests for model name resolution and error cases

Users can now configure:
```elisp
(setq agent-shell-anthropic-default-model-name "Opus")
```

Instead of:
```elisp
(setq agent-shell-anthropic-default-model-id "claude-3-6-opus-20250109")
```

The implementation handles case-insensitive matching and provides clear error messages when models cannot be found or when configuration is invalid.