### PR TITLE
Display qualifier key binding help in text style header

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3217,44 +3217,58 @@ When provided, included in help-echo tooltips."
   (unless state
     (error "STATE is required"))
   (let* ((header-model (agent-shell--make-header-model state :qualifier qualifier :bindings bindings))
-         (text-header (format " %s%s%s @ %s%s%s%s"
-                              (propertize (map-elt header-model :buffer-name)
-                                          'font-lock-face 'font-lock-variable-name-face)
-                              (if (map-elt header-model :model-name)
-                                  (concat " ➤ " (propertize (map-elt header-model :model-name)
-                                                            'font-lock-face 'font-lock-negation-char-face
-                                                            'help-echo (concat "Click to open LLM model menu "
-                                                                               (when model-binding
-                                                                                 (propertize model-binding 'face 'help-key-binding)))
-                                                            'mouse-face 'mode-line-highlight
-                                                            'local-map (let ((map (make-sparse-keymap)))
-                                                                         (define-key map [header-line mouse-1]
-                                                                                     (agent-shell--mode-line-model-menu))
-                                                                         map)))
-                                "")
-                              (if (map-elt header-model :mode-name)
-                                  (concat " ➤ " (propertize (map-elt header-model :mode-name)
-                                                            'font-lock-face 'font-lock-type-face
-                                                            'help-echo (concat "Click to open session mode menu "
-                                                                               (when mode-binding
-                                                                                 (propertize mode-binding 'face 'help-key-binding)))
-                                                            'mouse-face 'mode-line-highlight
-                                                            'local-map (let ((map (make-sparse-keymap)))
-                                                                         (define-key map [header-line mouse-1]
-                                                                                     (agent-shell--mode-line-mode-menu))
-                                                                         map)))
-                                "")
-                              (propertize (map-elt header-model :project-name) 'font-lock-face 'font-lock-string-face)
-                              (if (map-elt header-model :session-id)
-                                  (concat " ➤ " (map-elt header-model :session-id))
-                                "")
-                              (if (map-elt header-model :context-indicator)
-                                  (concat (if (> (length (map-elt header-model :context-indicator)) 1) " ➤ " " ")
-                                          (map-elt header-model :context-indicator))
-                                "")
-                              (if (map-elt header-model :busy-indicator-frame)
-                                  (map-elt header-model :busy-indicator-frame)
-                                ""))))
+         (text-header (concat
+                       (format " %s%s%s @ %s%s%s%s"
+                               (propertize (map-elt header-model :buffer-name)
+                                           'font-lock-face 'font-lock-variable-name-face)
+                               (if (map-elt header-model :model-name)
+                                   (concat " ➤ " (propertize (map-elt header-model :model-name)
+                                                             'font-lock-face 'font-lock-negation-char-face
+                                                             'help-echo (concat "Click to open LLM model menu "
+                                                                                (when model-binding
+                                                                                  (propertize model-binding 'face 'help-key-binding)))
+                                                             'mouse-face 'mode-line-highlight
+                                                             'local-map (let ((map (make-sparse-keymap)))
+                                                                          (define-key map [header-line mouse-1]
+                                                                                      (agent-shell--mode-line-model-menu))
+                                                                          map)))
+                                 "")
+                               (if (map-elt header-model :mode-name)
+                                   (concat " ➤ " (propertize (map-elt header-model :mode-name)
+                                                             'font-lock-face 'font-lock-type-face
+                                                             'help-echo (concat "Click to open session mode menu "
+                                                                                (when mode-binding
+                                                                                  (propertize mode-binding 'face 'help-key-binding)))
+                                                             'mouse-face 'mode-line-highlight
+                                                             'local-map (let ((map (make-sparse-keymap)))
+                                                                          (define-key map [header-line mouse-1]
+                                                                                      (agent-shell--mode-line-mode-menu))
+                                                                          map)))
+                                 "")
+                               (propertize (map-elt header-model :project-name) 'font-lock-face 'font-lock-string-face)
+                               (if (map-elt header-model :session-id)
+                                   (concat " ➤ " (map-elt header-model :session-id))
+                                 "")
+                               (if (map-elt header-model :context-indicator)
+                                   (concat (if (> (length (map-elt header-model :context-indicator)) 1) " ➤ " " ")
+                                           (map-elt header-model :context-indicator))
+                                 "")
+                               (if (map-elt header-model :busy-indicator-frame)
+                                   (map-elt header-model :busy-indicator-frame)
+                                 ""))
+                       (when (or bindings qualifier)
+                         (concat
+                          "  "
+                          (when qualifier
+                            (concat qualifier " "))
+                          (mapconcat
+                           (lambda (binding)
+                             (format "%s %s"
+                                     (propertize (map-elt binding :key)
+                                                 'font-lock-face 'help-key-binding)
+                                     (map-elt binding :description)))
+                           bindings
+                           "  "))))))
     (pcase agent-shell-header-style
       ((or 'none (pred null)) nil)
       ('text text-header)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3219,44 +3219,58 @@ When provided, included in help-echo tooltips."
   (unless state
     (error "STATE is required"))
   (let* ((header-model (agent-shell--make-header-model state :qualifier qualifier :bindings bindings))
-         (text-header (format " %s%s%s @ %s%s%s%s"
-                              (propertize (map-elt header-model :buffer-name)
-                                          'font-lock-face 'font-lock-variable-name-face)
-                              (if (map-elt header-model :model-name)
-                                  (concat " ➤ " (propertize (map-elt header-model :model-name)
-                                                            'font-lock-face 'font-lock-negation-char-face
-                                                            'help-echo (concat "Click to open LLM model menu "
-                                                                               (when model-binding
-                                                                                 (propertize model-binding 'face 'help-key-binding)))
-                                                            'mouse-face 'mode-line-highlight
-                                                            'local-map (let ((map (make-sparse-keymap)))
-                                                                         (define-key map [header-line mouse-1]
-                                                                                     (agent-shell--mode-line-model-menu))
-                                                                         map)))
-                                "")
-                              (if (map-elt header-model :mode-name)
-                                  (concat " ➤ " (propertize (map-elt header-model :mode-name)
-                                                            'font-lock-face 'font-lock-type-face
-                                                            'help-echo (concat "Click to open session mode menu "
-                                                                               (when mode-binding
-                                                                                 (propertize mode-binding 'face 'help-key-binding)))
-                                                            'mouse-face 'mode-line-highlight
-                                                            'local-map (let ((map (make-sparse-keymap)))
-                                                                         (define-key map [header-line mouse-1]
-                                                                                     (agent-shell--mode-line-mode-menu))
-                                                                         map)))
-                                "")
-                              (propertize (map-elt header-model :project-name) 'font-lock-face 'font-lock-string-face)
-                              (if (map-elt header-model :session-id)
-                                  (concat " ➤ " (map-elt header-model :session-id))
-                                "")
-                              (if (map-elt header-model :context-indicator)
-                                  (concat (if (> (length (map-elt header-model :context-indicator)) 1) " ➤ " " ")
-                                          (map-elt header-model :context-indicator))
-                                "")
-                              (if (map-elt header-model :busy-indicator-frame)
-                                  (map-elt header-model :busy-indicator-frame)
-                                ""))))
+         (text-header (concat
+                       (format " %s%s%s @ %s%s%s%s"
+                               (propertize (map-elt header-model :buffer-name)
+                                           'font-lock-face 'font-lock-variable-name-face)
+                               (if (map-elt header-model :model-name)
+                                   (concat " ➤ " (propertize (map-elt header-model :model-name)
+                                                             'font-lock-face 'font-lock-negation-char-face
+                                                             'help-echo (concat "Click to open LLM model menu "
+                                                                                (when model-binding
+                                                                                  (propertize model-binding 'face 'help-key-binding)))
+                                                             'mouse-face 'mode-line-highlight
+                                                             'local-map (let ((map (make-sparse-keymap)))
+                                                                          (define-key map [header-line mouse-1]
+                                                                                      (agent-shell--mode-line-model-menu))
+                                                                          map)))
+                                 "")
+                               (if (map-elt header-model :mode-name)
+                                   (concat " ➤ " (propertize (map-elt header-model :mode-name)
+                                                             'font-lock-face 'font-lock-type-face
+                                                             'help-echo (concat "Click to open session mode menu "
+                                                                                (when mode-binding
+                                                                                  (propertize mode-binding 'face 'help-key-binding)))
+                                                             'mouse-face 'mode-line-highlight
+                                                             'local-map (let ((map (make-sparse-keymap)))
+                                                                          (define-key map [header-line mouse-1]
+                                                                                      (agent-shell--mode-line-mode-menu))
+                                                                          map)))
+                                 "")
+                               (propertize (map-elt header-model :project-name) 'font-lock-face 'font-lock-string-face)
+                               (if (map-elt header-model :session-id)
+                                   (concat " ➤ " (map-elt header-model :session-id))
+                                 "")
+                               (if (map-elt header-model :context-indicator)
+                                   (concat (if (> (length (map-elt header-model :context-indicator)) 1) " ➤ " " ")
+                                           (map-elt header-model :context-indicator))
+                                 "")
+                               (if (map-elt header-model :busy-indicator-frame)
+                                   (map-elt header-model :busy-indicator-frame)
+                                 ""))
+                       (when (or bindings qualifier)
+                         (concat
+                          "  "
+                          (when qualifier
+                            (concat qualifier " "))
+                          (mapconcat
+                           (lambda (binding)
+                             (format "%s %s"
+                                     (propertize (map-elt binding :key)
+                                                 'font-lock-face 'help-key-binding)
+                                     (map-elt binding :description)))
+                           bindings
+                           "  "))))))
     (pcase agent-shell-header-style
       ((or 'none (pred null)) nil)
       ('text text-header)


### PR DESCRIPTION
Previously, the qualifier (e.g., "[1/5][Edit]") and key binding hints
(e.g., "C-c C-c Submit") were only rendered in graphical-style headers.
This meant that users with agent-shell-header-style set to 'text would
not see any key documentation in the header line.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.