### PR TITLE
Fix map-not-inplace error when seeding :title on new sessions

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4362,7 +4362,8 @@ Falls back to latest session in batch mode (e.g. tests)."
                                                                   `((:model-id . ,(map-elt model 'modelId))
                                                                     (:name . ,(map-elt model 'name))
                                                                     (:description . ,(map-elt model 'description))))
-                                                                (map-nested-elt acp-response '(models availableModels))))))
+                                                                (map-nested-elt acp-response '(models availableModels))))
+                                          (cons :title (map-nested-elt agent-shell--state '(:session :title)))))
                  (agent-shell--update-fragment
                   :state agent-shell--state
                   :block-id "starting"


### PR DESCRIPTION
## Summary

`agent-shell--initiate-new-session` builds the `:session` alist without a `:title` cell, but `agent-shell--set-session-title` (called from `agent-shell--send-command` on the first prompt) does `(map-put! session :title ...)`. Since `:title` is missing from the alist, `map-put!` cannot update in place and signals `map-not-inplace`, which surfaces as `Cannot modify map in-place: ((:id . ...) (:mode-id . ...) ...)` in `*Messages*` and aborts title seeding for every fresh session.

dbc1702 added `:title` to `agent-shell--set-session-from-response`; this PR mirrors that change so the new-session path also has the key present.

## Repro (before the fix)

```elisp
(require 'map)
(let ((state (list (cons :session (list (cons :id "uuid")
                                         (cons :mode-id "auto")
                                         (cons :modes nil)
                                         (cons :model-id "opus[1m]")
                                         (cons :models nil))))))
  ;; what agent-shell--set-session-title does:
  (map-put! (map-elt state :session) :title "Hello"))
;; => (map-not-inplace ((:id . "uuid") (:mode-id . "auto") ...))
```

Adding `(cons :title nil)` (or the existing-state lookup used in `--set-session-from-response`) to the new-session alist makes the same call succeed.

## Test plan

- [ ] Start a fresh agent-shell (any agent that goes through `agent-shell--initiate-new-session`, e.g. Claude Code) and submit a first prompt — no `Cannot modify map in-place` in `*Messages*`, and `(map-nested-elt agent-shell--state '(:session :title))` is set to the prompt text.
- [ ] Resumed/loaded sessions still work (covered by the existing `--set-session-from-response` path).

## Checklist

- [ ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.