### PR TITLE
Add agent-shell-clear

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -853,7 +853,7 @@ Always prompts for agent selection, even if existing shells are available."
   (agent-shell '(4)))
 
 ;;;###autoload
-(defun agent-shell-clear ()
+(defun agent-shell-restart ()
   "Clear conversation by restarting the agent shell in the same project.
 
 Kills the current shell buffer (shutting down the ACP client) and


### PR DESCRIPTION
This adds a function that kills the current shell buffer and starts a new one with the same agent configuration.

This resolves issue #416

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [X] I've filed a feature request/discussion for a new feature.
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.