### PR TITLE
Avoid leading space in agent-shell-select-config prompt in terminal frames

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -804,19 +804,18 @@ OUTGOING-REQUEST-DECORATOR is an optional function passed through to
 
 (cl-defun agent-shell--config-icon (&key config)
   "Create icon string for CONFIG if available and icons are enabled.
-Returns an empty string if no icon should be displayed."
-  (if-let* ((graphics-capable (display-graphic-p))
-            (icon-filename (if (map-elt config :icon-name)
-                               (agent-shell--fetch-agent-icon
-                                (map-elt config :icon-name))
-                             (agent-shell--make-agent-fallback-icon
-                              (map-elt config :buffer-name) 100))))
-      (with-temp-buffer
-        (insert-image (create-image icon-filename nil nil
-                                    :ascent 'center
-                                    :height (frame-char-height)))
-        (buffer-string))
-    ""))
+Returns nil if no icon should be displayed."
+  (and-let* ((graphics-capable (display-graphic-p))
+             (icon-filename (if (map-elt config :icon-name)
+                                (agent-shell--fetch-agent-icon
+                                 (map-elt config :icon-name))
+                              (agent-shell--make-agent-fallback-icon
+                               (map-elt config :buffer-name) 100))))
+    (with-temp-buffer
+      (insert-image (create-image icon-filename nil nil
+                                  :ascent 'center
+                                  :height (frame-char-height)))
+      (buffer-string))))
 
 (cl-defun agent-shell-select-config (&key prompt)
   "Display PROMPT to select an agent config from `agent-shell-agent-configs'."


### PR DESCRIPTION
Prior to this change, in terminal frames, with `agent-shell-show-config-icons` enabled (by default), each candidate in the prompt would have a leading space, which is somewhat confusing.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

(I did not create a discussion because I think this is a pretty straightforward improvement)