### PR TITLE
Add CI workflow and local test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: timvisher-dd/acp.el-plus
+          path: deps/acp.el
+
+      - uses: actions/checkout@v4
+        with:
+          repository: xenodium/shell-maker
+          path: deps/shell-maker
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 29.4
+
+      - name: Remove stale .elc files
+        run: find . deps -follow -name '*.elc' -print0 | xargs -0 rm -f
+
+      - name: Byte-compile
+        run: |
+          compile_files=()
+          for f in *.el; do
+            case "$f" in x.*|y.*|z.*) ;; *) compile_files+=("$f") ;; esac
+          done
+          emacs -Q --batch \
+            -L . -L deps/acp.el -L deps/shell-maker \
+            -f batch-byte-compile \
+            "${compile_files[@]}"
+
+      - name: Run ERT tests
+        run: |
+          test_args=()
+          for f in tests/*-tests.el; do
+            test_args+=(-l "$f")
+          done
+          emacs -Q --batch \
+            -L . -L deps/acp.el -L deps/shell-maker -L tests \
+            "${test_args[@]}" \
+            -f ert-run-tests-batch-and-exit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.agent-shell/
+/deps/
 
 *.elc

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Runs the same checks as CI by parsing .github/workflows/ci.yml directly.
+# If CI steps change, this script automatically picks them up.
+#
+# Local adaptations:
+# - Dependencies (acp.el, shell-maker) are symlinked into deps/ from
+#   local worktree checkouts instead of being cloned by GitHub Actions.
+#   Override locations with acp_root and shell_maker_root env vars.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ci_yaml=".github/workflows/ci.yml"
+
+if ! command -v yq &>/dev/null; then
+  echo "error: yq is required (brew install yq)" >&2
+  exit 1
+fi
+
+# Resolve local dependency paths — CI checks these out via actions/checkout
+acp_root=${acp_root:-../../acp.el/main}
+shell_maker_root=${shell_maker_root:-../../shell-maker/main}
+
+die=0
+if ! [[ -r ${acp_root}/acp.el ]]; then
+  echo "error: acp.el not found at ${acp_root}" >&2
+  echo "Set acp_root to your acp.el checkout" >&2
+  die=1
+fi
+
+if ! [[ -r ${shell_maker_root}/shell-maker.el ]]; then
+  echo "error: shell-maker.el not found at ${shell_maker_root}" >&2
+  echo "Set shell_maker_root to your shell-maker checkout" >&2
+  die=1
+fi
+
+if (( 0 < die )); then
+  exit 1
+fi
+
+# Create deps/ symlinks to match CI layout
+mkdir -p deps
+ln -sfn "$(cd "${acp_root}" && pwd)" deps/acp.el
+ln -sfn "$(cd "${shell_maker_root}" && pwd)" deps/shell-maker
+
+# Extract and run CI steps
+step_count=$(yq '[.jobs.test.steps[] | select(.run)] | length' "$ci_yaml")
+
+for (( i = 0; i < step_count; i++ )); do
+  name=$(yq "[.jobs.test.steps[] | select(.run)].[${i}].name" "$ci_yaml")
+  cmd=$(yq "[.jobs.test.steps[] | select(.run)].[${i}].run" "$ci_yaml")
+
+  echo "=== ${name} ==="
+  eval "$cmd"
+  echo ""
+done
+
+echo "=== All CI checks passed ==="


### PR DESCRIPTION
- Add GitHub Actions CI workflow that byte-compiles all `.el` files and runs the full ERT test suite on push to main/dev and on PRs to main.
- CI checks out `timvisher-dd/acp.el-plus` and `xenodium/shell-maker` as dependencies into `deps/`.
- Add `bin/test` that parses `ci.yml` with `yq` so local test runs automatically stay in sync with CI steps — if CI changes, `bin/test` picks it up without manual edits.
- `bin/test` symlinks local dependency checkouts into `deps/` to match the CI directory layout. Override paths with `acp_root` and `shell_maker_root` env vars.

## Test plan

- [x] `bin/test` passes locally (66/66 tests on upstream/main)
- [ ] CI runs green after push
