### PR TITLE
Update Pi coding agent logo to look more official

### DIFF
--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -116,16 +116,18 @@ environment variables are required by default."
   "Pi ASCII art."
   (let* ((is-dark (eq (frame-parameter nil 'background-mode) 'dark))
          (text (string-trim "
-        ██████╗ ██╗
-        ██╔══██╗██║
-        ██████╔╝██║
-        ██╔═══╝ ██║
-        ██║     ██║
-        ╚═╝     ╚═╝
+        ████████████
+        ████████████
+        ████    ████
+        ████    ████
+        ████████    ████
+        ████████    ████
+        ████        ████
+        ████        ████
 " "\n")))
     (propertize text 'font-lock-face (if is-dark
-                                         '(:foreground "#ff6b6b" :inherit fixed-pitch)
-                                       '(:foreground "#c0392b" :inherit fixed-pitch)))))
+                                         '(:foreground "#ffffff" :inherit fixed-pitch)
+                                       '(:foreground "#000000" :inherit fixed-pitch)))))
 
 (provide 'agent-shell-pi)
 


### PR DESCRIPTION
Not the most important, but fixing Pi logo to be more like official logo.
See: https://pi.dev/press-kit for official logo/badges.

Screenshot:
<img width="622" height="458" alt="image" src="https://github.com/user-attachments/assets/4b76bbed-129b-4df8-97ad-6373d20e8fdd" />

Issue: https://github.com/xenodium/agent-shell/issues/560

----

Thank you for contributing to agent-shell!

## Checklist

- [x ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
