### PR TITLE
Add agent-shell-macext to related projects

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,6 +52,7 @@ We now have a handful of additional packages to extend the =agent-shell= experie
 - [[https://github.com/xenodium/agent-shell-knockknock][agent-shell-knockknock]]: Notifications for =agent-shell= via [[https://github.com/konrad1977/knockknock][knockknock.el]].
 - [[https://github.com/zackattackz/agent-shell-notifications][agent-shell-notifications]]: Desktop notifications for =agent-shell= events.
 - [[https://github.com/ElleNajt/meta-agent-shell][meta-agent-shell]]: Multi-agent coordination system for =agent-shell= with inter-agent communication, task tracking, and project-level dispatching.
+- [[https://github.com/cxa/agent-shell-macext][agent-shell-macext]]: macOS-specific enhancements for =agent-shell=.
 
 * Icons
 


### PR DESCRIPTION
Adds <https://github.com/cxa/agent-shell-macext> to the related projects list in README.org.
