### PR TITLE
Avoid gitignore update for external data dirs

### DIFF
--- a/README.org
+++ b/README.org
@@ -522,7 +522,7 @@ Optional: to prevent the agent running inside the container to access your local
 
 *** Data storage location
 
-By default, agent-shell stores per-project data (transcripts, screenshots, etc.) under a =.agent-shell/= directory in the project root, and automatically adds that directory to =.gitignore= the first time it is created.  This is a one-time operation: removing the entry from =.gitignore= will not cause it to be re-added.
+By default, agent-shell stores per-project data (transcripts, screenshots, etc.) under a =.agent-shell/= directory in the project root, and automatically adds that directory to =.gitignore= the first time it is created.  This is a one-time operation: removing the entry from =.gitignore= will not cause it to be re-added.  If you configure =agent-shell-dot-subdir-function= to store data outside the project =.agent-shell/= directory, agent-shell will not update the project's =.gitignore=.
 
 You can change where this data is stored by setting =agent-shell-dot-subdir-function= to a custom function.  The function receives one argument, SUBDIR (e.g. ="screenshots"=), and must return the absolute path to that subdirectory (without creating it).
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2405,10 +2405,10 @@ For example:
 (defun agent-shell--dot-subdir (subdir)
   "Return path to SUBDIR for `agent-shell' data, creating it if needed.
 Calls `agent-shell-dot-subdir-function' to resolve the path.
-When the directory is first created inside a git repo and
-.agent-shell/ is not yet ignored, automatically add it to .gitignore.
-This gitignore update is a one-time operation: if the entry is later
-removed from .gitignore it will not be re-added."
+When the directory is first created under the project .agent-shell/ directory
+inside a git repo and .agent-shell/ is not yet ignored, automatically add it
+to .gitignore.  This gitignore update is a one-time operation: if the entry is
+later removed from .gitignore it will not be re-added."
   (unless (functionp agent-shell-dot-subdir-function)
     (error "agent-shell-dot-subdir-function must be set to a function"))
   (let ((dir (funcall agent-shell-dot-subdir-function subdir)))
@@ -2416,8 +2416,23 @@ removed from .gitignore it will not be re-added."
       (error "Failed to resolve agent-shell data directory (subdir: %s).  Resulting directory is not a non-empty string (dir: %s)" subdir dir))
     (unless (file-directory-p dir)
       (make-directory dir t)
-      (agent-shell--ensure-gitignore (agent-shell-cwd)))
+      (when (agent-shell--dot-subdir-in-repo-p dir)
+        (agent-shell--ensure-gitignore (agent-shell-cwd))))
     dir))
+
+(defun agent-shell--dot-subdir-in-repo-p (dir)
+  "Return non-nil when DIR is under the project .agent-shell directory.
+
+For example:
+
+  (agent-shell--dot-subdir-in-repo-p \"/path/to/project/.agent-shell/screenshots\")
+  => t
+
+  (agent-shell--dot-subdir-in-repo-p \"/home/user/.emacs.d/agent-shell/project/screenshots\")
+  => nil"
+  (file-in-directory-p dir
+                       (file-name-as-directory
+                        (expand-file-name ".agent-shell" (agent-shell-cwd)))))
 
 (defun agent-shell--ensure-gitignore (project-root)
   "If .agent-shell/ is not ignored under PROJECT-ROOT, add it to .gitignore."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1956,6 +1956,38 @@ code block content
             (should (equal (agent-shell--dot-subdir "screenshots") expected-dir))))
       (delete-directory temp-dir t))))
 
+(ert-deftest agent-shell--dot-subdir-ensures-gitignore-for-in-repo-directory-test ()
+  "Test that `agent-shell--dot-subdir' ensures gitignore for in-repo data."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (ensure-gitignore-called-with nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () temp-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore)
+                   (lambda (project-root)
+                     (setq ensure-gitignore-called-with project-root))))
+          (let ((agent-shell-dot-subdir-function #'agent-shell--dot-subdir-in-repo))
+            (agent-shell--dot-subdir "screenshots")
+            (should (equal ensure-gitignore-called-with temp-dir))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--dot-subdir-skips-gitignore-for-external-directory-test ()
+  "Test that `agent-shell--dot-subdir' skips gitignore for external data."
+  (let ((project-dir (make-temp-file "agent-shell-project" t))
+        (data-dir (make-temp-file "agent-shell-data" t))
+        (ensure-gitignore-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () project-dir))
+                  ((symbol-function 'agent-shell--ensure-gitignore)
+                   (lambda (_project-root)
+                     (setq ensure-gitignore-called t))))
+          (let ((agent-shell-dot-subdir-function
+                 (lambda (subdir)
+                   (expand-file-name subdir data-dir))))
+            (agent-shell--dot-subdir "screenshots")
+            (should-not ensure-gitignore-called)))
+      (delete-directory project-dir t)
+      (delete-directory data-dir t))))
+
 (ert-deftest agent-shell--dot-subdir-noop-if-directory-exists-test ()
   "Test that `agent-shell--dot-subdir' does not error if the directory already exists."
   (let* ((temp-dir (make-temp-file "agent-shell-test" t))


### PR DESCRIPTION
## Summary

When users customize `agent-shell-dot-subdir-function` to store data outside the project tree, `agent-shell--dot-subdir` still updates the project's `.gitignore` after creating the configured directory.

The root cause is that `.gitignore` handling is tied only to directory creation. It does not check whether the resolved directory is actually under the default project `.agent-shell/` location.

This change keeps the current default behavior for project-local `.agent-shell/` data, but skips the `.gitignore` update when the resolved data directory is outside the project `.agent-shell/` directory.

Here is my emacs config for full context:

``` elisp
(defun silex/agent-shell-toggle-project ()
  "Toggle the current project's agent shell without DWIM context capture."
  (interactive)
  (let* ((default-directory (or (projectile-project-root) default-directory))
          (project-shell (seq-first (agent-shell-project-buffers)))
          (shell-buffer
            (or project-shell
              (agent-shell--start
                :config (or (seq-find (lambda (config)
                                        (eq (map-elt config :identifier) 'codex))
                                      agent-shell-agent-configs)
                            (error "No Codex agent config found"))
                :no-focus t
                :new-session t
                :session-strategy agent-shell-session-strategy))))
    (if-let ((window (get-buffer-window shell-buffer)))
      (if (and (> (count-windows) 1)
            (not (bound-and-true-p transient--prefix)))
        (delete-window window)
        (switch-to-prev-buffer))
      (if agent-shell-prefer-viewport-interaction
        (agent-shell-viewport--show-buffer :shell-buffer shell-buffer)
        (agent-shell--display-buffer shell-buffer)))))

(defun silex/agent-shell-emacs-directory-subdir (subdir)
  (let* ((cwd (string-remove-suffix "/" (agent-shell-cwd)))
          (sanitized (replace-regexp-in-string "/" "-" (string-remove-prefix "/" cwd))))
    (expand-file-name subdir (locate-user-emacs-file (concat "agent-shell/" sanitized)))))

(use-package agent-shell
  :ensure t
  :ensure-system-package
  (codex-acp . "npm install -g @zed-industries/codex-acp")
  :bind
  ("C-c x" . silex/agent-shell-toggle-project)
  :config
  (setopt agent-shell-dot-subdir-function #'silex/agent-shell-emacs-directory-subdir))
```

## Changes

- Add `agent-shell--dot-subdir-in-repo-p` to identify project-local `.agent-shell/` data directories.
- Gate `agent-shell--ensure-gitignore` behind that path check.
- Cover the in-repo and external-directory cases with ERT tests.
- Clarify the README storage-location behavior.

## Validation

Tests were not run locally.
