### PR TITLE
Fix error when cancelling session selection prompt

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3751,14 +3751,17 @@ SUBSCRIPTION is a token returned by `agent-shell-subscribe-to'."
   "Emit an EVENT to matching subscribers.
 EVENT is a symbol identifying the event.
 DATA is an optional alist of event-specific data."
-  (let ((event-alist (list (cons :event event))))
+  (let ((state (agent-shell--state))
+        (event-alist (list (cons :event event))))
     (when data
       (push (cons :data data) event-alist))
-    (dolist (sub (map-elt (agent-shell--state) :event-subscriptions))
-      (when (or (not (map-elt sub :event))
-                (eq (map-elt sub :event) event))
-        (with-current-buffer (map-elt (agent-shell--state) :buffer)
-          (funcall (map-elt sub :on-event) event-alist))))))
+    (let ((buffer (map-elt state :buffer)))
+      (dolist (sub (map-elt state :event-subscriptions))
+        (when (and (buffer-live-p buffer)
+                   (or (not (map-elt sub :event))
+                       (eq (map-elt sub :event) event)))
+          (with-current-buffer buffer
+            (funcall (map-elt sub :on-event) event-alist)))))))
 
 (cl-defun agent-shell--start-idle-timer (&key event data)
   "Start the idle timer for EVENT with DATA.


### PR DESCRIPTION
Cancelling the session prompt with C-g triggers two subscribers: one kills the shell buffer, the other hides the "Loading..." message. The `agent-shell--emit-event` loop called `agent-shell--state` on each iteration to get the buffer. After the first subscriber killed the buffer, the second iteration called `agent-shell--state` in whatever buffer Emacs fell back to, failing the `derived-mode-p` check.

Fix: capture state and buffer once before the loop, skip remaining subscribers if the buffer dies mid-iteration.



## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
