### PR TITLE
Normalize missing MCP transport collection fields for ACP compatibility

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4488,19 +4488,34 @@ normalized server configs."
     (apply #'vector
            (mapcar (lambda (server)
                      (setq server (agent-shell--eval-dynamic-values server))
-                     (let ((normalized (copy-alist server)))
-                       (when (map-contains-key normalized 'args)
+                     (let* ((normalized (copy-alist server))
+                            (transport-type (map-elt normalized 'type)))
+                       ;; ACP requires transport-specific collection fields,
+                       ;; but users often omit them in hand-written configs.
+                       ;; Default them to empty vectors before vectorizing any
+                       ;; provided list values so agents like Codex accept the
+                       ;; resulting payload.
+                       (when (and (assoc 'command normalized)
+                                  (not (member transport-type '("http" "sse"))))
+                         (unless (assoc 'args normalized)
+                           (setf (alist-get 'args normalized) []))
+                         (unless (assoc 'env normalized)
+                           (setf (alist-get 'env normalized) [])))
+                       (when (member transport-type '("http" "sse"))
+                         (unless (assoc 'headers normalized)
+                           (setf (alist-get 'headers normalized) [])))
+                       (when (assoc 'args normalized)
                          (let ((args (map-elt normalized 'args)))
                            (when (listp args)
-                             (map-put! normalized 'args (apply #'vector args)))))
-                       (when (map-contains-key normalized 'env)
+                             (setf (alist-get 'args normalized) (apply #'vector args)))))
+                       (when (assoc 'env normalized)
                          (let ((env (map-elt normalized 'env)))
                            (when (listp env)
-                             (map-put! normalized 'env (apply #'vector env)))))
-                       (when (map-contains-key normalized 'headers)
+                             (setf (alist-get 'env normalized) (apply #'vector env)))))
+                       (when (assoc 'headers normalized)
                          (let ((headers (map-elt normalized 'headers)))
                            (when (listp headers)
-                             (map-put! normalized 'headers (apply #'vector headers)))))
+                             (setf (alist-get 'headers normalized) (apply #'vector headers)))))
                        normalized))
                    agent-shell-mcp-servers))))
 

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -933,13 +933,26 @@ code block content
                      (args . ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"])
                      (env . []))])))
 
-  ;; Test server without optional fields
+  ;; Test stdio transport defaults missing ACP collection fields
   (let ((agent-shell-mcp-servers
          '(((name . "simple")
             (command . "simple-server")))))
     (should (equal (agent-shell--mcp-servers)
                    [((name . "simple")
-                     (command . "simple-server"))]))))
+                     (command . "simple-server")
+                     (args . [])
+                     (env . []))])))
+
+  ;; Test HTTP transport defaults missing ACP collection fields
+  (let ((agent-shell-mcp-servers
+         '(((name . "remote")
+            (type . "http")
+            (url . "https://example.com/mcp")))))
+    (should (equal (agent-shell--mcp-servers)
+                   [((name . "remote")
+                     (type . "http")
+                     (url . "https://example.com/mcp")
+                     (headers . []))]))))
 
 (ert-deftest agent-shell--completion-bounds-test ()
   "Test `agent-shell--completion-bounds' function."


### PR DESCRIPTION
Error I have been getting

```
((:object (jsonrpc . "2.0") (id . 4)
  (error (code . -32602) (message . "Invalid params")
         (data . "data did not match any variant of untagged enum McpServer at line 1 column 118")))
 (:json
  . "{\"jsonrpc\":\"2.0\",\"id\":4,\"error\":{\"code\":-32602,\"message\":\"Invalid params\",\"data\":\"data did not match any variant of untagged enum McpServer at line 1 column 118\"}}"))

```

my config -

```emacs-lisp
(setq agent-shell-mcp-servers
        '(((name . "context7-mcp")
          (command . "context7-mcp"))
         ((name . "splunk-nonprod")
          (command . "/Users/mymac/GitRepos/mcp-scripts/splunk-mcp.py")
          (env . (((name . "SPLUNK_HOST") (value . "stage.splunk.com")))))
         ((name . "splunk-prod")
          (command . "/Users/mymac/GitRepos/mcp-scripts/splunk-mcp.py")
          (env . (((name . "SPLUNK_HOST") (value . "prod.splunk.com")))))))
```

This change makes MCP server normalization more robust when users provide minimal hand-written configs.

`agent-shell--mcp-servers` now fills in the collection fields ACP expects based on transport type before normalizing list values into vectors:

- stdio-style transports now default missing `args` and `env` to empty vectors
- HTTP/SSE transports now default missing `headers` to an empty vector

This prevents downstream consumers from receiving incomplete payloads when optional collection fields are omitted from user config.


## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [X] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
