### PR TITLE
Add agent-shell-org-transcript to Related projects

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,6 +53,7 @@ We now have a handful of additional packages to extend the =agent-shell= experie
 - [[https://github.com/zackattackz/agent-shell-notifications][agent-shell-notifications]]: Desktop notifications for =agent-shell= events.
 - [[https://github.com/ElleNajt/meta-agent-shell][meta-agent-shell]]: Multi-agent coordination system for =agent-shell= with inter-agent communication, task tracking, and project-level dispatching.
 - [[https://github.com/cxa/agent-shell-macext][agent-shell-macext]]: macOS-specific enhancements for =agent-shell=.
+- [[https://github.com/lllShamanlll/agent-shell-org-transcript][agent-shell-org-transcript]]: Org-mode transcripts for =agent-shell= sessions, with org-roam integration.
 
 * Icons
 


### PR DESCRIPTION
Add `agent-shell-org-transcript` to the Related projects section.

`agent-shell-org-transcript` saves agent-shell conversation transcripts as `.org` files in `org-roam-directory` (or a custom directory), converting markdown to org format on the fly. It also adds an `org-id`, `#+FILETAGS` with agent and project tags, making transcripts indexable and filterable in org-roam.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.