### PR TITLE
Use project-name instead of default-directory in header

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3121,7 +3121,7 @@ The model contains all inputs needed to render the graphical header."
       (:model-name . ,model-name)
       (:mode-id . ,mode-id)
       (:mode-name . ,mode-name)
-      (:directory . ,default-directory)
+      (:project-name . ,(agent-shell--project-name))
       (:session-id . ,(agent-shell--session-id-indicator))
       (:frame-width . ,(frame-pixel-width))
       (:font-height . ,(frame-char-height))
@@ -3164,8 +3164,7 @@ BINDINGS is a list of alists defining key bindings to display, each with:
                               (if (map-elt header-model :mode-name)
                                   (concat " ➤ " (propertize (map-elt header-model :mode-name) 'font-lock-face 'font-lock-type-face))
                                 "")
-                              (propertize (string-remove-suffix "/" (abbreviate-file-name (map-elt header-model :directory)))
-                                          'font-lock-face 'font-lock-string-face)
+                              (propertize (map-elt header-model :project-name) 'font-lock-face 'font-lock-string-face)
                               (if (map-elt header-model :session-id)
                                   (concat " ➤ " (map-elt header-model :session-id))
                                 "")
@@ -3295,7 +3294,7 @@ BINDINGS is a list of alists defining key bindings to display, each with:
                                       (dom-append-child text-node
                                                         (dom-node 'tspan
                                                                   `((fill . ,(face-attribute 'font-lock-string-face :foreground)))
-                                                                  (string-remove-suffix "/" (abbreviate-file-name (map-elt header-model :directory)))))
+                                                                  (map-elt header-model :project-name)))
                                       ;; Session ID (optional)
                                       (when (map-elt header-model :session-id)
                                         ;; Separator arrow (default foreground)


### PR DESCRIPTION
`agent-shell--project-name`'s default implementation includes the last component of the directory path by default, so this is expected to be a strict improvement for cases where `project-name` does something more clever.

Tests still pass, but I did not bother to add new tests for a custom `project-name` implementation.  I manually tested on my site's custom implementation instead, just to make sure it got called.

Close #444

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.