### PR TITLE
prompt-select-session preserves sorting

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3372,11 +3372,12 @@ Falls back to latest session in batch mode (e.g. tests)."
                                                    (length (agent-shell--session-title s)))
                                                  acp-sessions)))
            (new-session-choice "Start a new session")
-           (choices (cons (cons new-session-choice nil)
-                          (mapcar (lambda (acp-session)
-                                    (cons (agent-shell--session-choice-label acp-session max-dir-width max-title-width)
-                                          acp-session))
-                                  acp-sessions)))
+           (choices (append
+                     (mapcar (lambda (acp-session)
+                               (cons (agent-shell--session-choice-label acp-session max-dir-width max-title-width)
+                                     acp-session))
+                             acp-sessions)
+                     (list (cons new-session-choice nil))))
            (candidates (mapcar #'car choices))
            ;; Some completion frameworks yielded appended (nil) to each line
            ;; unless this-command was bound.
@@ -3387,8 +3388,14 @@ Falls back to latest session in batch mode (e.g. tests)."
            ;; Let's optimize the rocket engine      Feb 12, 21:02 (nil)
            (this-command 'agent-shell))
       (agent-shell--emit-event :event 'session-prompt)
-      (let ((selection (completing-read "Resume session: "
-                                        candidates
+      (let ((selection (completing-read "Resume session (default: start new): "
+                                        (lambda (string pred action)
+                                          (if (eq action 'metadata)
+                                              '(metadata
+                                                (display-sort-function . identity)
+                                                (eager-display . t)
+                                                (eager-update . t))
+                                            (complete-with-action action candidates string pred)))
                                         nil t nil nil
                                         new-session-choice)))
         (map-elt choices selection))))))


### PR DESCRIPTION
agent-shell--prompt-select-session now has completion table metadata such that it won't be sorted alphabetically by completion frontends which check display-sort-function (such as the default completion frontend), and sets eager-display and eager-update to reflect that it's a small list of candidates on which completion is cheap. (these are new in Emacs 31)

The "Start a new session" candidate is now at the end of the candidate list.  It's still the default, so a user can still select it easily by pressing RET, but now they more easily can select the candidates at the start of the candidate list, using whatever methods are specific to their completion frontend.

## Checklist

- [X] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for a new feature.
- [X] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
