### PR TITLE
Add hook to customize @ file completion

### DIFF
--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -39,6 +39,15 @@
   :type 'boolean
   :group 'agent-shell)
 
+(defcustom agent-shell-file-completion-function
+  #'agent-shell--file-completion-at-point
+  "Function to call for @ file completion.
+Called with no arguments when @ is typed at a word boundary.
+If it returns non-nil, `completion-at-point' is not called.
+If it returns nil, falls through to the standard CAPF."
+  :type 'function
+  :group 'agent-shell)
+
 (defun agent-shell--completion-bounds (char-class trigger-char)
   "Find completion bounds for CHAR-CLASS, if TRIGGER-CHAR precedes them.
 Returns alist with :start and :end if TRIGGER-CHAR is found before
@@ -105,7 +114,8 @@ preventing spurious completions mid-word or in paths."
                  (memq (char-before (1- (point))) '(?\s ?\t ?\n))))
     (cond
      ((eq (char-before) ?@)
-      (completion-at-point))
+      (unless (funcall agent-shell-file-completion-function)
+        (completion-at-point)))
      ((and (eq (char-before) ?/)
            (agent-shell--command-completion-at-point))
       (completion-at-point)))))


### PR DESCRIPTION
# Problem

@ completion is hardcoded to CAPF/projectile, preventing fuzzy or alternative backends. 

Without corfu/company it faills through to *Completions* buffer with prefix mathching.

# Solution

- add `agent-shell-file-completion-function` defcustom to handle @ completion; if it returns non-nil, CAPF is skipped.
- Default behavior remains unchanged (CAPF still used when the custom function returns nil).

# My Hack
Because I dont' use courfu/company,  currently I use this hack to make agent-shell completion to use with another backend, it would be nice that agent-shell provide an option for user to provide custom function

```elisp
;; Fuzzy file completion for @ references using consult-snapfile.
    ;; Replaces prefix-based CAPF with minibuffer fuzzy search via vertico.
    (defun backbone/agent-shell-fuzzy-insert-file ()
      "Insert a file reference using consult-snapfile fuzzy matching.
On cancel, inserts bare @ for manual typing."
      (interactive)
      (if (not (fboundp 'consult-snapfile--async-source))
          (progn (self-insert-command 1 ?@)
                 (completion-at-point))
        (let* ((root (consult-snapfile--project-root))
               (default-directory root)
               (prompt (format "@ File [%s]: " (abbreviate-file-name root)))
               (selected (condition-case nil
                             (consult--read
                              #'consult-snapfile--async-source
                              :prompt prompt
                              :sort nil
                              :require-match t
                              :category 'file
                              :history 'file-name-history)
                           (quit nil))))
          (if selected
              (insert "@" (substring-no-properties selected) " ")
            (insert "@")))))

    (keymap-set agent-shell-mode-map "@" #'backbone/agent-shell-fuzzy-insert-file)

    ;; Route / command CAPF completion through minibuffer for fuzzy matching.
    (defun backbone/agent-shell-setup-fuzzy-completion ()
      "Use consult-completion-in-region for CAPF in agent-shell."
      (setq-local completion-in-region-function
                  #'consult-completion-in-region))
    (add-hook 'agent-shell-mode-hook #'backbone/agent-shell-setup-fuzzy-completion)
```

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
