### PR TITLE
Prefer cache directory over tmp for caching

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1983,6 +1983,24 @@ function before returning."
   "Resolve PATH using `agent-shell-path-resolver-function'."
   (funcall (or agent-shell-path-resolver-function #'identity) path))
 
+(defun agent-shell--cache-dir (&rest components)
+  "Determine and create a system-dependent agent-shell cache directory.
+
+Optionally, COMPONENTS specifies a subdirectory within the cache
+directory to be created."
+  (let* ((base (or (getenv "XDG_CACHE_HOME")
+                   (pcase system-type
+                     ('darwin (expand-file-name "Library/Caches" "~"))
+                     ('windows-nt (or (getenv "LOCALAPPDATA") (getenv "APPDATA")))
+                     ;; Emacs write getCacheDir() into this environment variable
+                     ('android (getenv "TMPDIR"))
+                     ((or 'ms-dos 'cygwin 'haiku) nil)
+                     (_ (expand-file-name ".cache" "~")))
+                   (expand-file-name "cache" user-emacs-directory)))
+         (cache-dir (apply #'file-name-concat base "agent-shell" components)))
+    (make-directory cache-dir t)
+    cache-dir))
+
 (defun agent-shell--stop-reason-description (stop-reason)
   "Return a human-readable text description for STOP-REASON.
 
@@ -3394,10 +3412,8 @@ Icon names starting with https:// are downloaded directly from that location."
                            url))
                        ;; For lobe-icons names, use the original filename
                        (file-name-nondirectory url)))
-           (cache-dir (file-name-concat (temporary-file-directory) "agent-shell" mode))
-           (cache-path (expand-file-name filename cache-dir)))
+           (cache-path (expand-file-name filename (agent-shell--cache-dir mode))))
       (unless (file-exists-p cache-path)
-        (make-directory cache-dir t)
         (let ((buffer (url-retrieve-synchronously url t t 5.0)))
           (when buffer
             (with-current-buffer buffer
@@ -3419,13 +3435,11 @@ Return file path of the generated SVG."
     (let* ((icon-text (char-to-string (string-to-char icon-name)))
            (mode (if (eq (frame-parameter nil 'background-mode) 'dark) "dark" "light"))
            (filename (format "%s-%s.svg" icon-name width))
-           (cache-dir (file-name-concat (temporary-file-directory) "agent-shell" mode))
-           (cache-path (expand-file-name filename cache-dir))
+           (cache-path (expand-file-name filename (agent-shell--cache-dir mode)))
            (font-size (* 0.7 width))
            (x (/ width 2))
            (y (/ width 2)))
       (unless (file-exists-p cache-path)
-        (make-directory cache-dir t)
         (let ((svg (svg-create width width :stroke "white" :fill "black")))
           (svg-text svg icon-text
                     :x x :y y


### PR DESCRIPTION
This change replaces the use of =/tmp= (~temporary-file-directory~) for caching with the user's cache directory as given by the XDG Base Directory specification or a system-dependent fallback. This avoids permission conflicts when multiple users use agent-shell on a shared system.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
