### PR TITLE
Snapshot session strategy in any case

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2743,8 +2743,9 @@ variable (see makunbound)"))
         (map-put! agent-shell--state :resume-session-id session-id))
       (when fork-session-id
         (map-put! agent-shell--state :fork-session-id fork-session-id))
-      (when session-strategy
-        (setq-local agent-shell-session-strategy session-strategy))
+      ;; Snapshot the strategy also in case it was dynamically re-bound
+      (setq-local agent-shell-session-strategy
+                  (or session-strategy agent-shell-session-strategy))
       ;; Show deferred welcome text,
       ;; but first wipe buffer content.
       (let ((inhibit-read-only t))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1249,6 +1249,41 @@ code block content
       (when (and test-buffer (buffer-live-p test-buffer))
         (kill-buffer test-buffer)))))
 
+(ert-deftest agent-shell--start-snapshots-dynamic-session-strategy ()
+  "Starting a shell should localize the effective session strategy."
+  (let ((test-buffer nil)
+        (shell-buffer nil)
+        (fake-process (start-process "fake-agent" nil "cat"))
+        (config (list (cons :buffer-name "test-agent")
+                      (cons :client-maker
+                            (lambda (_buf)
+                              (list (cons :command "cat")))))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'shell-maker-start)
+                   (lambda (_config &rest _args)
+                     (setq test-buffer (get-buffer-create "*test-agent-shell*"))
+                     (with-current-buffer test-buffer
+                       (setq major-mode 'agent-shell-mode))
+                     test-buffer))
+                  ((symbol-function 'shell-maker--process) (lambda () fake-process))
+                  ((symbol-function 'shell-maker-finish-output) #'ignore)
+                  ((symbol-function 'agent-shell--handle) #'ignore)
+                  (agent-shell-file-completion-enabled nil))
+          (let ((agent-shell-session-strategy 'latest))
+            (let ((agent-shell-session-strategy 'prompt))
+              (setq shell-buffer (agent-shell--start :config config
+                                                    :no-focus t
+                                                    :new-session t))))
+          (should (local-variable-p 'agent-shell-session-strategy shell-buffer))
+          (should (eq (buffer-local-value 'agent-shell-session-strategy shell-buffer)
+                      'prompt)))
+      (when (process-live-p fake-process)
+        (delete-process fake-process))
+      (when (and shell-buffer (buffer-live-p shell-buffer))
+        (kill-buffer shell-buffer))
+      (when (and test-buffer (buffer-live-p test-buffer))
+        (kill-buffer test-buffer)))))
+
 (ert-deftest agent-shell--initiate-session-prefers-list-and-load-when-supported ()
   "Test `agent-shell--initiate-session' prefers session/list + session/load."
   (with-temp-buffer


### PR DESCRIPTION
Dynamically rebinding the session strategy is very useful when programming around agent-shell (I have helpers to restore shells from my previous emacs session, to recover from API endpoint hangups, or to continue work on multiple issues in existing worktrees - i would like to vary the session strategy, but not use the more private agent-shell--start function)

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've added tests where applicable.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
