### PR TITLE
Add configurable session selection columns and optional session ID

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -279,11 +279,14 @@ Can be one of:
                  (const :tag "No header" nil))
   :group 'agent-shell)
 
-(defvar agent-shell-show-session-id nil
-  "Non-nil to display the session ID in the header.
+(defcustom agent-shell-show-session-id nil
+  "Non-nil to display the session ID in the header and session selection.
 
-When enabled, the session ID is shown after the directory path.
-Only appears when a session is active.")
+When enabled, the session ID is shown after the directory path in the
+header and as an additional column in the session selection prompt.
+Only appears when a session is active."
+  :type 'boolean
+  :group 'agent-shell)
 
 (defcustom agent-shell-show-welcome-message t
   "Non-nil to show welcome message."
@@ -486,16 +489,6 @@ Available values:
                  (const :tag "Load latest session" latest)
                  (const :tag "Prompt for session" prompt))
   :group 'agent-shell)
-
-(defvar agent-shell-session-selection-columns '(directory title date)
-  "Columns to display in the session selection prompt, in order.
-
-Each element is a symbol identifying a column:
-
-  `directory': The project directory name (last path component of cwd).
-  `title': The session title (truncated to 50 characters).
-  `date': The last-updated date in human-friendly format.
-  `session-id': The ACP session identifier.")
 
 (defun agent-shell--resolve-preferred-config ()
   "Resolve `agent-shell-preferred-agent-config' to a full configuration.
@@ -2705,7 +2698,7 @@ A buffer-local hash table mapping cache keys to header strings.")
   (when-let* ((agent-shell-show-session-id)
               (session-id (map-nested-elt (agent-shell--state) '(:session :id)))
               ((not (string-empty-p session-id))))
-    (propertize (format "[%s]" session-id) 'font-lock-face 'font-lock-constant-face)))
+    (propertize session-id 'font-lock-face 'font-lock-constant-face)))
 
 (cl-defun agent-shell--make-header-model (state &key qualifier bindings)
   "Create a header model alist from STATE, QUALIFIER, and BINDINGS.
@@ -2774,7 +2767,7 @@ BINDINGS is a list of alists defining key bindings to display, each with:
                               (propertize (string-remove-suffix "/" (abbreviate-file-name (map-elt header-model :directory)))
                                           'font-lock-face 'font-lock-string-face)
                               (if (map-elt header-model :session-id)
-                                  (concat " " (map-elt header-model :session-id))
+                                  (concat " ➤ " (map-elt header-model :session-id))
                                 "")
                               (if (map-elt header-model :context-indicator)
                                   (concat " " (map-elt header-model :context-indicator))
@@ -2899,15 +2892,18 @@ BINDINGS is a list of alists defining key bindings to display, each with:
                                                                   (string-remove-suffix "/" (abbreviate-file-name (map-elt header-model :directory)))))
                                       ;; Session ID (optional)
                                       (when (map-elt header-model :session-id)
-                                        (let* ((face (get-text-property 0 'font-lock-face (map-elt header-model :session-id)))
-                                               (color (if face
-                                                          (face-attribute face :foreground nil t)
-                                                        (face-attribute 'default :foreground))))
-                                          (dom-append-child text-node
-                                                            (dom-node 'tspan
-                                                                      `((fill . ,color)
-                                                                        (dx . "8"))
-                                                                      (substring-no-properties (map-elt header-model :session-id))))))
+                                        ;; Separator arrow (default foreground)
+                                        (dom-append-child text-node
+                                                          (dom-node 'tspan
+                                                                    `((fill . ,(face-attribute 'default :foreground))
+                                                                      (dx . "8"))
+                                                                    "➤"))
+                                        ;; Session ID text
+                                        (dom-append-child text-node
+                                                          (dom-node 'tspan
+                                                                    `((fill . ,(face-attribute 'font-lock-constant-face :foreground))
+                                                                      (dx . "8"))
+                                                                    (substring-no-properties (map-elt header-model :session-id)))))
                                       text-node))
                    ;; Bindings row (last row if bindings or qualifier present)
                    (when (or bindings qualifier)
@@ -3544,13 +3540,21 @@ COLUMN is a symbol: `directory', `title', `date', or `session-id'.
     ('session-id 'font-lock-constant-face)
     (_ nil)))
 
+(defun agent-shell--session-selection-columns ()
+  "Return the list of columns for session selection.
+Always includes directory, title, and date.  Appends session-id
+when `agent-shell-show-session-id' is non-nil."
+  (if agent-shell-show-session-id
+      '(directory title date session-id)
+    '(directory title date)))
+
 (cl-defun agent-shell--session-choice-label (&key acp-session max-widths)
   "Return completion label for ACP-SESSION.
-MAX-WIDTHS is an alist mapping column symbols to their max widths.
-Columns are determined by `agent-shell-session-selection-columns'."
-  (let (parts
-        (last-col (car (last agent-shell-session-selection-columns))))
-    (dolist (col agent-shell-session-selection-columns)
+MAX-WIDTHS is an alist mapping column symbols to their max widths."
+  (let* ((columns (agent-shell--session-selection-columns))
+         parts
+         (last-col (car (last columns))))
+    (dolist (col columns)
       (let* ((value (agent-shell--session-column-value col acp-session))
              (face (agent-shell--session-column-face col))
              (max-width (or (map-elt max-widths col) (length value)))
@@ -3576,13 +3580,14 @@ Falls back to latest session in batch mode (e.g. tests)."
       (let* ((other-shells (seq-remove (lambda (b) (eq b (current-buffer)))
                                       (agent-shell-buffers)))
              (new-session-choice "Start new shell")
+             (columns (agent-shell--session-selection-columns))
              (max-widths (when acp-sessions
                           (mapcar (lambda (col)
                                     (cons col (apply #'max
                                                      (mapcar (lambda (s)
                                                                (length (agent-shell--session-column-value col s)))
                                                              acp-sessions))))
-                                  agent-shell-session-selection-columns)))
+                                  columns)))
              (session-choices (append (list (cons new-session-choice nil))
                               (when other-shells
                                 (list (cons "Open existing shell" :other-shell)))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1405,7 +1405,7 @@ code block content
 
 (ert-deftest agent-shell--session-choice-label-default-columns-test ()
   "Test `agent-shell--session-choice-label' with default columns."
-  (let ((agent-shell-session-selection-columns '(directory title date))
+  (let ((agent-shell-show-session-id nil)
         (session '((sessionId . "s1")
                    (title . "My session")
                    (cwd . "/home/user/project")
@@ -1424,12 +1424,12 @@ code block content
 
 (ert-deftest agent-shell--session-choice-label-with-session-id-test ()
   "Test `agent-shell--session-choice-label' includes session-id column."
-  (let ((agent-shell-session-selection-columns '(directory title session-id date))
+  (let ((agent-shell-show-session-id t)
         (session '((sessionId . "abc-123")
                    (title . "My session")
                    (cwd . "/home/user/project")
                    (updatedAt . "2026-01-19T14:00:00Z")))
-        (max-widths '((directory . 10) (title . 15) (session-id . 10) (date . 20))))
+        (max-widths '((directory . 10) (title . 15) (date . 20) (session-id . 10))))
     (let ((label (substring-no-properties
                   (agent-shell--session-choice-label
                    :acp-session session
@@ -1437,18 +1437,6 @@ code block content
       (should (string-match-p "abc-123" label))
       (should (string-match-p "project" label))
       (should (string-match-p "My session" label)))))
-
-(ert-deftest agent-shell--session-choice-label-single-column-test ()
-  "Test `agent-shell--session-choice-label' with a single column."
-  (let ((agent-shell-session-selection-columns '(session-id))
-        (session '((sessionId . "abc-123")))
-        (max-widths '((session-id . 10))))
-    (let ((label (substring-no-properties
-                  (agent-shell--session-choice-label
-                   :acp-session session
-                   :max-widths max-widths))))
-      ;; Single column = last column = no padding
-      (should (equal label "abc-123")))))
 
 (ert-deftest agent-shell--session-id-indicator-disabled-test ()
   "Test `agent-shell--session-id-indicator' returns nil when disabled."
@@ -1471,7 +1459,7 @@ code block content
         (let ((indicator (agent-shell--session-id-indicator)))
           (should indicator)
           (should (equal (substring-no-properties indicator)
-                         "[test-session-id]")))))))
+                         "test-session-id")))))))
 
 (ert-deftest agent-shell--session-id-indicator-no-session-test ()
   "Test `agent-shell--session-id-indicator' returns nil without active session."
@@ -1529,7 +1517,7 @@ code block content
         (let ((model (agent-shell--make-header-model agent-shell--state)))
           (should (assq :session-id model))
           (should (equal (substring-no-properties (map-elt model :session-id))
-                         "[test-session-id]"))))
+                         "test-session-id"))))
       ;; Disabled
       (let ((agent-shell-show-session-id nil))
         (let ((model (agent-shell--make-header-model agent-shell--state)))


### PR DESCRIPTION
## Motivation

When switching between an agent inside Emacs and the same agent's standalone CLI (or vice versa), knowing the session ID makes it possible to resume the exact same session in either context. Additionally, when multiple sessions accumulate during a day, the transcript snippet alone is often not enough to distinguish them — seeing the session ID before killing a buffer or restarting Emacs helps ensure the correct session is resumed later.

Currently the session ID is available in the ACP data but not exposed to the user anywhere in the UI.

## Changes

- **Configurable session columns:** Refactor `agent-shell--session-choice-label`
  from hard-coded `max-dir-width`/`max-title-width` keyword args to a single
  `:max-widths` alist, driven by `agent-shell-session-selection-columns`. New
  helper functions `agent-shell--session-column-value` and
  `agent-shell--session-column-face` handle per-column value extraction and
  styling via `pcase` dispatch.

- **Session ID in header:** Add `agent-shell--session-id-indicator` and wire it
  into `agent-shell--make-header-model`. Both text and graphical (SVG) header
  styles render the session ID when `agent-shell-show-session-id` is non-nil.
  The SVG path uses `tspan` elements within a parent `text` node, matching the
  existing pattern used for the bindings row.

- **Copy session ID:** Add `agent-shell-copy-session-id` interactive command
  to copy the current session ID to the kill ring. Useful for passing the ID
  to standalone agents or scripts.

- **Max-widths hoisted:** The per-column max-width computation in
  `agent-shell--prompt-select-session` is now computed once and passed as an
  alist, rather than recalculated per session inside the `mapcar`.

## Backward compatibility

- Default value of `agent-shell-session-selection-columns` is
  `'(directory title date)`, preserving existing behavior.
- `agent-shell-show-session-id` defaults to nil — no visible change unless
  the user opts in.
- Both variables are `defvar` (not `defcustom`) per the contributing guidelines
  on avoiding premature customization.

## Usage

```elisp
;; Show session ID in header
(setq agent-shell-show-session-id t)

;; Add session-id column to session selection prompt
(setq agent-shell-session-selection-columns
      '(directory title date session-id))

;; Copy session ID to kill ring
M-x agent-shell-copy-session-id
```

## Test plan
- [x] All 51 tests pass (`M-x agent-shell-run-all-tests`)
- [x] 13 new tests covering column value extraction, face mapping, label
  formatting with various column configs, session ID indicator states,
  copy-session-id command, and header model/text integration
- [x] `M-x checkdoc` clean (on changed files)
- [x] `M-x byte-compile-file` clean
- [x] Manual: verify session selection prompt renders correctly
- [x] Manual: verify `(setq agent-shell-show-session-id t)` shows ID in header
- [x] Manual: verify custom column order with session-id column
- [x] Manual: verify `M-x agent-shell-copy-session-id` copies to kill ring

## Checklist
- [x] I agree to communicate (PR description and comments) with the author myself (not AI-generated).
- [x] I've reviewed all code in PR myself and will vouch for its quality.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature. N/A since this just tests documented behavior.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run M-x checkdoc and M-x byte-compile-file.