### PR TITLE
Add related project `agent-circus` to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,7 @@ We now have a handful of additional packages to extend the =agent-shell= experie
 - [[https://github.com/ElleNajt/meta-agent-shell][meta-agent-shell]]: Multi-agent coordination system for =agent-shell= with inter-agent communication, task tracking, and project-level dispatching.
 - [[https://github.com/xenodium/agent-shell-knockknock][agent-shell-knockknock]]: Notifications for =agent-shell= via [[https://github.com/konrad1977/knockknock][knockknock.el]].
 - [[https://github.com/xenodium/emacs-skills][emacs-skills]]: Claude Agent skills for Emacs.
+- [[https://github.com/Embedded-Focus/agent-circus][agent-circus]]: Run AI coding agents in sandboxed Docker containers.
 
 * Icons
 


### PR DESCRIPTION
This PR adds a link to the [agent-circus](https://github.com/Embedded-Focus/agent-circus) as a related project.

Please, also see issue #440.

The goal of the agent-circus is to allow for easy sandboxing of AI agents. In Emacs, agent-circus relies on the `agent-shell-command-prefix` configuration setting introduced by @fritzgrabo and extended by myself.

The agent-circus is not complete (probably will never be). But it is good enough to be my daily driver for running containerized AI agents in the context of Emacs/agent-shell.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
