### PR TITLE
fix plan not showing from session/request_permission

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1413,6 +1413,13 @@ COMMAND, when present, may be a shell command string or an argv vector."
                     (when-let ((diff (agent-shell--make-diff-info
                                       :tool-call .params.toolCall)))
                       (list (cons :diff diff)))))
+           (when-let ((plan .params.toolCall.rawInput.plan))
+             (agent-shell--update-fragment
+              :state state
+              :block-id (concat .params.toolCall.toolCallId "-plan")
+              :label-left (propertize "Proposed plan" 'font-lock-face 'font-lock-doc-markup-face)
+              :body plan
+              :expanded t))
            (agent-shell--update-fragment
             :state state
             ;; block-id must be the same as the one used


### PR DESCRIPTION
Fixes #310 

Claude code now sends plan in `session/request_permission` instead of `session/update`.

## Changes

Display the plan in `session/request_permission` before showing the tool call.

Example `session/request_permission` with plan: 
[example.txt](https://github.com/user-attachments/files/25546748/example.txt)


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
