### PR TITLE
Do not create a file if no image in Wayland clipboard

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -395,9 +395,12 @@ Assume screenshot file path will be appended to this list."
   (list
    (list (cons :command "wl-paste")
          (cons :save (lambda (file-path)
-                       (let ((exit-code (call-process "wl-paste" nil `(:file ,file-path))))
-                         (unless (zerop exit-code)
-                           (error "Command wl-paste failed with exit code %d" exit-code))))))
+                       (with-temp-buffer
+                         (let* ((coding-system-for-read 'binary)
+                                (exit-code (call-process "wl-paste" nil (list t nil) nil "--type" "image/png")))
+                           (if (zerop exit-code)
+                               (write-region nil nil file-path)
+                             (error "Command wl-paste failed with exit code %d" exit-code)))))))
    (list (cons :command "pngpaste")
          (cons :save (lambda (file-path)
                        (let ((exit-code (call-process "pngpaste" nil nil nil file-path)))


### PR DESCRIPTION
The old call to ~call-process~ would merge stdout and stderr into a single stream that would always create ~file-path~ even if no image was in the clipboard. This could then lead downstream code to erroneously assume that an image had been found even though an error was signaled.

Fixes #468.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [ ] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
