### PR TITLE
Add agent-recall to related projects

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,6 +63,7 @@ We now have a handful of additional packages to extend the =agent-shell= experie
 - [[https://github.com/cxa/agent-shell-macext][agent-shell-macext]]: macOS-specific enhancements for =agent-shell=.
 - [[https://github.com/lllShamanlll/agent-shell-org-transcript][agent-shell-org-transcript]]: Org-mode transcripts for =agent-shell= sessions, with org-roam integration.
 - [[https://github.com/eddof13/ob-agent-shell][ob-agent-shell]]: Org Babel backend for executing =agent-shell= source blocks.
+- [[https://github.com/Marx-A00/agent-recall][agent-recall]]: Search, browse, and resume =agent-shell= conversation transcripts.
 
 * Icons
 


### PR DESCRIPTION
Adds [agent-recall](https://github.com/Marx-A00/agent-recall) to the related projects section.

agent-recall lets you search, browse (with live preview), and resume agent-shell conversation transcripts. Available on [MELPA](https://melpa.org/#/agent-recall).

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've updated documentation where necessary.