### PR TITLE
Make the limitation of region context lines optional

### DIFF
--- a/README.org
+++ b/README.org
@@ -650,6 +650,7 @@ always go to Evil modes if you need to with ~C-z~).
 | agent-shell-qwen-acp-command                  | Command and parameters for the Qwen Code client.                                |
 | agent-shell-qwen-authentication               | Configuration for Qwen Code authentication.                                     |
 | agent-shell-qwen-environment                  | Environment variables for the Qwen Code client.                                 |
+| agent-shell-region-context-max-lines          | Limit region context to this many lines                                         |
 | agent-shell-screenshot-command                | The program to use for capturing screenshots.                                   |
 | agent-shell-section-functions                 | Abnormal hook run after overlays are applied (experimental).                    |
 | agent-shell-session-strategy                  | How to handle sessions when starting a new shell.                               |

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -291,6 +291,11 @@ passed through to `acp-make-client'."
                                                    (map-elt (buffer-local-value 'agent-shell--state context-buffer)
                                                             :outgoing-request-decorator)))))
 
+(defcustom agent-shell-region-context-max-lines nil
+  "Limit region context to at most this many lines if non-nil."
+  :type '(choice (const nil) integer)
+  :group 'agent-shell)
+
 (defcustom agent-shell-text-file-capabilities t
   "Whether agents are initialized with read/write text file capabilities.
 
@@ -5736,8 +5741,7 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                    (numbered-preview
                                     (when-let ((buffer (get-file-buffer (map-elt region :file))))
                                       (let ((char-start (map-elt region :char-start))
-                                            (char-end (map-elt region :char-end))
-                                            (max-preview-lines 5))
+                                            (char-end (map-elt region :char-end)))
                                         (if (equal (line-number-at-pos char-start)
                                                    (line-number-at-pos char-end))
                                             ;; Same line region? Avoid numbering.
@@ -5746,7 +5750,7 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                            :buffer buffer
                                            :from char-start
                                            :to char-end
-                                           :cap max-preview-lines))))))
+                                           :cap agent-shell-region-context-max-lines))))))
                                (if numbered-preview
                                    (concat file-link "\n\n" numbered-preview)
                                  file-link))


### PR DESCRIPTION
This change lets the user decide to how many lines the embedded region context should be limited. I have set the default nil, because I personally expect the context to send the complete region when I explicitly select one, but I can of course change it to 5 as it was hard-coded before.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
