### PR TITLE
Make permission-ui stays visible even if status_update comes

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1369,11 +1369,11 @@ COMMAND, when present, may be a shell command string or an argv vector."
                          :output body-text)
                   :file-path agent-shell--transcript-file))
                ;; Hide permission after sending response.
-               ;; Status and permission are no longer pending. User
+               ;; Status is completed or failed so the user
                ;; likely selected one of: accepted/rejected/always.
                ;; Remove stale permission dialog.
-               (when (and (map-nested-elt acp-notification '(params update status))
-                          (not (equal (map-nested-elt acp-notification '(params update status)) "pending")))
+               (when (member (map-nested-elt acp-notification '(params update status))
+                             '("completed" "failed"))
                  ;; block-id must be the same as the one used as
                  ;; agent-shell--update-fragment param by "session/request_permission".
                  (agent-shell--delete-fragment :state state :block-id (format "permission-%s" (map-nested-elt acp-notification '(params update toolCallId)))))


### PR DESCRIPTION
This MR is my attempt of fixing the problem described in this issue : https://github.com/xenodium/agent-shell/issues/369

This introduces a `permission-state` that tracks if the user actually answered or not a permission ask of the agent. This solves the issue where the agent would update the tool call to `in_progress` even if the permission wasn't granted yet (and the agent is still waiting for it).

I'm currently running this and it fixes my issue with OpenCode/Codex.

I'm not that good in elisp so please don't hesitate to re-write it better or provide another solution. :)

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [X] I've filed a feature request/discussion for a new feature.
- [X] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
