### PR TITLE
feature: Allow file completion outside a project

### DIFF
--- a/agent-shell-project.el
+++ b/agent-shell-project.el
@@ -36,8 +36,31 @@
 (declare-function projectile-project-name "projectile")
 (declare-function projectile-current-project-files "projectile")
 
+(defvar agent-shell-list-files-depth 1
+  "Maximum directory depth for file completion outside a project.
+Set to 0 to disable the fallback entirely.")
+
+(defun agent-shell--should-descend (max-depth root dir)
+  "Return non-nil if DIR should be descended into within MAX-DEPTH levels of ROOT."
+  (let* ((rel (string-remove-prefix root dir))
+         (current-depth (length (seq-filter
+                                 (lambda (s) (not (string-empty-p s)))
+                                 (file-name-split rel)))))
+    (< current-depth max-depth)))
+
+(defun agent-shell--directory-files (dir max-depth)
+  "List files under DIR, up to MAX-DEPTH levels."
+  (let ((root (file-name-as-directory (expand-file-name dir))))
+    (directory-files-recursively
+     root
+     directory-files-no-dot-files-regexp
+     nil
+     (apply-partially #'agent-shell--should-descend max-depth root)
+     nil)))
+
 (defun agent-shell--project-files ()
-  "Get project files using projectile or project.el."
+  "Get project files using `projectile', `project.el'.
+Fall back to `agent-shell-cwd' if not in a detected project."
   (cond
    ((and (boundp 'projectile-mode)
          projectile-mode
@@ -52,7 +75,8 @@
       (mapcar (lambda (f)
                 (string-remove-prefix root f))
               (project-files proj))))
-   (t nil)))
+   ((> agent-shell-list-files-depth 0)
+    (agent-shell--directory-files (agent-shell-cwd) agent-shell-list-files-depth))))
 
 (defcustom agent-shell-cwd-function nil
   "When non-nil, a function called to determine the shell's CWD.


### PR DESCRIPTION
If not in a `projectile` or `project.el` project, use the `agent-shell-cwd` as the project root -- by default, though, list files only one level deep to minimize overwhelming responses.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
