### PR TITLE
Fix file skip check to use filename only, not full path

### DIFF
--- a/tests/.dir-locals.el
+++ b/tests/.dir-locals.el
@@ -8,7 +8,7 @@
                                  (ert-delete-test sym))))
                    (let ((test-dir (expand-file-name "tests/" (project-root (project-current t)))))
                      (dolist (file (directory-files-recursively test-dir "\\.el$"))
-                       (unless (string-match-p "/\\." file)
+                       (unless (string-prefix-p "." (file-name-nondirectory file))
                          (load file)))
                      (if noninteractive
                          (ert-run-tests-batch-and-exit "^agent-shell")


### PR DESCRIPTION
Previously `/\\.` matched any dot in the full path, including dots in parent directory names. Now only the filename itself is checked.

This is in regards to `agent-shell-run-all-tests`'s  file ignoring logic. I needed to add this fix because my agent-shell repo exists under a path with a dot in it, so no tests were being loaded as they all got skipped from this condition.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
