### PR TITLE
Add Thought process contents to the conversation transcript.

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1157,7 +1157,13 @@ COMMAND, when present, may be a shell command string or an argv vector."
                  ;;          (equal (map-elt state :last-entry-type) "agent_thought_chunk"))
                  (unless (equal (map-elt state :last-entry-type)
                                 "agent_thought_chunk")
-                   (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count))))
+                   (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
+                   (agent-shell--append-transcript
+                    :text (format "## Agent's Thoughts (%s)\n\n" (format-time-string "%F %T"))
+                    :file-path agent-shell--transcript-file))
+                 (agent-shell--append-transcript
+                  :text .content.text
+                  :file-path agent-shell--transcript-file)
                  (agent-shell--update-fragment
                   :state state
                   :block-id (format "%s-agent_thought_chunk"
@@ -1175,7 +1181,7 @@ COMMAND, when present, may be a shell command string or an argv vector."
                (unless (equal (map-elt state :last-entry-type) "agent_message_chunk")
                  (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
                  (agent-shell--append-transcript
-                  :text (format "## Agent (%s)\n\n" (format-time-string "%F %T"))
+                  :text (format "\n## Agent (%s)\n\n" (format-time-string "%F %T"))
                   :file-path agent-shell--transcript-file))
                (let-alist update
                  (agent-shell--append-transcript


### PR DESCRIPTION
This is in relation to #321 

I'm not entirely sure why, but sometimes the Thought chunk ends without a newline at the end, so the next `# Agent` heading would be misaligned. I added an additional newline before that heading.

I'm also not sure how to add tests for this - there aren't tests for `agent-shell--on-notification` yet. 

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
