### PR TITLE
Add agent-shell-confirm-interrupt option

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -53,6 +53,7 @@
 (declare-function agent-shell-copy-session-id "agent-shell")
 (declare-function agent-shell-cycle-session-mode "agent-shell")
 (declare-function agent-shell-interrupt "agent-shell")
+(declare-function agent-shell-interrupt-confirmed-p "agent-shell")
 (declare-function agent-shell-open-transcript "agent-shell")
 (declare-function agent-shell-queue-request "agent-shell")
 (declare-function agent-shell-remove-pending-request "agent-shell")
@@ -223,7 +224,7 @@ Returns an alist with insertion details or nil otherwise:
           (viewport-buffer (current-buffer))
           (prompt (string-trim (buffer-string))))
       (when (agent-shell-viewport--busy-p)
-        (unless (y-or-n-p "Interrupt?")
+        (unless (agent-shell-interrupt-confirmed-p)
           (throw 'exit nil))
         (with-current-buffer shell-buffer
           (agent-shell-interrupt t))
@@ -265,7 +266,7 @@ Returns an alist with insertion details or nil otherwise:
     (let ((shell-buffer (agent-shell-viewport--shell-buffer)))
       (unless (agent-shell-viewport--busy-p)
         (user-error "No pending request"))
-      (unless (y-or-n-p "Interrupt?")
+      (unless (agent-shell-interrupt-confirmed-p)
         (throw 'exit nil))
       (with-current-buffer shell-buffer
         (agent-shell-interrupt t))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -241,6 +241,22 @@ See https://github.com/xenodium/agent-shell/issues/119"
   :type 'boolean
   :group 'agent-shell)
 
+(defcustom agent-shell-confirm-interrupt t
+  "Whether to prompt for confirmation before interrupting.
+
+When non-nil (the default), `agent-shell-interrupt' and related
+commands ask \"Interrupt?\" via `y-or-n-p' before cancelling the
+in-progress request.  Set to nil to interrupt immediately without
+prompting."
+  :type 'boolean
+  :group 'agent-shell)
+
+(defun agent-shell-interrupt-confirmed-p ()
+  "Prompt the user to confirm an interrupt and return non-nil if confirmed.
+When `agent-shell-confirm-interrupt' is nil, skip the prompt and return t."
+  (or (not agent-shell-confirm-interrupt)
+      (y-or-n-p "Interrupt?")))
+
 (defcustom agent-shell-context-sources '(files region error line)
   "Sources to consider when determining \\<agent-shell-mode-map>\\[agent-shell] automatic context.
 
@@ -987,13 +1003,14 @@ Includes shells accessed via viewport buffers, preserving visited order."
 
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
-When FORCE is non-nil, skip confirmation prompt."
+When FORCE is non-nil, skip confirmation prompt.
+See also `agent-shell-confirm-interrupt'."
   (declare (modes agent-shell-mode))
   (interactive)
   (unless (derived-mode-p 'agent-shell-mode)
     (error "Not in a shell"))
   (cond ((map-nested-elt (agent-shell--state) '(:session :id))
-         (when (or force (y-or-n-p "Interrupt?"))
+         (when (or force (agent-shell-interrupt-confirmed-p))
            ;; First cancel all pending permission requests
            (map-do
             (lambda (tool-call-id tool-call-data)
@@ -5066,7 +5083,7 @@ ACTIONS as per `agent-shell--make-permission-action'."
                                 :message-text (map-elt action :option)))))
               :on-reject (lambda ()
                            (interactive)
-                           (when (y-or-n-p "Interrupt?")
+                           (when (agent-shell-interrupt-confirmed-p)
                              (agent-shell-diff-kill-buffer (current-buffer))
                              (with-current-buffer shell-buffer
                                (agent-shell-interrupt t))))


### PR DESCRIPTION
Instead of directly calling y-or-n-p, call agent-shell-interrupt-confirmed-p. If agent-shell-confirm-interrupt is nil, it will return non-nil without prompting. This allows quicker cancelling for those who prefer.

Fixes #422

## Checklist

- [ ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [ ] *I've reviewed all code in PR myself and will vouch for its quality*.
- [ ] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
