### PR TITLE
Indent markdown headers in transcript to preserve hierarchy

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1220,7 +1220,8 @@ COMMAND, when present, may be a shell command string or an argv vector."
                 :text (format "## Agent's Thoughts (%s)\n\n" (format-time-string "%F %T"))
                 :file-path agent-shell--transcript-file))
              (agent-shell--append-transcript
-              :text (map-nested-elt acp-notification '(params update content text))
+              :text (agent-shell--indent-markdown-headers
+                     (map-nested-elt acp-notification '(params update content text)))
               :file-path agent-shell--transcript-file)
              (agent-shell--update-fragment
               :state state
@@ -1246,8 +1247,13 @@ COMMAND, when present, may be a shell command string or an argv vector."
                (agent-shell--append-transcript
                 :text (format "\n## Agent (%s)\n\n" (format-time-string "%F %T"))
                 :file-path agent-shell--transcript-file))
+             ;; Indent markdown headers in LLM output so they nest
+             ;; below the transcript's ## section headers.  Applied
+             ;; per-chunk: if a header is split across chunks it may
+             ;; not be indented (graceful degradation).
              (agent-shell--append-transcript
-              :text (map-nested-elt acp-notification '(params update content text))
+              :text (agent-shell--indent-markdown-headers
+                     (map-nested-elt acp-notification '(params update content text)))
               :file-path agent-shell--transcript-file)
              (agent-shell--update-fragment
               :state state
@@ -1269,7 +1275,9 @@ COMMAND, when present, may be a shell command string or an argv vector."
                 :text (format "## User (%s)\n\n" (format-time-string "%F %T"))
                 :file-path agent-shell--transcript-file))
              (agent-shell--append-transcript
-              :text (format "> %s\n" (map-nested-elt acp-notification '(params update content text)))
+              :text (format "> %s\n"
+                            (agent-shell--indent-markdown-headers
+                             (map-nested-elt acp-notification '(params update content text))))
               :file-path agent-shell--transcript-file)
              (agent-shell--update-text
               :state state
@@ -4091,7 +4099,7 @@ If FILE-PATH is not an image, returns nil."
     (agent-shell--append-transcript
      :text (format "## User (%s)\n\n%s\n\n"
                    (format-time-string "%F %T")
-                   prompt)
+                   (agent-shell--indent-markdown-headers prompt))
      :file-path agent-shell--transcript-file)
 
     (when-let ((viewport-buffer (agent-shell-viewport--buffer
@@ -5768,6 +5776,45 @@ Returns the file path, or nil if disabled."
         (error
          (message "Failed to initialize transcript: %S" err))))
     filepath))
+
+(defun agent-shell--indent-markdown-headers (text)
+  "Indent markdown headers in TEXT by 2 levels for transcript hierarchy.
+
+Increases the level of all markdown headers while leaving content
+inside code blocks unchanged.  Headers are capped at level 6
+since markdown doesn't support deeper levels.
+
+For example:
+
+  (agent-shell--indent-markdown-headers \"# Foo\")
+    => \"### Foo\"
+  (agent-shell--indent-markdown-headers \"##### Deep\")
+    => \"###### Deep\""
+  (unless (stringp text)
+    (setq text (or text "")))
+  (let ((lines (split-string text "\n"))
+        (in-code-block nil)
+        (result nil))
+    (dolist (line lines)
+      (cond
+       ;; Toggle code block state on fence lines (3+ backticks).
+       ((string-match "\\`\\(```+\\)" line)
+        (if in-code-block
+            (when (>= (length (match-string 1 line)) in-code-block)
+              (setq in-code-block nil))
+          (setq in-code-block (length (match-string 1 line))))
+        (push line result))
+       ;; Outside code blocks, indent header lines.
+       ((and (not in-code-block)
+             (string-match "\\`\\(#+\\) " line))
+        (let* ((hashes (match-string 1 line))
+               (new-level (min 6 (+ (length hashes) 2)))
+               (new-hashes (make-string new-level ?#)))
+          (push (replace-regexp-in-string "\\`#+ " (concat new-hashes " ") line)
+                result)))
+       (t (push line result))))
+    (mapconcat #'identity (nreverse result) "\n")))
+
 
 (cl-defun agent-shell--append-transcript (&key text file-path)
   "Append TEXT to the transcript at FILE-PATH."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -726,6 +726,88 @@ code block content
   (should (= (agent-shell--longest-backtick-run "has ```` four and ``` three") 4))
   (should (= (agent-shell--longest-backtick-run "``````") 6)))
 
+(ert-deftest agent-shell--indent-markdown-headers-test ()
+  "Test `agent-shell--indent-markdown-headers'."
+  ;; Text without headers is unchanged.
+  (should (equal (agent-shell--indent-markdown-headers "no headers here")
+                 "no headers here"))
+  ;; Simple H1 becomes H3.
+  (should (equal (agent-shell--indent-markdown-headers "# Foo")
+                 "### Foo"))
+  ;; H2 becomes H4.
+  (should (equal (agent-shell--indent-markdown-headers "## Bar")
+                 "#### Bar"))
+  ;; H4 becomes H6.
+  (should (equal (agent-shell--indent-markdown-headers "#### Deep")
+                 "###### Deep"))
+  ;; H5 is capped at H6.
+  (should (equal (agent-shell--indent-markdown-headers "##### Five")
+                 "###### Five"))
+  ;; H6 stays at H6.
+  (should (equal (agent-shell--indent-markdown-headers "###### Six")
+                 "###### Six"))
+  ;; Mixed content with multiple headers.
+  (should (equal (agent-shell--indent-markdown-headers
+                  "some text\n# Heading 1\nmore text\n## Heading 2\nend")
+                 "some text\n### Heading 1\nmore text\n#### Heading 2\nend"))
+  ;; Headers inside code blocks are left unchanged.
+  (should (equal (agent-shell--indent-markdown-headers
+                  "before\n```\n# code comment\n## also code\n```\nafter")
+                 "before\n```\n# code comment\n## also code\n```\nafter"))
+  ;; Headers outside code blocks are indented, inside are not.
+  (should (equal (agent-shell--indent-markdown-headers
+                  "# Top\n```\n# Inside\n```\n# Bottom")
+                 "### Top\n```\n# Inside\n```\n### Bottom"))
+  ;; Code blocks with 4+ backticks.
+  (should (equal (agent-shell--indent-markdown-headers
+                  "````\n# Inside\n````\n# Outside")
+                 "````\n# Inside\n````\n### Outside"))
+  ;; Nested code blocks (inner fence shorter than outer).
+  (should (equal (agent-shell--indent-markdown-headers
+                  "````\n```\n# Inside\n```\n````\n# Outside")
+                 "````\n```\n# Inside\n```\n````\n### Outside"))
+  ;; Nil input returns empty string.
+  (should (equal (agent-shell--indent-markdown-headers nil) ""))
+  ;; Empty string.
+  (should (equal (agent-shell--indent-markdown-headers "") ""))
+  ;; Hash without space is not a header.
+  (should (equal (agent-shell--indent-markdown-headers "#not-a-header")
+                 "#not-a-header"))
+  ;; Simulated LLM output with mixed headers and code blocks.
+  ;; This is the primary transcript use case: an agent response containing
+  ;; its own markdown structure that must be indented to stay below the
+  ;; transcript's ## section headers.
+  (should (equal (agent-shell--indent-markdown-headers
+                  (concat "Here's my analysis:\n"
+                          "# Summary\n"
+                          "Some text\n"
+                          "## Details\n"
+                          "More text\n"
+                          "```elisp\n"
+                          "# this is a comment in code\n"
+                          "(defun foo () nil)\n"
+                          "```\n"
+                          "### Conclusion\n"
+                          "Final thoughts"))
+                 (concat "Here's my analysis:\n"
+                          "### Summary\n"
+                          "Some text\n"
+                          "#### Details\n"
+                          "More text\n"
+                          "```elisp\n"
+                          "# this is a comment in code\n"
+                          "(defun foo () nil)\n"
+                          "```\n"
+                          "##### Conclusion\n"
+                          "Final thoughts")))
+  ;; Tool call entries (### Tool Call) are NOT passed through this function
+  ;; because they are code-generated, not LLM output.  Verify that if
+  ;; they hypothetically were, they would be indented -- this confirms the
+  ;; function is agnostic and the correct behavior comes from applying it
+  ;; only to LLM text.
+  (should (equal (agent-shell--indent-markdown-headers "### Tool Call [completed]: grep")
+                 "##### Tool Call [completed]: grep")))
+
 (ert-deftest agent-shell-mcp-servers-test ()
   "Test `agent-shell-mcp-servers' function normalization."
   ;; Test with nil


### PR DESCRIPTION
Fixes #356

LLM output can contain its own markdown headers which clash with the transcript's `##` section headers. This adds `agent-shell--indent-markdown-headers` to shift all headers in LLM text by 2 levels (`#` → `###`, `##` → `####`, capped at h6) while leaving code blocks untouched. Applied to agent, thinking, and user text in the transcript.

Because content arrives in streaming chunks, a header that is split across two chunks may not be detected and therefore not indented. This is a graceful degradation — the transcript remains valid, just with an occasional unindented header.