### PR TITLE
Add minimum transient version (0.9.0) to Package-Requires

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -5,7 +5,7 @@
 ;; Author: Alvaro Ramirez https://xenodium.com
 ;; URL: https://github.com/xenodium/agent-shell
 ;; Version: 0.44.1
-;; Package-Requires: ((emacs "29.1") (shell-maker "0.86.1") (acp "0.11.1"))
+;; Package-Requires: ((emacs "29.1") (shell-maker "0.86.1") (acp "0.11.1") (transient "0.9.0"))
 
 (defconst agent-shell--version "0.44.1")
 


### PR DESCRIPTION
## Problem

Users loading `agent-shell` may encounter this error at startup:

```
Error (use-package): agent-shell/:catch: Symbol's function definition is void: transient--set-layout
```

## Root Cause

`transient--set-layout` was introduced in **transient 0.9.0** (released 2025-06-01) as an internal function used by the `transient-define-prefix` macro. When the package is compiled against transient 0.9.0+, calls to `transient--set-layout` are baked into the `.elc` bytecode via macro expansion.

If Emacs loads the built-in `transient` (shipped with Emacs 29.x, which is pre-0.9.0) instead of the MELPA version, the function is missing at runtime.

## Fix

Add `(transient "0.9.0")` to `Package-Requires` so that package managers (ELPA/MELPA) automatically enforce the minimum version and install the correct transient from MELPA when needed.