### PR TITLE
Use helper function from shell-maker rather than eob

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2909,7 +2909,7 @@ by default, RENDER-BODY-IMAGES to enable inline image rendering in body."
                 (derived-mode-p 'agent-shell-viewport-view-mode))))
     (with-current-buffer viewport-buffer
       (let ((inhibit-read-only t)
-            (auto-scroll (eobp))
+            (auto-scroll (shell-maker--should-auto-scroll-p))
             (saved-point (point-marker)))
         (when-let* ((range (agent-shell-ui-update-fragment
                             (agent-shell-ui-make-fragment-model


### PR DESCRIPTION
This relies on a [pr](https://github.com/xenodium/shell-maker/pull/30) in shell-maker but it makes it so scrolling back while a wall of text is flooding in doesn't keep jumping to the bottom.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
