### PR TITLE
Fix heartbeat nil value crash in timer and busy indicator

### DIFF
--- a/agent-shell-heartbeat.el
+++ b/agent-shell-heartbeat.el
@@ -84,12 +84,12 @@ Returns the heartbeat alist with the timer started."
       (map-put! heartbeat :heartbeat-timer
                 (run-at-time 0 (/ 1.0 (map-elt heartbeat :beats-per-second))
                              (lambda ()
-                               (map-put! heartbeat :status 'busy)
-                               (map-put! heartbeat :value
-                                         (1+ (map-elt heartbeat :value)))
-                               (funcall (map-elt heartbeat :on-heartbeat)
-                                        (map-elt heartbeat :value)
-                                        (map-elt heartbeat :status))))))
+                               (when-let ((value (map-elt heartbeat :value)))
+                                 (map-put! heartbeat :status 'busy)
+                                 (map-put! heartbeat :value (1+ value))
+                                 (funcall (map-elt heartbeat :on-heartbeat)
+                                          (map-elt heartbeat :value)
+                                          (map-elt heartbeat :status)))))))
     heartbeat))
 
 (cl-defun agent-shell-heartbeat-stop (&key heartbeat)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -5176,9 +5176,9 @@ See https://agentclientprotocol.com/protocol/session-modes for details."
                         ('dots-round '("⢎⡰" "⢎⡡" "⢎⡑" "⢎⠱" "⠎⡱" "⢊⡱" "⢌⡱" "⢆⡱"))
                         ('wide '("░   " "░░  " "░░░ " "░░░░" "░░░ " "░░  " "░   " "    "))
                         ((pred listp) agent-shell-busy-indicator-frames)
-                        (_ '("▁" "▂" "▃" "▄" "▅" "▆" "▇" "█" "▇" "▆" "▅" "▄" "▃" "▂")))))
-    (concat " " (seq-elt frames (mod (map-nested-elt (agent-shell--state) '(:heartbeat :value))
-                                     (length frames))))))
+                        (_ '("▁" "▂" "▃" "▄" "▅" "▆" "▇" "█" "▇" "▆" "▅" "▄" "▃" "▂"))))
+              (value (map-nested-elt (agent-shell--state) '(:heartbeat :value))))
+    (concat " " (seq-elt frames (mod value (length frames))))))
 
 (defun agent-shell--mode-line-format ()
   "Return `agent-shell''s mode-line format.


### PR DESCRIPTION
## Summary

- Guard against nil `:heartbeat :value` in the timer lambda and busy indicator frame function

## Problem

`agent-shell-heartbeat-stop` sets `:value` to nil, but `cancel-timer` doesn't prevent an already-dispatched timer tick from running. When that final tick fires, it calls `(1+ nil)`, producing:

```
(wrong-type-argument number-or-marker-p nil)
```

The same nil value propagates to `agent-shell--busy-indicator-frame` via mode-line redisplay during the `force-mode-line-update` call, triggering the error there too. This results in repeated error spam in `*Messages*`.

## Changes

- `agent-shell-heartbeat.el`: Wrap timer lambda body in `when-let` so it skips the tick when value is nil
- `agent-shell.el`: Add `value` binding to `when-let*` in `agent-shell--busy-indicator-frame` so `mod` never receives nil

## Test plan

- [ ] Start an agent-shell session and let it run (busy indicator active)
- [ ] Interrupt/stop the session and verify no `wrong-type-argument` errors in `*Messages*`

---
*Written by Claude*