### PR TITLE
Fix restart using wrong default-directory

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -940,7 +940,8 @@ Works from both shell and viewport buffers."
                  (not (y-or-n-p "Agent is busy.  Restart anyway?")))
         (user-error "Cancelled")))
     (kill-buffer shell-buffer)
-    (let ((new-shell-buffer (agent-shell--start
+    (let* ((default-directory (buffer-local-value 'default-directory shell-buffer))
+           (new-shell-buffer (agent-shell--start
                              :config config
                              :session-strategy strategy
                              :session-id session-id

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2073,5 +2073,62 @@ Based on ACP traffic from https://github.com/xenodium/agent-shell/issues/415."
                                       (rawInput . ((command . "ls -la")))
                                       (kind . "execute"))))))))))
 
+(ert-deftest agent-shell-restart-preserves-default-directory ()
+  "Restart should use the shell's directory, not the fallback buffer's.
+
+After `kill-buffer' happens during restart, Emacs falls back to another
+buffer.  Without the fix, `default-directory' would be inherited from
+that fallback buffer, potentially starting the new shell in the wrong project."
+  (let ((shell-buffer nil)
+        (other-buffer nil)
+        (captured-dir nil)
+        (frame (make-frame '((visibility . nil))))
+        (project-a "/tmp/project-a/")
+        (project-b "/tmp/project-b/")
+        (config (list (cons :buffer-name "test-agent")
+                      (cons :client-maker
+                            (lambda (_buf)
+                              (list (cons :command "cat")))))))
+    (unwind-protect
+        (progn
+          ;; Create a buffer from "project B" that Emacs will fall back to
+          ;; after the shell buffer is killed.
+          (setq other-buffer (get-buffer-create "*project-b-file*"))
+          (with-current-buffer other-buffer
+            (setq default-directory project-b))
+          ;; Create the shell buffer in "project A".
+          (setq shell-buffer (get-buffer-create "*test-restart-shell*"))
+          (with-current-buffer shell-buffer
+            (setq major-mode 'agent-shell-mode)
+            (setq default-directory project-a)
+            (setq-local agent-shell-session-strategy 'new)
+            (setq-local agent-shell--state
+                        `((:agent-config . ,config)
+                          (:active-requests))))
+          ;; Use a hidden frame and swap buffers around
+          ;; so that when kill-buffer happens it will fallback to project-b
+          ;; rather than the last buffer in the user's frame.
+          (with-selected-frame frame
+            (switch-to-buffer other-buffer)
+            (switch-to-buffer shell-buffer)
+            ;; Mock agent-shell--start to capture default-directory
+            ;; instead of actually starting a shell.
+            (cl-letf (((symbol-function 'agent-shell--start)
+                       (lambda (&rest _args)
+                         (setq captured-dir default-directory)
+                         (get-buffer-create "*test-restart-new-shell*")))
+                      ((symbol-function 'agent-shell--display-buffer)
+                       #'ignore))
+              (agent-shell-restart)))
+          (should (equal captured-dir project-a)))
+      (when (and frame (frame-live-p frame))
+        (delete-frame frame))
+      (when (and shell-buffer (buffer-live-p shell-buffer))
+        (kill-buffer shell-buffer))
+      (when (and other-buffer (buffer-live-p other-buffer))
+        (kill-buffer other-buffer))
+      (when-let ((buf (get-buffer "*test-restart-new-shell*")))
+        (kill-buffer buf)))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
`agent-shell-restart` kills the buffer and calls `agent-shell--start` directly after.
Since `kill-buffer` will have the effect of changing the default directory to the "other buffer", `agent-shell--start` can possibly end up creating the new shell an unexpected project (e.g if the user's last buffer was in a different project, the new shell will be made for this project instead of the expected behavior of being for the same project the original shell was for).

The fix is to bind `default-directory` around calling `agent-shell--start`, since this will retain the default directory across the `kill-buffer` call.

`agent-shell-reload` was also affected, since it delegates to `agent-shell-restart`.

A new test is added to ensure that, in a frame whose last buffer was another project than the current shell's, calling restart will still use the shell's project as expected. Without the fix, the test fails.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
