### PR TITLE
Fixes #455: unhandled method returns an error, unblocking client

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1824,13 +1824,21 @@ COMMAND, when present, may be a shell command string or an argv vector."
           :state state
           :acp-request acp-request))
         (t
-         (agent-shell--update-fragment
-          :state state
-          :block-id "Unhandled Incoming Request"
-          :body (format "⚠ Unhandled incoming request: \"%s\"" (map-elt acp-request 'method))
-          :create-new t
-          :navigation 'never)
-         (map-put! state :last-entry-type nil))))
+         (let ((method (map-elt acp-request 'method)))
+           (agent-shell--update-fragment
+            :state state
+            :block-id "Unhandled Incoming Request"
+            :body (format "⚠ Unhandled incoming request: \"%s\"" method)
+            :create-new t
+            :navigation 'never)
+           ;; Send error response to prevent client from hanging.
+           (acp-send-response
+            :client (map-elt state :client)
+            :response `((:request-id . ,(map-elt acp-request 'id))
+                        (:error . ,(acp-make-error
+                                    :code -32601
+                                    :message (format "Method not found: %s" method)))))
+           (map-put! state :last-entry-type nil)))))
 
 (cl-defun agent-shell--extract-buffer-text (&key buffer line limit)
   "Extract text from BUFFER starting from LINE with optional LIMIT.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1965,6 +1965,34 @@ code block content
         (should-not responded)
         (should (equal (map-elt state :last-entry-type) "session/request_permission"))))))
 
+(ert-deftest agent-shell--on-request-sends-error-for-unhandled-method-test ()
+  "Test `agent-shell--on-request' responds with an error for unknown methods."
+  (with-temp-buffer
+    (let* ((captured-response nil)
+           (state `((:buffer . ,(current-buffer))
+                    (:client . test-client)
+                    (:event-subscriptions . nil)
+                    (:last-entry-type . "previous-entry"))))
+      (cl-letf (((symbol-function 'agent-shell--update-fragment)
+                 (lambda (&rest _)))
+                ((symbol-function 'acp-send-response)
+                 (lambda (&rest args)
+                   (setq captured-response (plist-get args :response))))
+                ((symbol-function 'acp-make-error)
+                 (lambda (&rest args)
+                   `((:code . ,(plist-get args :code))
+                     (:message . ,(plist-get args :message))))))
+        (agent-shell--on-request
+         :state state
+         :acp-request '((id . "req-404")
+                        (method . "unknown/method")))
+        (should (equal (map-elt captured-response :request-id) "req-404"))
+        (let ((error (map-elt captured-response :error)))
+          (should (equal (map-elt error :code) -32601))
+          (should (equal (map-elt error :message)
+                         "Method not found: unknown/method")))
+        (should-not (map-elt state :last-entry-type))))))
+
 ;;; Tests for agent-shell-show-context-usage-indicator
 
 (ert-deftest agent-shell--context-usage-indicator-bar-test ()


### PR DESCRIPTION
Fixes #417, #455 - pulls the code from #386 / #393 into a separate patch to handle proliferation of custom ACP message types.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [X] I've filed a feature request/discussion for a new feature.
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
