### PR TITLE
replace all references to "Claude Code Agent" with "Claude Agent"

### DIFF
--- a/README.org
+++ b/README.org
@@ -392,7 +392,7 @@ You can select and start any of the known agent shells (see =agent-shell-agent-c
 
 Start a specific agent shell session directly:
 
-- =M-x agent-shell-anthropic-start-claude-code= - Start a Claude Code agent session
+- =M-x agent-shell-anthropic-start-claude-code= - Start a Claude Agent session
 - =M-x agent-shell-auggie-start-agent= - Start an Auggie agent session
 - =M-x agent-shell-openai-start-codex= - Start a Codex agent session
 - =M-x agent-shell-google-start-gemini= - Start a Gemini agent session
@@ -705,7 +705,7 @@ always go to Evil modes if you need to with ~C-z~).
 |-----------------+---------------------------------------------------------+-------------------------------------------------------------------------------|
 |                 | agent-shell                                             | Start or reuse an existing agent shell.                                       |
 |                 | agent-shell--display-buffer                             | Toggle agent SHELL-BUFFER display.                                            |
-|                 | agent-shell-anthropic-start-claude-code                 | Start an interactive Claude Code agent shell.                                 |
+|                 | agent-shell-anthropic-start-claude-code                 | Start an interactive Claude Agent shell.                                      |
 |                 | agent-shell-auggie-start-agent                          | Start an interactive Auggie agent shell.                                      |
 |                 | agent-shell-clear-buffer                                | Clear the current shell buffer.                                               |
 |                 | agent-shell-completion-mode                             | Toggle agent shell completion with @ or / prefix.                             |

--- a/agent-shell-anthropic.el
+++ b/agent-shell-anthropic.el
@@ -132,7 +132,7 @@ Example usage to set a custom Anthropic API base URL:
   :group 'agent-shell)
 
 (defun agent-shell-anthropic-make-claude-code-config ()
-  "Create a Claude Code agent configuration.
+  "Create a Claude Agent configuration.
 
 Returns an agent configuration alist using `agent-shell-make-agent-config'."
   (agent-shell-make-agent-config
@@ -152,7 +152,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :install-instructions "See https://github.com/zed-industries/claude-agent-acp for installation."))
 
 (defun agent-shell-anthropic-start-claude-code ()
-  "Start an interactive Claude Code agent shell."
+  "Start an interactive Claude Agent shell."
   (interactive)
   (agent-shell--dwim :config (agent-shell-anthropic-make-claude-code-config)
                      :new-shell t))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -413,8 +413,8 @@ on the system is used."
   "Format to use when generating agent shell buffer names.
 
 Each element can be:
-- Default: For example \='Claude Code Agent @ My Project\='
-- Kebab case: For example \='claude-code-agent @ my-project\='
+- Default: For example \='Claude Agent @ My Project\='
+- Kebab case: For example \='claude-agent @ my-project\='
 - A function: Called with agent name and project name."
   :type '(choice (const :tag "Default" default)
                  (const :tag "Kebab case" kebab-case)


### PR DESCRIPTION
In reference to the [Claude Agent SDK branding
guidelines](https://platform.claude.com/docs/en/agent-sdk/overview#branding-guidelines) and earlier
work in #299.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

<!-- Message of single commit: -->