### PR TITLE
Apply dir-local variables in agent-shell buffer

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2307,6 +2307,7 @@ variable (see makunbound)"))
     ;; Better to check on shell creation and bail early (leaving no
     ;; shell behind).
     (with-current-buffer shell-buffer
+      ;; Apply dir-local variables in agent-shell buffer
       (hack-dir-local-variables-non-file-buffer)
       (unless (and (map-elt config :client-maker)
                    (funcall (map-elt config :client-maker) (current-buffer)))


### PR DESCRIPTION
As I ran some tests while I was gearing up for the extraction of the agent-shell-devcontainer package, I noticed that dir-local variables do not get applied to agent-shell buffers.

For example, here's a `.dir-locals.el` that I have in my project to set up running the ACP agent in a devcontainer:

```
((agent-shell-mode . ((agent-shell-path-resolver-function . agent-shell-devcontainer-resolve-path)
                      (agent-shell-command-prefix . ("devcontainer" "exec" "--workspace-folder" ".")))))
```

Without this PR, the agent-shell buffer does not pick up the dir-local variables at all. I believe this is because the buffer gets created as a temp buffer first, then gets the `default-directory` set only afterwards.

With this PR, the agent-shell buffer picks up the dir-local variables properly, allowing for per-project / per-directory customization.