### PR TITLE
Fix for structured input from toolCall.rawInput.plan

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1429,7 +1429,7 @@ COMMAND, when present, may be a shell command string or an argv vector."
                   :state state
                   :block-id (concat (map-nested-elt acp-notification '(params update toolCallId)) "-plan")
                   :label-left (propertize "Proposed plan" 'font-lock-face 'font-lock-doc-markup-face)
-                  :body (map-nested-elt acp-notification '(params update rawInput plan))
+                  :body (agent-shell--format-plan (map-nested-elt acp-notification '(params update rawInput plan)))
                   :expanded t)))
              (map-put! state :last-entry-type "tool_call")))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "agent_thought_chunk")
@@ -1743,7 +1743,7 @@ COMMAND, when present, may be a shell command string or an argv vector."
               :state state
               :block-id (concat (map-nested-elt acp-request '(params toolCall toolCallId)) "-plan")
               :label-left (propertize "Proposed plan" 'font-lock-face 'font-lock-doc-markup-face)
-              :body (map-nested-elt acp-request '(params toolCall rawInput plan))
+              :body (agent-shell--format-plan (map-nested-elt acp-request '(params toolCall rawInput plan)))
               :expanded t))
            ;; block-id must be the same as the one used
            ;; in agent-shell--delete-fragment param.
@@ -2478,7 +2478,8 @@ Returns propertized labels in :status and :title propertized."
              (lambda (entry)
                (agent-shell--make-status-kind-label :status (map-elt entry 'status)))
              (lambda (entry)
-               (map-elt entry 'content)))
+               (or (map-elt entry 'content)
+                   (map-elt entry 'step))))
    :separator " "
    :joiner "\n"))
 


### PR DESCRIPTION
I am getting this JSON sometimes with codex-acp:

```
{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"019d02d5-885b-7b40-9c8f-a75845dd96f2","update":{"sessionUpdate":"tool_call","toolCallId":"call_7ADCCGOkY7FL8ram6C1Wbabn","title":"update_plan","status":"completed","rawInput":{"explanation":"Entered planning mode. Starting with task definition before any implementation work.","plan":[{"step":"Clarify the target task and constraints","status":"in_progress"},{"step":"Inspect the relevant code and tests","status":"pending"},{"step":"Draft an implementation and verification plan","status":"pending"}]}}}}
```

or more structured from your traffic log

```
:direction incoming
:kind      notification
:object
           jsonrpc 2.0
           method  session/update
           params
                   sessionId 019d02d5-885b-7b40-9c8f-a75845dd96f2
                   update
                             sessionUpdate tool_call
                             toolCallId    call_7ADCCGOkY7FL8ram6C1Wbabn
                             title         update_plan
                             status        completed
                             rawInput
                                           explanation Entered planning mode. Starting with task definition before any implementation work.
                                           plan
                                                       step   Clarify the target task and constraints
                                                       status in_progress

                                                       step   Inspect the relevant code and tests
                                                       status pending

                                                       step   Draft an implementation and verification plan
                                                       status pending
```

This ends up causing this error:

```
Debugger entered--Lisp error: (wrong-type-argument stringp [((step . "Clarify the target task and constraints") (status . "in_progress")) ((step . "Inspect the relevant code and tests") (status . "pending")) ((step . "Draft an implementation and verification plan") (status . "pending"))])
  string-empty-p([((step . "Clarify the target task and constraints") (status . "in_progress")) ((step . "Inspect the relevant code and tests") (status . "pending")) ((step . "Draft an implementation and verification plan") (status . "pending"))])
  (not (string-empty-p str))
  (and str (not (string-empty-p str)) str)
  agent-shell-ui--string-or-nil([((step . "Clarify the target task and constraints") (status . "in_progress")) ((step . "Inspect the relevant code and tests") (status . "pending")) ((step . "Draft an implementation and verification plan") (status . "pending"))])
```

AFAICT the issue is that agent-shell here assumes that rawInput is a plain string, the spec says it can be an object
* https://agentclientprotocol.com/protocol/tool-calls#param-raw-input

This fixes it for me, although I really cannot say if this is an ok fix. It seems odd to me that rawInput can be an object per spec in the first place...

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
