### PR TITLE
Drop stale session/update notifications that arrive after turn completion

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -586,6 +586,7 @@ OUTGOING-REQUEST-DECORATOR (passed through to `acp-make-client')."
                              (cons :mode-id nil)
                              (cons :modes nil)))
         (cons :last-entry-type nil)
+        (cons :turn-completed nil)
         (cons :chunked-group-count 0)
         (cons :request-count 0)
         (cons :tool-calls nil)
@@ -1178,52 +1179,56 @@ COMMAND, when present, may be a shell command string or an argv vector."
                     :expanded t)))
                (map-put! state :last-entry-type "tool_call"))
               ((equal (map-elt update 'sessionUpdate) "agent_thought_chunk")
-               (let-alist update
-                 ;; (message "agent_thought_chunk: last-type=%s, will-append=%s"
-                 ;;          (map-elt state :last-entry-type)
-                 ;;          (equal (map-elt state :last-entry-type) "agent_thought_chunk"))
-                 (unless (equal (map-elt state :last-entry-type)
-                                "agent_thought_chunk")
+               ;; Drop stale notifications that arrive after the turn completed.
+               (unless (map-elt state :turn-completed)
+                 (let-alist update
+                   ;; (message "agent_thought_chunk: last-type=%s, will-append=%s"
+                   ;;          (map-elt state :last-entry-type)
+                   ;;          (equal (map-elt state :last-entry-type) "agent_thought_chunk"))
+                   (unless (equal (map-elt state :last-entry-type)
+                                  "agent_thought_chunk")
+                     (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
+                     (agent-shell--append-transcript
+                      :text (format "## Agent's Thoughts (%s)\n\n" (format-time-string "%F %T"))
+                      :file-path agent-shell--transcript-file))
+                   (agent-shell--append-transcript
+                    :text .content.text
+                    :file-path agent-shell--transcript-file)
+                   (agent-shell--update-fragment
+                    :state state
+                    :block-id (format "%s-agent_thought_chunk"
+                                      (map-elt state :chunked-group-count))
+                    :label-left  (concat
+                                  agent-shell-thought-process-icon
+                                  " "
+                                  (propertize "Thought process" 'font-lock-face font-lock-doc-markup-face))
+                    :body .content.text
+                    :append (equal (map-elt state :last-entry-type)
+                                   "agent_thought_chunk")
+                    :expanded agent-shell-thought-process-expand-by-default))
+                 (map-put! state :last-entry-type "agent_thought_chunk")))
+              ((equal (map-elt update 'sessionUpdate) "agent_message_chunk")
+               ;; Drop stale notifications that arrive after the turn completed.
+               (unless (map-elt state :turn-completed)
+                 (unless (equal (map-elt state :last-entry-type) "agent_message_chunk")
                    (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
                    (agent-shell--append-transcript
-                    :text (format "## Agent's Thoughts (%s)\n\n" (format-time-string "%F %T"))
+                    :text (format "\n## Agent (%s)\n\n" (format-time-string "%F %T"))
                     :file-path agent-shell--transcript-file))
-                 (agent-shell--append-transcript
-                  :text .content.text
-                  :file-path agent-shell--transcript-file)
-                 (agent-shell--update-fragment
-                  :state state
-                  :block-id (format "%s-agent_thought_chunk"
-                                    (map-elt state :chunked-group-count))
-                  :label-left  (concat
-                                agent-shell-thought-process-icon
-                                " "
-                                (propertize "Thought process" 'font-lock-face font-lock-doc-markup-face))
-                  :body .content.text
-                  :append (equal (map-elt state :last-entry-type)
-                                 "agent_thought_chunk")
-                  :expanded agent-shell-thought-process-expand-by-default))
-               (map-put! state :last-entry-type "agent_thought_chunk"))
-              ((equal (map-elt update 'sessionUpdate) "agent_message_chunk")
-               (unless (equal (map-elt state :last-entry-type) "agent_message_chunk")
-                 (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
-                 (agent-shell--append-transcript
-                  :text (format "\n## Agent (%s)\n\n" (format-time-string "%F %T"))
-                  :file-path agent-shell--transcript-file))
-               (let-alist update
-                 (agent-shell--append-transcript
-                  :text .content.text
-                  :file-path agent-shell--transcript-file)
-                 (agent-shell--update-fragment
-                  :state state
-                  :block-id (format "%s-agent_message_chunk"
-                                    (map-elt state :chunked-group-count))
-                  :body .content.text
-                  :create-new (not (equal (map-elt state :last-entry-type)
-                                          "agent_message_chunk"))
-                  :append t
-                  :navigation 'never))
-               (map-put! state :last-entry-type "agent_message_chunk"))
+                 (let-alist update
+                   (agent-shell--append-transcript
+                    :text .content.text
+                    :file-path agent-shell--transcript-file)
+                   (agent-shell--update-fragment
+                    :state state
+                    :block-id (format "%s-agent_message_chunk"
+                                      (map-elt state :chunked-group-count))
+                    :body .content.text
+                    :create-new (not (equal (map-elt state :last-entry-type)
+                                            "agent_message_chunk"))
+                    :append t
+                    :navigation 'never))
+                 (map-put! state :last-entry-type "agent_message_chunk")))
               ((equal (map-elt update 'sessionUpdate) "user_message_chunk")
                (let ((new-prompt-p (not (equal (map-elt state :last-entry-type)
                                                "user_message_chunk"))))
@@ -3936,6 +3941,7 @@ If FILE-PATH is not an image, returns nil."
        :heartbeat (map-elt agent-shell--state :heartbeat)))
 
     (map-put! agent-shell--state :last-entry-type nil)
+    (map-put! agent-shell--state :turn-completed nil)
 
     (agent-shell--append-transcript
      :text (format "## User (%s)\n\n%s\n\n"
@@ -3958,6 +3964,10 @@ If FILE-PATH is not an image, returns nil."
                :prompt content-blocks)
      :buffer (current-buffer)
      :on-success (lambda (response)
+                   ;; Mark the turn as completed so late-arriving
+                   ;; notifications (e.g. from async PostToolUse hooks)
+                   ;; are dropped rather than displayed as a new message.
+                   (map-put! (agent-shell--state) :turn-completed t)
                    (when (equal (map-elt (agent-shell--state) :last-entry-type) "agent_message_chunk")
                      (agent-shell--append-transcript
                       :text "\n\n"

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -490,7 +490,8 @@
                              (cons :session (list (cons :id "test-session")))
                              (cons :prompt-capabilities '((:embedded-context . t)))
                              (cons :buffer (current-buffer))
-                             (cons :last-entry-type nil))))
+                             (cons :last-entry-type nil)
+                             (cons :turn-completed nil))))
 
     ;; Mock acp-send-request to capture what gets sent;
     ;; stub viewport--buffer to avoid interactive shell-buffer prompt in batch.
@@ -523,7 +524,8 @@
                              (cons :session (list (cons :id "test-session")))
                              (cons :prompt-capabilities '((:embedded-context . t)))
                              (cons :buffer (current-buffer))
-                             (cons :last-entry-type nil))))
+                             (cons :last-entry-type nil)
+                             (cons :turn-completed nil))))
 
     ;; Mock build-content-blocks to throw an error;
     ;; stub viewport--buffer to avoid interactive shell-buffer prompt in batch.
@@ -1398,6 +1400,86 @@ code block content
     (should (string-match-p "\\*\\*Parameters:\\*\\*" entry))
     (should (string-match-p "filePath: /home/user/test.txt" entry))
     (should (string-match-p "offset: 100" entry))))
+
+(ert-deftest agent-shell--stale-notification-after-turn-completion ()
+  "Test that late agent_message_chunk from a completed turn is dropped.
+
+Scenario:
+  1. Turn 1: agent responds with agent_message_chunk → state tracks it.
+  2. Turn 1 completes: on-success sets :turn-completed to t.
+  3. New prompt resets :last-entry-type to nil and :turn-completed to nil.
+     But before that reset, a stale agent_message_chunk arrives.
+  4. The stale chunk is dropped because :turn-completed is t."
+  (with-temp-buffer
+    (let* ((fragment-calls '())
+           (agent-shell--transcript-file nil)
+           (state `((:buffer . ,(current-buffer))
+                    (:client . test-client)
+                    (:session . ((:id . "test-session")))
+                    (:last-entry-type . nil)
+                    (:turn-completed . nil)
+                    (:chunked-group-count . 0)
+                    (:request-count . 1)
+                    (:tool-calls . nil)
+                    (:event-subscriptions . nil))))
+      (setq-local agent-shell--state state)
+      (cl-letf (((symbol-function 'agent-shell--state)
+                 (lambda () agent-shell--state))
+                ((symbol-function 'agent-shell--update-fragment)
+                 (lambda (&rest args)
+                   (push args fragment-calls)))
+                ((symbol-function 'agent-shell--update-text)
+                 (lambda (&rest _args) nil))
+                ((symbol-function 'agent-shell--emit-event)
+                 (lambda (&rest _args) nil))
+                ((symbol-function 'agent-shell--append-transcript)
+                 (lambda (&rest _args) nil)))
+
+        ;; --- Turn 1: normal agent_message_chunk arrives ---
+        (agent-shell--on-notification
+         :state state
+         :notification '((method . "session/update")
+                         (params . ((update . ((sessionUpdate . "agent_message_chunk")
+                                               (content . ((text . "Turn 1 response")))))))))
+
+        (should (equal (map-elt state :last-entry-type) "agent_message_chunk"))
+        (should (equal (map-elt state :chunked-group-count) 1))
+        (let ((first-call (car fragment-calls)))
+          (should (equal (plist-get first-call :body) "Turn 1 response"))
+          (should (equal (plist-get first-call :create-new) t)))
+
+        ;; --- Turn 1 completes (on-success fires) ---
+        (map-put! state :turn-completed t)
+        (setq fragment-calls nil)
+
+        ;; --- Stale agent_message_chunk from turn 1 arrives late ---
+        (agent-shell--on-notification
+         :state state
+         :notification '((method . "session/update")
+                         (params . ((update . ((sessionUpdate . "agent_message_chunk")
+                                               (content . ((text . "Stale turn 1 text")))))))))
+
+        ;; Stale notification is dropped: no new fragment, count unchanged.
+        (should (equal (map-elt state :chunked-group-count) 1))
+        (should (null fragment-calls))
+
+        ;; --- New prompt resets state for turn 2 ---
+        (map-put! state :last-entry-type nil)
+        (map-put! state :turn-completed nil)
+
+        ;; --- Turn 2: fresh agent_message_chunk arrives ---
+        (agent-shell--on-notification
+         :state state
+         :notification '((method . "session/update")
+                         (params . ((update . ((sessionUpdate . "agent_message_chunk")
+                                               (content . ((text . "Turn 2 response")))))))))
+
+        ;; Turn 2 chunk is processed normally.
+        (should (equal (map-elt state :chunked-group-count) 2))
+        (should (equal (map-elt state :last-entry-type) "agent_message_chunk"))
+        (let ((turn2-call (car fragment-calls)))
+          (should (equal (plist-get turn2-call :body) "Turn 2 response"))
+          (should (equal (plist-get turn2-call :create-new) t)))))))
 
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
Fixes https://github.com/xenodium/agent-shell/issues/345

See the linked issue for the full problem description and server-side analysis.

## What changed

- New `:turn-completed` state field in `agent-shell--make-state`, initialized to `nil`.
- `on-success` callback in `agent-shell--send-command` sets `:turn-completed` to `t` when the turn's RPC response arrives.
- `agent-shell--send-command` resets `:turn-completed` to `nil` alongside `:last-entry-type` when sending a new prompt.
- `agent_message_chunk` and `agent_thought_chunk` handlers in `agent-shell--on-notification` are wrapped with `(unless (map-elt state :turn-completed) ...)` to drop notifications that arrive after the turn has completed.

Even if the server fixes its ordering, the client should be resilient to out-of-order notifications rather than blindly trusting that all notifications arrive before the response.

## Test plan

- New test `agent-shell--stale-notification-after-turn-completion` verifies that a stale `agent_message_chunk` arriving after `:turn-completed` is set is silently dropped (no fragment created, `:chunked-group-count` unchanged), and that a subsequent turn's chunks are processed normally.
- Existing `agent-shell--send-command-integration-test` and `agent-shell--send-command-error-fallback-test` updated to include `:turn-completed` in their test state to avoid `map-not-inplace` errors.
- Full test suite: 36/36 pass.

## Checklist

- [x] I've reviewed all code in PR myself and will vouch for its quality.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've added tests where applicable.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
