### PR TITLE
Add programmatic query API: agent-shell-query and agent-shell-shell-buffer

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4930,6 +4930,98 @@ Returns a buffer object or nil."
                                          (current-buffer)))
                                 (agent-shell-buffers))))))
 
+;;;###autoload
+(cl-defun agent-shell-shell-buffer (&key viewport-buffer no-error no-create)
+  "Return an agent-shell buffer for the current context.
+
+A stable public API wrapping the internal resolver, intended for
+packages that integrate with agent-shell programmatically.
+
+Resolution order: viewport → current buffer → project buffers → prompt user.
+
+Example:
+  (agent-shell-shell-buffer)           ;; most recently used shell
+  (agent-shell-shell-buffer :no-error t) ;; nil instead of error when none found"
+  (agent-shell--shell-buffer :viewport-buffer viewport-buffer
+                              :no-error no-error
+                              :no-create no-create))
+
+(defun agent-shell--extract-last-response (buf start-pos)
+  "Extract plain-text agent response from BUF added after START-POS.
+
+Strips the echoed input and <shell-maker-end-of-prompt> separator,
+then strips the trailing shell prompt, returning only the response text.
+
+Example:
+  start-pos points to position before query was inserted
+  → returns \"Paris\" from a \"What is the capital of France?\" query"
+  (with-current-buffer buf
+    (let ((raw (buffer-substring-no-properties start-pos (point-max)))
+          (prompt-re (map-elt (agent-shell-get-config buf) :shell-prompt-regexp)))
+      (string-trim
+       (if (string-match (regexp-quote "<shell-maker-end-of-prompt>") raw)
+           (let ((after (substring raw (match-end 0))))
+             (if (and prompt-re (string-match (concat prompt-re ".*\\'") after))
+                 (substring after 0 (match-beginning 0))
+               after))
+         raw)))))
+
+(cl-defun agent-shell-query (&key text shell-buffer on-complete on-error timeout)
+  "Send TEXT to SHELL-BUFFER and call ON-COMPLETE with the response string.
+
+ON-COMPLETE is called with the plain-text response string.
+ON-ERROR is called with an error message string.
+TIMEOUT is seconds to wait before giving up (default: 60).
+SHELL-BUFFER defaults to the most recently used agent-shell buffer.
+
+Returns a cancel function — call it with no args to abort the in-flight
+query and clean up all subscriptions.
+
+Example:
+  (agent-shell-query
+   :text \"What is 2+2?\"
+   :on-complete (lambda (response) (message \"Got: %s\" response))
+   :on-error    (lambda (msg)      (message \"Error: %s\" msg)))"
+  (let* ((buf (or shell-buffer (agent-shell-shell-buffer)))
+         (timeout (or timeout 60))
+         (start (with-current-buffer buf (point-max)))
+         (tokens nil)
+         (timer nil)
+         (cancel (lambda ()
+                   (when timer (cancel-timer timer))
+                   (with-current-buffer buf
+                     (dolist (tok tokens)
+                       (agent-shell-unsubscribe :subscription tok))))))
+    (setq timer
+          (run-at-time timeout nil
+                       (lambda ()
+                         (funcall cancel)
+                         (when on-error
+                           (funcall on-error
+                                    (format "agent-shell-query: timed out after %ds"
+                                            timeout))))))
+    (push (agent-shell-subscribe-to
+           :shell-buffer buf
+           :event 'turn-complete
+           :on-event (lambda (_data)
+                       (let ((response (agent-shell--extract-last-response buf start)))
+                         (funcall cancel)
+                         (when on-complete (funcall on-complete response)))))
+          tokens)
+    (push (agent-shell-subscribe-to
+           :shell-buffer buf
+           :event 'error
+           :on-event (lambda (data)
+                       (funcall cancel)
+                       (when on-error
+                         (funcall on-error
+                                  (format "[%s] %s"
+                                          (map-elt data :code)
+                                          (map-elt data :message))))))
+          tokens)
+    (agent-shell-insert :text text :submit t :no-focus t :shell-buffer buf)
+    cancel))
+
 (defun agent-shell--input ()
   "Return shell input (not yet submitted)."
   (when-let* ((shell-buffer (agent-shell--shell-buffer))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4943,84 +4943,8 @@ Example:
   (agent-shell-shell-buffer)           ;; most recently used shell
   (agent-shell-shell-buffer :no-error t) ;; nil instead of error when none found"
   (agent-shell--shell-buffer :viewport-buffer viewport-buffer
-                              :no-error no-error
-                              :no-create no-create))
-
-(defun agent-shell--extract-last-response (buf start-pos)
-  "Extract plain-text agent response from BUF added after START-POS.
-
-Strips the echoed input and <shell-maker-end-of-prompt> separator,
-then strips the trailing shell prompt, returning only the response text.
-
-Example:
-  start-pos points to position before query was inserted
-  → returns \"Paris\" from a \"What is the capital of France?\" query"
-  (with-current-buffer buf
-    (let ((raw (buffer-substring-no-properties start-pos (point-max)))
-          (prompt-re (map-elt (agent-shell-get-config buf) :shell-prompt-regexp)))
-      (string-trim
-       (if (string-match (regexp-quote "<shell-maker-end-of-prompt>") raw)
-           (let ((after (substring raw (match-end 0))))
-             (if (and prompt-re (string-match (concat prompt-re ".*\\'") after))
-                 (substring after 0 (match-beginning 0))
-               after))
-         raw)))))
-
-(cl-defun agent-shell-query (&key text shell-buffer on-complete on-error timeout)
-  "Send TEXT to SHELL-BUFFER and call ON-COMPLETE with the response string.
-
-ON-COMPLETE is called with the plain-text response string.
-ON-ERROR is called with an error message string.
-TIMEOUT is seconds to wait before giving up (default: 60).
-SHELL-BUFFER defaults to the most recently used agent-shell buffer.
-
-Returns a cancel function — call it with no args to abort the in-flight
-query and clean up all subscriptions.
-
-Example:
-  (agent-shell-query
-   :text \"What is 2+2?\"
-   :on-complete (lambda (response) (message \"Got: %s\" response))
-   :on-error    (lambda (msg)      (message \"Error: %s\" msg)))"
-  (let* ((buf (or shell-buffer (agent-shell-shell-buffer)))
-         (timeout (or timeout 60))
-         (start (with-current-buffer buf (point-max)))
-         (tokens nil)
-         (timer nil)
-         (cancel (lambda ()
-                   (when timer (cancel-timer timer))
-                   (with-current-buffer buf
-                     (dolist (tok tokens)
-                       (agent-shell-unsubscribe :subscription tok))))))
-    (setq timer
-          (run-at-time timeout nil
-                       (lambda ()
-                         (funcall cancel)
-                         (when on-error
-                           (funcall on-error
-                                    (format "agent-shell-query: timed out after %ds"
-                                            timeout))))))
-    (push (agent-shell-subscribe-to
-           :shell-buffer buf
-           :event 'turn-complete
-           :on-event (lambda (_data)
-                       (let ((response (agent-shell--extract-last-response buf start)))
-                         (funcall cancel)
-                         (when on-complete (funcall on-complete response)))))
-          tokens)
-    (push (agent-shell-subscribe-to
-           :shell-buffer buf
-           :event 'error
-           :on-event (lambda (data)
-                       (funcall cancel)
-                       (when on-error
-                         (funcall on-error
-                                  (format "[%s] %s"
-                                          (map-elt data :code)
-                                          (map-elt data :message))))))
-          tokens)
-    (agent-shell-insert :text text :submit t :no-focus t :shell-buffer buf)
-    cancel))
+                             :no-error no-error
+                             :no-create no-create))
 
 (defun agent-shell--input ()
   "Return shell input (not yet submitted)."

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4940,8 +4940,8 @@ packages that integrate with agent-shell programmatically.
 Resolution order: viewport → current buffer → project buffers → prompt user.
 
 Example:
-  (agent-shell-shell-buffer)           ;; most recently used shell
-  (agent-shell-shell-buffer :no-error t) ;; nil instead of error when none found"
+  (agent-shell-shell-buffer)
+  (agent-shell-shell-buffer :no-error t)"
   (agent-shell--shell-buffer :viewport-buffer viewport-buffer
                              :no-error no-error
                              :no-create no-create))


### PR DESCRIPTION
Hi @xenodium I was trying to get org-babel for AI prompts but I don't like the idea of configuring another client like https://github.com/karthink/gptel or https://github.com/rksm/org-ai so I have this https://github.com/eddof13/ob-agent-shell to get that support while reusing agent-shell- I had claude suggest some API hooks to clean up the code,  maybe this will be useful or you have some alternative suggestion?

## Summary

- `agent-shell-shell-buffer` — public wrapper around `agent-shell--shell-buffer`
- `agent-shell--extract-last-response` — extracts plain-text response from a buffer position
- `agent-shell-query` — programmatic async query function with cancel support

## Motivation

I built [ob-agent-shell](https://github.com/eddof13/ob-agent-shell), an org-babel backend that routes `#+begin_src agent-shell` blocks through a running agent-shell session. Rather than configure a second AI client for org, it reuses whatever agent-shell buffer you already have open.

To make this work I needed to:
1. Resolve a shell buffer from outside agent-shell (buffer resolution)
2. Send a query programmatically and capture the response

Both require reaching into private internals (`agent-shell--shell-buffer`, manual subscribe/unsubscribe/extract). That works today but is fragile across refactors.

These three additions provide a stable surface for that use case — and for any other package wanting to drive agent-shell programmatically.

## API

```elisp
;; Get the current shell buffer (same heuristic as internal code)
(agent-shell-shell-buffer)
(agent-shell-shell-buffer :no-error t)

;; Send a query and handle the response asynchronously
(agent-shell-query
 :text "What is 2+2?"
 :on-complete (lambda (response) (message "Got: %s" response))
 :on-error    (lambda (msg)      (message "Error: %s" msg)))

;; Cancel if needed
(let ((cancel (agent-shell-query :text "..." :on-complete ...)))
  (funcall cancel))
```

## Impact on ob-agent-shell

With these merged, ob-agent-shell's core [simplifies significantly](https://github.com/eddof13/ob-agent-shell/pull/1) — the subscribe/unsubscribe/extract/timeout logic all moves into `agent-shell-query` where it belongs.

## Notes

- `agent-shell-query` returns a cancel thunk so callers can abort in-flight requests
- Follows existing style: `cl-defun`/`&key`, `map.el`, `seq.el`, `when-let`
- `agent-shell--extract-last-response` is private (`--`) since it's an implementation detail of `agent-shell-query`; only `agent-shell-shell-buffer` and `agent-shell-query` are new public API
- Happy to split into two separate PRs if preferred