### PR TITLE
Add wl-paste as a Wayland image handler

### DIFF
--- a/README.org
+++ b/README.org
@@ -502,6 +502,13 @@ For example, to store data under =user-emacs-directory= instead of the project t
 
 This stores data at a path like =~/.emacs.d/agent-shell/home-user-src-myproject/screenshots/=.
 
+*** Screenshots from clipboard
+
+You can send a screenshot from your clipboard to your shell with =agent-shell-send-clipboard-image=. Call with =C-u= to =agent-shell-send-clipboard-image-to= to select from your shells. agent-shell relies on external programs to write an image from clipboard to file as configured in =agent-shell-clipboard-image-handlers=. Preconfigured handlers are
+- =wl-paste= for Wayland desktops,
+- =xclip= for Xorg,
+- =pngpaste= for MacOS.
+
 *** Inhibiting minor modes during file writes
 
 Some minor modes (for example, =aggressive-indent-mode=) can interfere with an agent's edits.  Agent Shell can temporarily disable selected per-buffer minor modes while applying edits.

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -393,6 +393,11 @@ Assume screenshot file path will be appended to this list."
 
 (defcustom agent-shell-clipboard-image-handlers
   (list
+   (list (cons :command "wl-paste")
+         (cons :save (lambda (file-path)
+                       (let ((exit-code (call-process "wl-paste" nil `(:file ,file-path))))
+                         (unless (zerop exit-code)
+                           (error "Command wl-paste failed with exit code %d" exit-code))))))
    (list (cons :command "pngpaste")
          (cons :save (lambda (file-path)
                        (let ((exit-code (call-process "pngpaste" nil nil nil file-path)))
@@ -5087,7 +5092,7 @@ The image is saved to .agent-shell/screenshots in the project root.
 The saved image file path is then inserted into the shell prompt.
 
 When PICK-SHELL is non-nil, prompt for which shell buffer to use."
-  (interactive)
+  (interactive "P")
   (unless (window-system)
     (user-error "Clipboard image requires a window system"))
   (let* ((screenshots-dir (agent-shell--dot-subdir "screenshots"))


### PR DESCRIPTION
If I see it correctly, pngpaste is for MacOS and xclip handles Xorg desktops. This adds wl-paste for Wayland environments. This also makes it so that =agent-shell-send-clipboard-image= lets you pick a shell with =C-u=.

I don't know how many handlers you want to put into the core of agent-shell, but at least one for Wayland is probably a good idea.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
