### PR TITLE
agent-shell-diff-mode: fix syntax highlighting

### DIFF
--- a/agent-shell-diff.el
+++ b/agent-shell-diff.el
@@ -107,6 +107,7 @@ Arguments:
             (let ((inhibit-read-only t)
                   (diff-mode-read-only nil))
               (erase-buffer)
+              (agent-shell-diff-mode)
               (agent-shell-diff--insert-diff old new file diff-buffer)
               ;; Add overlays to hide scary text.
               (save-excursion
@@ -140,7 +141,6 @@ Arguments:
                     (overlay-put overlay 'display
                                  (propertize "│ changes │\n╰─────────╯\n\n" 'face face))
                     (overlay-put overlay 'evaporate t)))))
-            (agent-shell-diff-mode)
             (when bindings
               (setq header-line-format
                     (concat


### PR DESCRIPTION
Fix syntax highlighting in diffs.
Move `agent-shell-diff-mode` before `diff-no-select` so the font locking doesn't get reset.

This change also fixes the `q` keybinding when exiting diff. Previously, pressing `q` would simply close the buffer without prompting for confirmation. (I'm not sure why though)

## Checklist

- [x] I've read the README's [Contributing](https://github.com/xenodium/agent-shell?tab=readme-ov-file#contributing) section.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] My code follows the project [style](https://github.com/xenodium/agent-shell?tab=readme-ov-file#style-or-personal-preference-tbh).
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
