### PR TITLE
Fix removing queued messages

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -6812,16 +6812,15 @@ or select a specific request to remove."
             (selection (cdr (assoc (completing-read "Remove: " choices nil t) choices))))
        (list (unless (eq selection 'remove-all) selection)))))
   (if remove-index
-      (when-let* ((message "Remove? \"%s\"")
-                  (confirmed (y-or-n-p (format message
-                                               (nth remove-index
-                                                    (map-elt agent-shell--state :pending-requests)))))
-                  (pending (map-elt agent-shell--state :pending-requests))
-                  (new-pending (append (seq-take pending remove-index)
-                                       (seq-drop pending (1+ remove-index)))))
-        (map-put! agent-shell--state :pending-requests new-pending)
-        (message "Removed (%d remaining)"
-                 (length new-pending)))
+      (when (y-or-n-p (format "Remove? \"%s\""
+                              (nth remove-index
+                                   (map-elt agent-shell--state :pending-requests))))
+        (let* ((pending (map-elt agent-shell--state :pending-requests))
+               (new-pending (append (seq-take pending remove-index)
+                                    (seq-drop pending (1+ remove-index)))))
+          (map-put! agent-shell--state :pending-requests new-pending)
+          (message "Removed (%d remaining)"
+                   (length new-pending))))
     (when (y-or-n-p (format "Remove %d pending requests?"
                             (length (map-elt agent-shell--state :pending-requests))))
       (map-put! agent-shell--state :pending-requests nil)


### PR DESCRIPTION
The fix replaces `when-let*` with `when` + `let*`. The problem was that `when-let*` short-circuits on any `nil` binding when removing the last item, `new-pending` is `nil` (empty list), so the `map-put!` never executed and the request stayed in the queue.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
