### PR TITLE
Deferred buffer display stuck on "Loading..." when session-strategy is 'prompt

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2810,7 +2810,7 @@ variable (see makunbound)"))
             ;; display the buffer.
             (agent-shell-subscribe-to
              :shell-buffer shell-buffer
-             :event 'session-selected
+             :event 'prompt-ready
              :on-event (lambda (_event)
                          (agent-shell--display-buffer shell-buffer)))
           (agent-shell--display-buffer shell-buffer))))


### PR DESCRIPTION
When agent-shell-session-strategy is prompt and the user selects an existing session to resume, the shell buffer never appears and the minibuffer shows "Loading..." indefinitely.                                       
                                                                                                                                                                                                                           
  The shell is actually ready (prompt displayed, session loaded, model set), but the buffer is never shown to the user.                                                                                                    
                                                                                                 
  Root cause:                                                                                                                                                                                                              
                                                                                                 
  In agent-shell--start, the deferred display at line ~2811 subscribes to session-selected:                                                                                                                                
   
  (agent-shell-subscribe-to                                                                                                                                                                                                
   :shell-buffer shell-buffer                                                                    
   :event 'session-selected                                                                                                                                                                                                
   :on-event (lambda (_event)
               (agent-shell--display-buffer shell-buffer)))                                                                                                                                                                
                                                                                                 
  But in agent-shell--initiate-session-list-and-load (line ~4407), session-selected is emitted before the session resume/load request is sent - not after bootstrap completes. The remaining bootstrap steps (session      
  resume response, set_model, prompt display) happen asynchronously afterward, and the buffer display call can race or fail to make the buffer visible.
                                                                                                                                                                                                                           
  Fix:                                                                                                                                                                                                                     
                                               
  Subscribe to prompt-ready instead of session-selected. This event fires once at the end of the full bootstrap chain, after the session is loaded, model is set, and the shell prompt is displayed.                       
                                                                                                 
  -             :event 'session-selected                                                                                                                                                                                   
  +             :event 'prompt-ready                                                                                                                                                                                       
                                               
  Steps to reproduce:                                                                                                                                                                                                      
                                                                                                 
  1. (setq agent-shell-session-strategy 'prompt)                                                                                                                                                                           
  2. Start agent-shell
  3. Select an existing session to resume from the session picker                                                                                                                                                          
  4. Buffer never appears; "Loading..." persists in minibuffer                                                                                                                                                             
  5. Manually switching to the buffer (C-x b) shows it's ready with a prompt