### PR TITLE
Add events for permission request and end-of-turn

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1499,6 +1499,12 @@ COMMAND, when present, may be a shell command string or an argv vector."
                                       :existing-only t)))
            (with-current-buffer viewport-buffer
              (agent-shell-jump-to-latest-permission-button-row)))
+         (let ((tool-call-id (map-nested-elt acp-request '(params toolCall toolCallId))))
+           (agent-shell--emit-event
+            :event 'permission-request
+            :data (list (cons :request-id (map-elt acp-request 'id))
+                        (cons :tool-call-id tool-call-id)
+                        (cons :tool-call (map-nested-elt state (list :tool-calls tool-call-id))))))
          (map-put! state :last-entry-type "session/request_permission"))
         ((equal (map-elt acp-request 'method) "fs/read_text_file")
          (agent-shell--on-fs-read-text-file-request
@@ -3169,8 +3175,12 @@ Session events:
     :data contains :tool-call-id and :tool-call
   `file-write'          - File written via fs/write_text_file
     :data contains :path and :content
+  `permission-request'  - Permission prompt displayed to user
+    :data contains :request-id, :tool-call-id, :tool-call
   `permission-response' - Permission response sent
     :data contains :request-id, :tool-call-id, :option-id, :cancelled
+  `turn-complete'       - Agent turn finished and prompt ready for input
+    :data contains :stop-reason and :usage
 
 Returns a subscription token for use with `agent-shell-unsubscribe'.
 
@@ -4147,6 +4157,10 @@ If FILE-PATH is not an image, returns nil."
                        (agent-shell--display-pending-requests))
                      (shell-maker-finish-output :config shell-maker--config
                                                 :success t)
+                     (agent-shell--emit-event
+                      :event 'turn-complete
+                      :data (list (cons :stop-reason (map-elt acp-response 'stopReason))
+                                  (cons :usage (map-elt (agent-shell--state) :usage))))
                      ;; Update viewport header (longer busy)
                      (when-let ((viewport-buffer (agent-shell-viewport--buffer
                                                   :shell-buffer shell-buffer

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -515,6 +515,47 @@
         ;; Should be a single text block with the original prompt
         (should (equal prompt '[((type . "text") (text . "Test prompt with @file.txt"))]))))))
 
+(ert-deftest agent-shell--send-command-emits-turn-complete-event-test ()
+  "Test `agent-shell--send-command' emits turn-complete on success."
+  (let ((received-events nil)
+        (captured-on-success nil)
+        (agent-shell--state (list (cons :buffer (current-buffer))
+                                  (cons :event-subscriptions nil)
+                                  (cons :client 'test-client)
+                                  (cons :session (list (cons :id "test-session")))
+                                  (cons :last-entry-type nil)
+                                  (cons :tool-calls nil)
+                                  (cons :usage (list (cons :total-tokens 0)))))
+        (agent-shell-show-busy-indicator nil)
+        (agent-shell-show-usage-at-turn-end nil))
+    (cl-letf (((symbol-function 'agent-shell--state)
+               (lambda () agent-shell--state))
+              ((symbol-function 'agent-shell--send-request)
+               (lambda (&rest args)
+                 (setq captured-on-success (plist-get args :on-success))))
+              ((symbol-function 'shell-maker-finish-output)
+               (lambda (&rest _)))
+              ((symbol-function 'agent-shell--process-pending-request)
+               (lambda (&rest _))))
+      (agent-shell-subscribe-to
+       :shell-buffer (current-buffer)
+       :event 'turn-complete
+       :on-event (lambda (event)
+                   (push event received-events)))
+      (agent-shell--send-command
+       :prompt "Hello"
+       :shell-buffer (current-buffer))
+      ;; Simulate the ACP response arriving
+      (should captured-on-success)
+      (funcall captured-on-success
+               `((stopReason . "end_turn")
+                 (usage . ((totalTokens . 1500)))))
+      (should (= (length received-events) 1))
+      (let ((data (map-elt (car received-events) :data)))
+        (should (equal (map-elt data :stop-reason) "end_turn"))
+        (should (equal (map-elt (map-elt data :usage) :total-tokens)
+                       1500))))))
+
 (ert-deftest agent-shell--format-diff-as-text-test ()
   "Test `agent-shell--format-diff-as-text' function."
   ;; Test nil input
@@ -1014,6 +1055,37 @@ code block content
       (agent-shell--emit-event :event 'prompt-ready)
       (should (= (length received-events) 1))
       (should (equal (map-elt (nth 0 received-events) :event) 'prompt-ready)))))
+
+(ert-deftest agent-shell--on-request-emits-permission-request-event-test ()
+  "Test `agent-shell--on-request' emits permission-request event."
+  (let ((received-events nil)
+        (agent-shell--state (list (cons :buffer (current-buffer))
+                                  (cons :event-subscriptions nil)
+                                  (cons :tool-calls nil)
+                                  (cons :last-entry-type nil))))
+    (cl-letf (((symbol-function 'agent-shell--state)
+               (lambda () agent-shell--state))
+              ((symbol-function 'agent-shell--update-fragment)
+               (lambda (&rest _))))
+      (agent-shell-subscribe-to
+       :shell-buffer (current-buffer)
+       :event 'permission-request
+       :on-event (lambda (event)
+                   (push event received-events)))
+      (agent-shell--on-request
+       :state agent-shell--state
+       :acp-request `((id . "req-123")
+                      (method . "session/request_permission")
+                      (params . ((toolCall . ((toolCallId . "tc-456")
+                                              (title . "Run command")
+                                              (status . "pending")
+                                              (kind . "bash")))))))
+      (should (= (length received-events) 1))
+      (let ((data (map-elt (car received-events) :data)))
+        (should (equal (map-elt data :request-id) "req-123"))
+        (should (equal (map-elt data :tool-call-id) "tc-456"))
+        (should (equal (map-elt (map-elt data :tool-call) :title)
+                       "Run command"))))))
 
 (ert-deftest agent-shell--initiate-session-prefers-list-and-load-when-supported ()
   "Test `agent-shell--initiate-session' prefers session/list + session/load."


### PR DESCRIPTION
This PR fleshes out the events available to also include `permission-request` and `turn-complete` events. My personal usage for this is to notify me that things need attention - especially useful when the agent is doing things unattended.

Implements #381

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
