### PR TITLE
Make prompt images deletable (without selection)

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -998,6 +998,10 @@ END from the buffer."
 (defvar-keymap agent-shell-mode-map
   :parent shell-maker-mode-map
   :doc "Keymap for `agent-shell-mode'."
+  "C-d" #'agent-shell-delete-char
+  "DEL" #'agent-shell-backward-delete-char
+  "<backspace>" #'agent-shell-backward-delete-char
+  "<delete>" #'agent-shell-delete-char
   "TAB" #'agent-shell-next-item
   "<backtab>" #'agent-shell-previous-item
   "n" #'agent-shell-next-item
@@ -4468,6 +4472,36 @@ inserted into the shell buffer prompt."
 
 ;;; Completion
 
+(defun agent-shell--delete-image-field (pos)
+  "Delete the inserted image field at POS.
+
+Return non-nil when an image field was deleted."
+  (when (eq (get-text-property pos 'field) 'agent-shell--image-field)
+    (delete-field
+     (if (and (< pos (point-max))
+              (eq (get-text-property (1+ pos) 'field)
+                  'agent-shell--image-field))
+         (1+ pos)
+       pos))
+    t))
+
+(put 'agent-shell-delete-char 'delete-selection 'supersede)
+(defun agent-shell-delete-char (&optional arg)
+  "Delete the next ARG characters or attached image field at point."
+  (interactive "*p")
+  (unless (and (= (or arg 1) 1)
+               (agent-shell--delete-image-field (point)))
+    (delete-char (or arg 1))))
+
+(put 'agent-shell-backward-delete-char 'delete-selection 'supersede)
+(defun agent-shell-backward-delete-char (&optional arg)
+  "Delete the previous ARG characters or attached image field before point."
+  (interactive "*p")
+  (unless (and (= (or arg 1) 1)
+               (> (point) (point-min))
+               (agent-shell--delete-image-field (1- (point))))
+    (delete-char (- (or arg 1)))))
+
 (cl-defun agent-shell--get-files-context (&key files agent-cwd)
   "Process FILES into sendable text with image preview if applicable.
 
@@ -4480,17 +4514,19 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                           :file-path file
                                           :max-width 200)))
                      ;; Propertize text to display the image
-                     (agent-shell-ui-add-action-to-text
-                      (propertize (concat "@" file)
-                                  'display image-display
-                                  'pointer 'hand)
-                      (lambda ()
-                        (interactive)
-                        (find-file file))
-                      (lambda ()
-                        (message "Press RET to open"))
-                      ;; No link face for image (no underline).
-                      nil)
+                     (propertize
+                      (agent-shell-ui-add-action-to-text
+                       (propertize (concat "@" file)
+                                   'display image-display
+                                   'pointer 'hand)
+                       (lambda ()
+                         (interactive)
+                         (find-file file))
+                       (lambda ()
+                         (message "Press RET to open"))
+                       ;; No link face for image (no underline).
+                       nil)
+                      'field 'agent-shell--image-field)
                    ;; Not an image, insert as normal text
                    (agent-shell-ui-add-action-to-text
                     (if (and agent-cwd (file-in-directory-p file agent-cwd))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -438,6 +438,67 @@
     (let ((uris (agent-shell--collect-attached-files blocks)))
       (should (= (length uris) 2)))))
 
+(ert-deftest agent-shell--get-files-context-adds-image-field-test ()
+  "Test `agent-shell--get-files-context' marks image content as one field."
+  (let ((temp-file (make-temp-file "agent-shell-context" nil ".png")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--load-image)
+                   (lambda (&rest _) 'fake-image)))
+          (let ((text (agent-shell--get-files-context :files (list temp-file))))
+            (should (eq (get-text-property 0 'field text)
+                        'agent-shell--image-field))))
+      (delete-file temp-file))))
+
+(ert-deftest agent-shell--get-files-context-leaves-non-image-without-field-test ()
+  "Test `agent-shell--get-files-context' leaves non-image files unchanged."
+  (let ((temp-file (make-temp-file "agent-shell-context" nil ".txt")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--load-image)
+                   (lambda (&rest _) nil)))
+          (let ((text (agent-shell--get-files-context :files (list temp-file))))
+            (should-not (get-text-property 0 'field text))))
+      (delete-file temp-file))))
+
+(ert-deftest agent-shell-delete-char-deletes-image-field-test ()
+  "Test `agent-shell-delete-char' deletes the whole attached image field."
+  (let ((temp-file (make-temp-file "agent-shell-context" nil ".png")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--load-image)
+                   (lambda (&rest _) 'fake-image)))
+          (with-temp-buffer
+            (insert "Prompt\n\n")
+            (insert (agent-shell--get-files-context :files (list temp-file)))
+            (goto-char (point-max))
+            (search-backward "@")
+            (agent-shell-delete-char 1)
+            (should (equal (buffer-string) "Prompt\n\n"))))
+      (delete-file temp-file))))
+
+(ert-deftest agent-shell-backward-delete-char-deletes-image-field-test ()
+  "Test `agent-shell-backward-delete-char' deletes the whole attached image field."
+  (let ((temp-file (make-temp-file "agent-shell-context" nil ".png")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--load-image)
+                   (lambda (&rest _) 'fake-image)))
+          (with-temp-buffer
+            (insert "Prompt\n\n")
+            (insert (agent-shell--get-files-context :files (list temp-file)))
+            (goto-char (point-max))
+            (agent-shell-backward-delete-char 1)
+            (should (equal (buffer-string) "Prompt\n\n"))))
+      (delete-file temp-file))))
+
+(ert-deftest agent-shell-mode-delete-keybindings-test ()
+  "Test `agent-shell-mode-map' binds delete keys for attached files."
+  (should (eq (lookup-key agent-shell-mode-map (kbd "C-d"))
+              #'agent-shell-delete-char))
+  (should (eq (lookup-key agent-shell-mode-map (kbd "DEL"))
+              #'agent-shell-backward-delete-char))
+  (should (eq (lookup-key agent-shell-mode-map (kbd "<backspace>"))
+              #'agent-shell-backward-delete-char))
+  (should (eq (lookup-key agent-shell-mode-map (kbd "<delete>"))
+              #'agent-shell-delete-char)))
+
 (ert-deftest agent-shell--send-command-integration-test ()
   "Integration test: verify agent-shell--send-command calls ACP correctly."
   (let ((sent-request nil)


### PR DESCRIPTION
Problem:
- In `agent-shell-mode`, when the prompt contains an inline image, `C-d` with point on the image and `DEL` with point just after the image do not remove it.

Fix:
- Add explicit `agent-shell-mode` bindings for `C-d`, `DEL`, `<backspace>`, and `<delete>` so the expected delete keys are available in the mode.
- Route image deletion through `delete-field`.
- Mark only inline image attachments with a private field symbol: `agent-shell--image-field`.
- Leave non-image file attachments unchanged.

Tests:
- Added a test that inline image context is marked with the image field.
- Added a test that non-image file context does not get that field.
- Added a forward-delete test for deleting an inline image.
- Added a backward-delete test for deleting an inline image.
- Added a keybinding test for the delete keys in `agent-shell-mode`.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've added tests where applicable.
