### PR TITLE
Fix xclip handler blocking on X11 when clipboard has no image

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -320,6 +320,11 @@ Assume screenshot file path will be appended to this list."
                            (error "Command pngpaste failed with exit code %d" exit-code))))))
    (list (cons :command "xclip")
          (cons :save (lambda (file-path)
+                       (when (eq (window-system) 'x)
+                         (let ((targets (gui-get-selection 'CLIPBOARD 'TARGETS)))
+                           (unless (and (vectorp targets)
+                                        (seq-find (lambda (target) (eq target 'image/png)) targets))
+                             (error "No image/png in clipboard"))))
                        (with-temp-buffer
                          (set-buffer-multibyte nil)
                          (let ((exit-code (call-process "xclip" nil t nil


### PR DESCRIPTION
On X11, calling xclip from a subprocess while Emacs owns the clipboard
deadlocks: Emacs can't service the X11 selection conversion request
while blocked in call-process.

Fix this by checking clipboard targets in-process via gui-get-selection
before invoking xclip, and erroring early if image/png is not available.
The check is gated on (window-system) 'x so Wayland/pgtk users keep the
original behavior.

Closes: #352

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>