### PR TITLE
Keep buffer name on agent-shell-reload and -restart.

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -967,6 +967,7 @@ Works from both shell and viewport buffers."
                             (derived-mode-p 'agent-shell-viewport-edit-mode)))
          (shell-buffer (or (agent-shell--current-shell)
                            (user-error "Not in a shell or viewport buffer")))
+         (shell-buffer-name (buffer-name shell-buffer))
          (strategy (if (eq (buffer-local-value 'agent-shell-session-strategy shell-buffer)
                            'new-deferred)
                        'new-deferred
@@ -985,6 +986,7 @@ Works from both shell and viewport buffers."
                              :session-id session-id
                              :new-session t
                              :no-focus t)))
+      (shell-maker-set-buffer-name new-shell-buffer shell-buffer-name)
       (if (or from-viewport agent-shell-prefer-viewport-interaction)
           (agent-shell-viewport--show-buffer
            :shell-buffer new-shell-buffer)


### PR DESCRIPTION
I do this frequently to get out of situations where the ACP client is stuck or to clean out history, would be nice to keep the name then.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
