### PR TITLE
Make dot-subdir storage location configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -479,6 +479,35 @@ Optional: to prevent the agent running inside the container to access your local
 (setq agent-shell-text-file-capabilities nil)
 #+end_src
 
+*** Data storage location
+
+By default, agent-shell stores per-project data (transcripts, screenshots, etc.) under a =.agent-shell/= directory in the project root, and automatically adds that directory to =.gitignore=.
+
+You can change where this data is stored by customising =agent-shell-dot-subdir-function=.  Two built-in implementations are provided:
+
+- =agent-shell--dot-subdir-in-repo= (default) — stores data under =.agent-shell/= inside the project root.
+- =agent-shell--dot-subdir-user-emacs-dir= — stores data under =user-emacs-directory= instead, keeping the project tree clean.  The project path is flattened into a directory name by stripping the leading slash and replacing remaining slashes with dashes.
+
+To keep all agent-shell data out of your project trees:
+
+#+begin_src emacs-lisp
+(setopt agent-shell-dot-subdir-function #'agent-shell--dot-subdir-user-emacs-dir)
+#+end_src
+
+This will store data at a path like =~/.emacs.d/agent-shell/home-user-src-myproject/screenshots/=.
+
+The top-level directory name under =user-emacs-directory= defaults to ="agent-shell"= and can be changed:
+
+#+begin_src emacs-lisp
+(setopt agent-shell-user-emacs-dir-subdir "my-agent-shell-data")
+#+end_src
+
+To disable automatic =.gitignore= management (e.g. when using a custom storage function that writes outside the project root, where gitignore updates make no sense):
+
+#+begin_src emacs-lisp
+(setopt agent-shell-dot-subdir-gitignore nil)
+#+end_src
+
 *** Inhibiting minor modes during file writes
 
 Some minor modes (for example, =aggressive-indent-mode=) can interfere with an agent's edits.  Agent Shell can temporarily disable selected per-buffer minor modes while applying edits.

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1985,20 +1985,75 @@ For example, shut down ACP client."
   (agent-shell-heartbeat-stop
    :heartbeat (map-elt (agent-shell--state) :heartbeat)))
 
-(defun agent-shell--dot-subdir (subdir)
-  "Return path to .agent-shell/SUBDIR under project root, creating it if needed.
-When the directory is first created inside a git repo and
-.agent-shell/ is not yet ignored, automatically add it to .gitignore.
+(defcustom agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo
+  "Function used by `agent-shell--dot-subdir' to resolve subdirectory paths.
+Called with one argument, SUBDIR (a string such as \"screenshots\" or
+\"transcripts\"), and must return the absolute path to that subdirectory.
+Directory creation is handled by `agent-shell--dot-subdir', not by this
+function.
+
+Two built-in implementations are provided:
+
+- `agent-shell--dot-subdir-in-repo' (default)
+
+- `agent-shell--dot-subdir-user-emacs-dir'"
+  :type '(choice (const :tag "In repo (.agent-shell/)" agent-shell--dot-subdir-in-repo)
+                 (const :tag "Under user-emacs-directory" agent-shell--dot-subdir-user-emacs-dir)
+                 (function :tag "Custom function"))
+  :group 'agent-shell)
+
+(defcustom agent-shell-user-emacs-dir-subdir "agent-shell"
+  "Directory name used under `user-emacs-directory' by `agent-shell--dot-subdir-user-emacs-dir'.
+Defaults to \"agent-shell\"."
+  :type 'string
+  :group 'agent-shell)
+
+(defcustom agent-shell-dot-subdir-gitignore t
+  "When non-nil, automatically add .agent-shell/ to .gitignore when needed.
+This only takes effect when the resolved subdirectory is located under the
+project root (as returned by `agent-shell-cwd')."
+  :type 'boolean
+  :group 'agent-shell)
+
+(defun agent-shell--dot-subdir-in-repo (subdir)
+  "Return path to .agent-shell/SUBDIR under the project root.
 
 For example:
 
-  (agent-shell--dot-subdir \"screenshots\")
-  => \"/path/to/project/.agent-shell/screenshots/\""
-  (let ((dir (expand-file-name (file-name-concat ".agent-shell" subdir)
-                               (agent-shell-cwd))))
+  (agent-shell--dot-subdir-in-repo \"screenshots\")
+  => \"/path/to/project/.agent-shell/screenshots\""
+  (expand-file-name (file-name-concat ".agent-shell" subdir)
+                    (agent-shell-cwd)))
+
+(defun agent-shell--dot-subdir-user-emacs-dir (subdir)
+  "Return path to SUBDIR under `user-emacs-directory'/agent-shell/<cwd>/.
+The current working directory path is sanitized by stripping the leading slash
+and replacing remaining slashes with dashes, mirroring how tools like Claude
+Code name per-project memory directories.
+
+For example, if the CWD is /home/user/src/myproject:
+
+  (agent-shell--dot-subdir-user-emacs-dir \"screenshots\")
+  => \"~/.emacs.d/agent-shell/home-user-src-myproject/screenshots\""
+  (let* ((cwd (string-remove-suffix "/" (agent-shell-cwd)))
+         (sanitized (replace-regexp-in-string "/" "-" (string-remove-prefix "/" cwd)))
+         (base (expand-file-name (file-name-concat agent-shell-user-emacs-dir-subdir sanitized) user-emacs-directory)))
+    (expand-file-name subdir base)))
+
+(defun agent-shell--dot-subdir (subdir)
+  "Return path to SUBDIR for agent-shell data, creating it if needed.
+Calls `agent-shell-dot-subdir-function' to resolve the path.  If the directory
+does not yet exist, creates it and, when `agent-shell-dot-subdir-gitignore' is
+non-nil and the resolved path is under the project root, also ensures
+.agent-shell/ is listed in .gitignore."
+  (let ((dir (funcall agent-shell-dot-subdir-function subdir))
+        (cwd (agent-shell-cwd)))
     (unless (file-directory-p dir)
       (make-directory dir t)
-      (agent-shell--ensure-gitignore (agent-shell-cwd)))
+      (when (and agent-shell-dot-subdir-gitignore
+                 (string-prefix-p (file-name-as-directory cwd)
+                                  (expand-file-name dir)))
+        (agent-shell--ensure-gitignore cwd)))
     dir))
 
 (defun agent-shell--ensure-gitignore (project-root)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1561,5 +1561,136 @@ code block content
           (should-not (string-match-p "test-session-id"
                                       (substring-no-properties header))))))))
 
+;;; Tests for agent-shell--dot-subdir-in-repo
+
+(ert-deftest agent-shell--dot-subdir-in-repo-returns-path-test ()
+  "Test that `agent-shell--dot-subdir-in-repo' returns the correct path."
+  (cl-letf (((symbol-function 'agent-shell-cwd)
+             (lambda () "/home/user/myproject")))
+    (should (equal (agent-shell--dot-subdir-in-repo "screenshots")
+                   "/home/user/myproject/.agent-shell/screenshots"))))
+
+;;; Tests for agent-shell--dot-subdir-user-emacs-dir
+
+(ert-deftest agent-shell--dot-subdir-user-emacs-dir-sanitizes-path-test ()
+  "Test that slashes in cwd are replaced with dashes in the result path."
+  (cl-letf (((symbol-function 'agent-shell-cwd)
+             (lambda () "/home/user/src/myproject")))
+    (let ((user-emacs-directory "/home/user/.emacs.d/")
+          (agent-shell-user-emacs-dir-subdir "agent-shell"))
+      (should (equal (agent-shell--dot-subdir-user-emacs-dir "screenshots")
+                     "/home/user/.emacs.d/agent-shell/home-user-src-myproject/screenshots")))))
+
+(ert-deftest agent-shell--dot-subdir-user-emacs-dir-custom-subdir-test ()
+  "Test that `agent-shell-user-emacs-dir-subdir' controls the directory name."
+  (cl-letf (((symbol-function 'agent-shell-cwd)
+             (lambda () "/home/user/src/myproject")))
+    (let ((user-emacs-directory "/home/user/.emacs.d/")
+          (agent-shell-user-emacs-dir-subdir "my-agent"))
+      (should (equal (agent-shell--dot-subdir-user-emacs-dir "screenshots")
+                     "/home/user/.emacs.d/my-agent/home-user-src-myproject/screenshots")))))
+
+;;; Tests for agent-shell--dot-subdir
+
+(ert-deftest agent-shell--dot-subdir-creates-directory-test ()
+  "Test that `agent-shell--dot-subdir' creates the directory."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (expected-dir (expand-file-name ".agent-shell/screenshots" temp-dir)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore) #'ignore))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo)
+                (agent-shell-dot-subdir-gitignore nil))
+            (agent-shell--dot-subdir "screenshots")
+            (should (file-directory-p expected-dir))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-returns-path-test ()
+  "Test that `agent-shell--dot-subdir' returns the resolved path."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (expected-dir (expand-file-name ".agent-shell/screenshots" temp-dir)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore) #'ignore))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo)
+                (agent-shell-dot-subdir-gitignore nil))
+            (should (equal (agent-shell--dot-subdir "screenshots") expected-dir))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-noop-if-directory-exists-test ()
+  "Test that `agent-shell--dot-subdir' does not error if the directory already exists."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (expected-dir (expand-file-name ".agent-shell/screenshots" temp-dir)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore) #'ignore))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo)
+                (agent-shell-dot-subdir-gitignore nil))
+            (make-directory expected-dir t)
+            (should (equal (agent-shell--dot-subdir "screenshots") expected-dir))
+            (should (file-directory-p expected-dir))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-uses-configured-function-test ()
+  "Test that `agent-shell--dot-subdir' delegates to `agent-shell-dot-subdir-function'."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (custom-called-with nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore) #'ignore))
+          (let ((agent-shell-dot-subdir-function
+                 (lambda (subdir)
+                   (setq custom-called-with subdir)
+                   (expand-file-name subdir temp-dir)))
+                (agent-shell-dot-subdir-gitignore nil))
+            (agent-shell--dot-subdir "screenshots")
+            (should (equal custom-called-with "screenshots"))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-gitignore-called-when-path-under-cwd-test ()
+  "Test that `agent-shell--ensure-gitignore' is called when path is under cwd."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (gitignore-calls nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore)
+                   (lambda (root) (push root gitignore-calls))))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo)
+                (agent-shell-dot-subdir-gitignore t))
+            (agent-shell--dot-subdir "screenshots")
+            (should (equal gitignore-calls (list (expand-file-name temp-dir))))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-gitignore-not-called-when-disabled-test ()
+  "Test that `agent-shell--ensure-gitignore' is not called when `agent-shell-dot-subdir-gitignore' is nil."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (gitignore-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore)
+                   (lambda (_root) (setq gitignore-called t))))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo)
+                (agent-shell-dot-subdir-gitignore nil))
+            (agent-shell--dot-subdir "screenshots")
+            (should-not gitignore-called)))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-gitignore-not-called-when-path-outside-cwd-test ()
+  "Test that `agent-shell--ensure-gitignore' is not called when path is outside cwd."
+  (let* ((cwd-dir (make-temp-file "agent-shell-cwd" t))
+         (emacs-dir (make-temp-file "agent-shell-emacs" t))
+         (gitignore-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () cwd-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore)
+                   (lambda (_root) (setq gitignore-called t))))
+          (let ((user-emacs-directory (file-name-as-directory emacs-dir))
+                (agent-shell-dot-subdir-function #'agent-shell--dot-subdir-user-emacs-dir)
+                (agent-shell-dot-subdir-gitignore t))
+            (agent-shell--dot-subdir "screenshots")
+            (should-not gitignore-called)))
+      (delete-directory cwd-dir t)
+      (delete-directory emacs-dir t))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
Hello! Thank you for this awesome project. I wanted to open this PR because I dislike how the current `.agent-shell` directory functionality will pollute the repo and `.gitignore`. I wanted to provide an alternative that would instead store this data in the user emacs directory. Please let me know if anything is needed, thank you.

##
Extract path resolution from `agent-shell--dot-subdir` into a pluggable `agent-shell-dot-subdir-function` defcustom, with two built-in implementations:

- `agent-shell--dot-subdir-in-repo` (default): existing behaviour, stores data under `.agent-shell/` in the project root.
- `agent-shell--dot-subdir-user-emacs-dir`: stores data under `user-emacs-directory` instead, keeping the project tree clean.  The project path is sanitized into a flat directory name by stripping the leading slash and replacing remaining slashes with dashes.

Two further defcustoms are added: `agent-shell-dot-subdir-gitignore` (boolean, default t) to control whether `.agent-shell/` is added to `.gitignore`, and `agent-shell-user-emacs-dir-subdir` (string, default "agent-shell") to control the top-level directory name used by the user-emacs-dir implementation.

The gitignore update is only performed when the resolved path is under the project root, preserving the original behaviour of triggering only on first directory creation.

Tests are added for all three functions covering path computation, directory creation, delegation to the configured function, and the gitignore guard conditions.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
