### PR TITLE
Accept function value for agent-shell-anthropic-default-model-id #311

### DIFF
--- a/agent-shell-anthropic.el
+++ b/agent-shell-anthropic.el
@@ -76,8 +76,10 @@ For api key:
   "Default Anthropic model ID.
 
 Must be one of the model ID's displayed under \"Available models\"
-when starting a new shell."
-  :type '(choice (const nil) string)
+when starting a new shell.
+
+Can be set to either a string or a function that returns a string."
+  :type '(choice (const nil) string function)
   :group 'agent-shell)
 
 (defcustom agent-shell-anthropic-default-session-mode-id
@@ -127,7 +129,9 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-anthropic--claude-code-welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-anthropic-make-claude-client :buffer buffer))
-   :default-model-id (lambda () agent-shell-anthropic-default-model-id)
+   :default-model-id (lambda () (if (functionp agent-shell-anthropic-default-model-id)
+                                    (funcall agent-shell-anthropic-default-model-id)
+                                  agent-shell-anthropic-default-model-id))
    :default-session-mode-id (lambda () agent-shell-anthropic-default-session-mode-id)
    :install-instructions "See https://github.com/zed-industries/claude-agent-acp for installation."))
 

--- a/tests/agent-shell-anthropic-tests.el
+++ b/tests/agent-shell-anthropic-tests.el
@@ -79,5 +79,26 @@
         (when (buffer-live-p test-buffer)
           (kill-buffer test-buffer))))))
 
+(ert-deftest agent-shell-anthropic-default-model-id-function-test ()
+  "Test that agent-shell-anthropic-default-model-id accepts a function."
+  (let* ((config (agent-shell-anthropic-make-claude-code-config))
+         (default-model-id-fn (map-elt config :default-model-id)))
+
+    ;; Test with nil value
+    (let ((agent-shell-anthropic-default-model-id nil))
+      (should (null (funcall default-model-id-fn))))
+
+    ;; Test with string value
+    (let ((agent-shell-anthropic-default-model-id "claude-opus-4-6"))
+      (should (string= (funcall default-model-id-fn) "claude-opus-4-6")))
+
+    ;; Test with function value
+    (let ((agent-shell-anthropic-default-model-id (lambda () "dynamic-model-id")))
+      (should (string= (funcall default-model-id-fn) "dynamic-model-id")))
+
+    ;; Test with function that returns nil
+    (let ((agent-shell-anthropic-default-model-id (lambda () nil)))
+      (should (null (funcall default-model-id-fn))))))
+
 (provide 'agent-shell-anthropic-tests)
 ;;; agent-shell-anthropic-tests.el ends here


### PR DESCRIPTION
Previously, `agent-shell-anthropic-default-model-id` only accepted a string, requiring users to specify model IDs like
"us.anthropic.claude-opus-4-6-v1".

This change allows a function value, enabling users to implement custom resolution logic.  For example, resolving a human-readable model name to a model ID using the session's available models:

```elisp
  (setq agent-shell-anthropic-default-model-id
        (lambda ()
          (when-let* ((models (and (boundp 'agent-shell--state)
                                   (map-nested-elt agent-shell--state
                                                   '(:session :models))))
                      (model (seq-find
                              (lambda (m)
                                (string-equal
                                 (downcase (or (map-elt m :name) ""))
                                 (downcase "Opus")))
                              models)))
            (map-elt model :model-id))))
```