### PR TITLE
Handle non-text content in user_message_chunk during session load

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1554,7 +1554,10 @@ COMMAND, when present, may be a shell command string or an argv vector."
                                              (agent-shell-experimental--methods))))
                            (map-elt state :active-requests))
              (let ((new-prompt-p (not (equal (map-elt state :last-entry-type)
-                                             "user_message_chunk"))))
+                                             "user_message_chunk")))
+                   (content-text (or (map-nested-elt acp-notification '(params update content text))
+                                     (format "[%s]" (or (map-nested-elt acp-notification '(params update content type))
+                                                        "attachment")))))
                (when new-prompt-p
                  (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
                  (agent-shell--append-transcript
@@ -1562,8 +1565,7 @@ COMMAND, when present, may be a shell command string or an argv vector."
                   :file-path agent-shell--transcript-file))
                (agent-shell--append-transcript
                 :text (format "> %s\n"
-                              (agent-shell--indent-markdown-headers
-                               (map-nested-elt acp-notification '(params update content text))))
+                              (agent-shell--indent-markdown-headers content-text))
                 :file-path agent-shell--transcript-file)
                (agent-shell--update-text
                 :state state
@@ -1574,9 +1576,9 @@ COMMAND, when present, may be a shell command string or an argv vector."
                                    (map-nested-elt
                                     state '(:agent-config :shell-prompt))
                                    'font-lock-face 'comint-highlight-prompt)
-                                  (propertize (map-nested-elt acp-notification '(params update content text))
+                                  (propertize content-text
                                               'font-lock-face 'comint-highlight-input))
-                        (propertize (map-nested-elt acp-notification '(params update content text))
+                        (propertize content-text
                                     'font-lock-face 'comint-highlight-input))
                 :create-new new-prompt-p
                 :append t))


### PR DESCRIPTION
Fixes #465
When loading a session with `agent-shell-prefer-session-resume` set to nil, `user_message_chunk` notifications replay the conversation history. Non-text content (e.g. images) lacks the `text` field, causing `(wrong-type-argument stringp nil)` when passed to `propertize`.

Fall back to a `[type]` placeholder (e.g. `[image]`) when `text` is nil.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
