### PR TITLE
Enable @ and / completion when reading queued prompts

### DIFF
--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -56,6 +56,23 @@ the word, nil otherwise."
 (defvar-local agent-shell--project-files-cache nil
   "Session-scoped cache for project files completion.")
 
+(defvar-local agent-shell-completion--shell-buffer nil
+  "Override shell buffer to source completion data from.
+When non-nil, file and command CAPFs read project files and
+available commands from this buffer instead of the current one.
+Set in non-shell buffers (e.g. the minibuffer) that want to offer
+@ and / completion against a specific shell.")
+
+(defun agent-shell-completion--source-buffer ()
+  "Return the buffer to source completion data from.
+Returns the override buffer when set and live, otherwise the current
+buffer.  Returns nil if the override is set but its buffer is dead."
+  (cond
+   ((null agent-shell-completion--shell-buffer)
+    (current-buffer))
+   ((buffer-live-p agent-shell-completion--shell-buffer)
+    agent-shell-completion--shell-buffer)))
+
 (defun agent-shell--clear-project-files-cache ()
   "Clear project files cache when completion session ends."
   (unless completion-in-region-mode
@@ -65,13 +82,15 @@ the word, nil otherwise."
 
 (defun agent-shell--file-completion-at-point ()
   "Complete project files after @."
-  (when-let* ((bounds (agent-shell--completion-bounds "[:alnum:]/_.-" ?@)))
-    (unless agent-shell--project-files-cache
-      (setq agent-shell--project-files-cache (agent-shell--project-files))
-      (add-hook 'completion-in-region-mode-hook
-                #'agent-shell--clear-project-files-cache nil t))
+  (when-let ((source (agent-shell-completion--source-buffer))
+             (bounds (agent-shell--completion-bounds "[:alnum:]/_.-" ?@)))
+    (with-current-buffer source
+      (unless agent-shell--project-files-cache
+        (setq agent-shell--project-files-cache (agent-shell--project-files))
+        (add-hook 'completion-in-region-mode-hook
+                  #'agent-shell--clear-project-files-cache nil t)))
     (list (map-elt bounds :start) (map-elt bounds :end)
-          agent-shell--project-files-cache
+          (buffer-local-value 'agent-shell--project-files-cache source)
           :exclusive 'no
           :company-kind (lambda (f) (if (string-suffix-p "/" f) 'folder 'file))
           :exit-function #'agent-shell--capf-exit-with-space)))
@@ -79,9 +98,10 @@ the word, nil otherwise."
 (defun agent-shell--command-completion-at-point ()
   "Complete available commands after /."
   (when-let* ((bounds (agent-shell--completion-bounds "[:alnum:]_-" ?/))
-              (commands (with-current-buffer (agent-shell--shell-buffer
-                                              :no-error t :no-create t)
-                          (map-elt agent-shell--state :available-commands)))
+              (source (or (agent-shell-completion--source-buffer)
+                          (agent-shell--shell-buffer :no-error t :no-create t)))
+              (commands (map-elt (buffer-local-value 'agent-shell--state source)
+                                 :available-commands))
               (descriptions (mapcar (lambda (c)
                                       (cons (map-elt c 'name)
                                             (map-elt c 'description)))
@@ -109,6 +129,38 @@ preventing spurious completions mid-word or in paths."
      ((and (eq (char-before) ?/)
            (agent-shell--command-completion-at-point))
       (completion-at-point)))))
+
+(defun agent-shell-completion--setup-minibuffer (shell-buffer)
+  "Enable @ and / completion in the current minibuffer for SHELL-BUFFER.
+
+@ always completes project files.  / completes available agent commands
+when SHELL-BUFFER has received them via ACP; if not, / is a no-op.
+
+No-ops when SHELL-BUFFER does not have `agent-shell-completion-mode'
+enabled, so user preference set in the shell carries over."
+  (when (and (buffer-live-p shell-buffer)
+             (buffer-local-value 'agent-shell-completion-mode shell-buffer))
+    (setq-local agent-shell-completion--shell-buffer shell-buffer)
+    (add-hook 'completion-at-point-functions
+              #'agent-shell--file-completion-at-point nil t)
+    (add-hook 'completion-at-point-functions
+              #'agent-shell--command-completion-at-point nil t)
+    (add-hook 'post-self-insert-hook
+              #'agent-shell--trigger-completion-at-point nil t)
+    (add-hook 'minibuffer-exit-hook
+              #'agent-shell-completion--cleanup-minibuffer nil t)))
+
+(defun agent-shell-completion--cleanup-minibuffer ()
+  "Remove `agent-shell' completion hooks from the minibuffer."
+  (kill-local-variable 'agent-shell-completion--shell-buffer)
+  (remove-hook 'completion-at-point-functions
+               #'agent-shell--file-completion-at-point t)
+  (remove-hook 'completion-at-point-functions
+               #'agent-shell--command-completion-at-point t)
+  (remove-hook 'post-self-insert-hook
+               #'agent-shell--trigger-completion-at-point t)
+  (remove-hook 'minibuffer-exit-hook
+               #'agent-shell-completion--cleanup-minibuffer t))
 
 (define-minor-mode agent-shell-completion-mode
   "Toggle agent shell completion with @ or / prefix."

--- a/agent-shell-ui.el
+++ b/agent-shell-ui.el
@@ -70,88 +70,100 @@ When EXPANDED is non-nil, body will be expanded by default.
 When NO-UNDO is non-nil, disable undo recording for this operation.
 
 For existing blocks, the current expansion state is preserved unless overridden."
-  (save-mark-and-excursion
-    (let* ((inhibit-read-only t)
-           (buffer-undo-list (if no-undo t buffer-undo-list))
-           (namespace-id (map-elt model :namespace-id))
-           (qualified-id (format "%s-%s" namespace-id (map-elt model :block-id)))
-           (new-label-left (map-elt model :label-left))
-           (new-label-right (map-elt model :label-right))
-           (new-body (map-elt model :body))
-           (block-start nil)
-           (padding-start nil)
-           (padding-end nil)
-           (match (save-mark-and-excursion
-                    (goto-char (point-max))
-                    (text-property-search-backward
-                     'agent-shell-ui-state nil
-                     (lambda (_ state)
-                       (equal (map-elt state :qualified-id) qualified-id))
-                     t))))
-      (when (or new-label-left new-label-right new-body)
-        (when match
-          (goto-char (prop-match-beginning match)))
-        (if (and match (not create-new))
-            ;; Found existing block - delete and regenerate
-            (let* ((existing-model (agent-shell-ui--read-fragment-at-point))
-                   (state (get-text-property (point) 'agent-shell-ui-state))
-                   (existing-body (map-elt existing-model :body))
-                   (block-end (prop-match-end match))
-                   (final-body (if new-body
-                                   (if (and append existing-body)
-                                       (concat existing-body new-body)
-                                     new-body)
-                                 existing-body))
-                   (final-model (list (cons :namespace-id namespace-id)
-                                      (cons :block-id (map-elt model :block-id))
-                                      (cons :label-left (or new-label-left
-                                                            (map-elt existing-model :label-left)))
-                                      (cons :label-right (or new-label-right
-                                                             (map-elt existing-model :label-right)))
-                                      (cons :body final-body))))
-              (setq block-start (prop-match-beginning match))
+  (let* ((inhibit-read-only t)
+         (buffer-undo-list (if no-undo t buffer-undo-list))
+         (window (get-buffer-window (current-buffer)))
+         (saved-point (point))
+         (saved-mark (mark t))
+         (saved-mark-active mark-active)
+         (saved-window-start (and window (window-start window)))
+         (namespace-id (map-elt model :namespace-id))
+         (qualified-id (format "%s-%s" namespace-id (map-elt model :block-id)))
+         (new-label-left (map-elt model :label-left))
+         (new-label-right (map-elt model :label-right))
+         (new-body (map-elt model :body))
+         (block-start nil)
+         (padding-start nil)
+         (padding-end nil)
+         (match (save-mark-and-excursion
+                  (goto-char (point-max))
+                  (text-property-search-backward
+                   'agent-shell-ui-state nil
+                   (lambda (_ state)
+                     (equal (map-elt state :qualified-id) qualified-id))
+                   t))))
+    (unwind-protect
+        (progn
+          (when (or new-label-left new-label-right new-body)
+            (when match
+              (goto-char (prop-match-beginning match)))
+            (if (and match (not create-new))
+                ;; Found existing block - delete and regenerate
+                (let* ((existing-model (agent-shell-ui--read-fragment-at-point))
+                       (state (get-text-property (point) 'agent-shell-ui-state))
+                       (existing-body (map-elt existing-model :body))
+                       (block-end (prop-match-end match))
+                       (final-body (if new-body
+                                       (if (and append existing-body)
+                                           (concat existing-body new-body)
+                                         new-body)
+                                     existing-body))
+                       (final-model (list (cons :namespace-id namespace-id)
+                                          (cons :block-id (map-elt model :block-id))
+                                          (cons :label-left (or new-label-left
+                                                                (map-elt existing-model :label-left)))
+                                          (cons :label-right (or new-label-right
+                                                                 (map-elt existing-model :label-right)))
+                                          (cons :body final-body))))
+                  (setq block-start (prop-match-beginning match))
 
-              ;; Safely replace existing block using narrow-to-region
-              (save-excursion
-                (goto-char block-start)
-                (skip-chars-backward "\n")
-                (setq padding-start (point)))
+                  ;; Safely replace existing block using narrow-to-region
+                  (save-excursion
+                    (goto-char block-start)
+                    (skip-chars-backward "\n")
+                    (setq padding-start (point)))
 
-              ;; Replace block
-              (delete-region block-start block-end)
-              (goto-char block-start)
-              (agent-shell-ui--insert-fragment final-model qualified-id
-                                               (not (map-elt state :collapsed))
-                                               navigation)
-              (setq padding-end (point)))
+                  ;; Replace block
+                  (delete-region block-start block-end)
+                  (goto-char block-start)
+                  (agent-shell-ui--insert-fragment final-model qualified-id
+                                                   (not (map-elt state :collapsed))
+                                                   navigation)
+                  (setq padding-end (point)))
 
-          ;; Not found or create-new - insert new block
-          (goto-char (point-max))
-          (setq padding-start (point))
-          (agent-shell-ui--insert-read-only (agent-shell-ui--required-newlines 2))
-          (setq block-start (point))
-          (agent-shell-ui--insert-fragment model qualified-id expanded navigation)
-          (agent-shell-ui--insert-read-only "\n\n")
-          (setq padding-end (point))))
-      (when on-post-process
-        (funcall on-post-process))
-      (when-let ((block-range (agent-shell-ui--block-range :position block-start)))
-        (list (cons :block block-range)
-              (cons :body (agent-shell-ui--nearest-range-matching-property
-                           :property 'agent-shell-ui-section :value 'body
-                           :from (map-elt block-range :start)
-                           :to (map-elt block-range :end)))
-              (cons :label-left (agent-shell-ui--nearest-range-matching-property
-                                 :property 'agent-shell-ui-section :value 'label-left
-                                 :from (map-elt block-range :start)
-                                 :to (map-elt block-range :end)))
-              (cons :label-right (agent-shell-ui--nearest-range-matching-property
-                                  :property 'agent-shell-ui-section :value 'label-right
-                                  :from (map-elt block-range :start)
-                                  :to (map-elt block-range :end)))
-              (cons :padding (when (and padding-start padding-end)
-                               (list (cons :start padding-start)
-                                     (cons :end padding-end)))))))))
+              ;; Not found or create-new - insert new block
+              (goto-char (point-max))
+              (setq padding-start (point))
+              (agent-shell-ui--insert-read-only (agent-shell-ui--required-newlines 2))
+              (setq block-start (point))
+              (agent-shell-ui--insert-fragment model qualified-id expanded navigation)
+              (agent-shell-ui--insert-read-only "\n\n")
+              (setq padding-end (point))))
+          (when on-post-process
+            (funcall on-post-process))
+          (when-let ((block-range (agent-shell-ui--block-range :position block-start)))
+            (list (cons :block block-range)
+                  (cons :body (agent-shell-ui--nearest-range-matching-property
+                               :property 'agent-shell-ui-section :value 'body
+                               :from (map-elt block-range :start)
+                               :to (map-elt block-range :end)))
+                  (cons :label-left (agent-shell-ui--nearest-range-matching-property
+                                     :property 'agent-shell-ui-section :value 'label-left
+                                     :from (map-elt block-range :start)
+                                     :to (map-elt block-range :end)))
+                  (cons :label-right (agent-shell-ui--nearest-range-matching-property
+                                      :property 'agent-shell-ui-section :value 'label-right
+                                      :from (map-elt block-range :start)
+                                      :to (map-elt block-range :end)))
+                  (cons :padding (when (and padding-start padding-end)
+                                   (list (cons :start padding-start)
+                                         (cons :end padding-end)))))))
+      (goto-char saved-point)
+      (when saved-mark
+        (set-marker (mark-marker) saved-mark))
+      (setq mark-active saved-mark-active)
+      (when window
+        (set-window-start window saved-window-start t)))))
 
 
 (defun agent-shell-ui--read-fragment-at (position qualified-id)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -7020,13 +7020,21 @@ Remove: M-x agent-shell-remove-pending-request
 
 Read PROMPT from the minibuffer.  If the shell is busy, add it to the pending
 requests queue.  Otherwise, submit it immediately.  Queued requests will be
-automatically sent when the current request completes."
+automatically sent when the current request completes.
+
+While reading, @ completes project files and / completes available agent
+commands when the agent has reported them."
   (interactive
    (progn
      (unless (derived-mode-p 'agent-shell-mode)
        (error "Not in a shell"))
-     (list (read-string (or (map-nested-elt (agent-shell--state) '(:agent-config :shell-prompt))
-                            "Enqueue request: ")))))
+     (let ((shell-buffer (current-buffer)))
+       (list
+        (minibuffer-with-setup-hook
+            (lambda ()
+              (agent-shell-completion--setup-minibuffer shell-buffer))
+          (read-string (or (map-nested-elt (agent-shell--state) '(:agent-config :shell-prompt))
+                           "Enqueue request: ")))))))
   (if (shell-maker-busy)
       (agent-shell--enqueue-request :prompt prompt)
     (agent-shell--insert-to-shell-buffer :text prompt :submit t :no-focus t)))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2970,8 +2970,7 @@ by default, RENDER-BODY-IMAGES to enable inline image rendering in body."
                 (derived-mode-p 'agent-shell-viewport-view-mode))))
     (with-current-buffer viewport-buffer
       (let ((inhibit-read-only t)
-            (auto-scroll (shell-maker--should-auto-scroll-p))
-            (saved-point (point-marker)))
+            (auto-scroll (shell-maker--should-auto-scroll-p)))
         (when-let* ((range (agent-shell-ui-update-fragment
                             (agent-shell-ui-make-fragment-model
                              :namespace-id (or namespace-id
@@ -3009,61 +3008,73 @@ by default, RENDER-BODY-IMAGES to enable inline image rendering in body."
               (let ((markdown-overlays-highlight-blocks agent-shell-highlight-blocks)
                     (markdown-overlays-render-images nil))
                 (markdown-overlays-put))))
-          (if auto-scroll
-              (goto-char (point-max))
-            (goto-char saved-point))))))
+          (when auto-scroll
+            (goto-char (point-max)))))))
   (with-current-buffer (map-elt state :buffer)
     (unless (and (derived-mode-p 'agent-shell-mode)
                  (equal (current-buffer)
                         (map-elt state :buffer)))
       (error "Editing the wrong buffer: %s" (current-buffer)))
-    (shell-maker-with-auto-scroll-edit
-     (when-let* ((range (agent-shell-ui-update-fragment
-                         (agent-shell-ui-make-fragment-model
-                          :namespace-id (or namespace-id
-                                            (map-elt state :request-count))
-                          :block-id block-id
-                          :label-left label-left
-                          :label-right label-right
-                          :body body)
-                         :navigation navigation
-                         :append append
-                         :create-new create-new
-                         :expanded expanded
-                         :no-undo t))
-                 (padding-start (map-nested-elt range '(:padding :start)))
-                 (padding-end (map-nested-elt range '(:padding :end)))
-                 (block-start (map-nested-elt range '(:block :start)))
-                 (block-end (map-nested-elt range '(:block :end))))
-       (save-restriction
-         ;; TODO: Move this to shell-maker?
-         (let ((inhibit-read-only t))
-           ;; comint relies on field property to
-           ;; derive `comint-next-prompt'.
-           ;; Marking as field to avoid false positives in
-           ;; `agent-shell-next-item' and `agent-shell-previous-item'.
-           (add-text-properties (or padding-start block-start)
-                                (or padding-end block-end) '(field output)))
-         ;; Apply markdown overlay to body.
-         (when-let ((body-start (map-nested-elt range '(:body :start)))
-                    (body-end (map-nested-elt range '(:body :end))))
-           (narrow-to-region body-start body-end)
-           (let ((markdown-overlays-highlight-blocks agent-shell-highlight-blocks))
-             (markdown-overlays-put))
-           (widen))
-         ;;
-         ;; Note: For now, we're skipping applying markdown overlays
-         ;; on left labels as they currently carry propertized text
-         ;; for statuses (ie. boxed).
-         ;;
-         ;; Apply markdown overlay to right label.
-         (when-let ((label-right-start (map-nested-elt range '(:label-right :start)))
-                    (label-right-end (map-nested-elt range '(:label-right :end))))
-           (narrow-to-region label-right-start label-right-end)
-           (let ((markdown-overlays-highlight-blocks agent-shell-highlight-blocks))
-             (markdown-overlays-put))
-           (widen)))
-       (run-hook-with-args 'agent-shell-section-functions range)))))
+    (let* ((window (get-buffer-window (current-buffer)))
+           (auto-scroll (eobp))
+           (saved-point (point))
+           (saved-mark (mark t))
+           (saved-mark-active mark-active)
+           (saved-window-start (and window (window-start window))))
+      (shell-maker-with-auto-scroll-edit
+       (when-let* ((range (agent-shell-ui-update-fragment
+                           (agent-shell-ui-make-fragment-model
+                            :namespace-id (or namespace-id
+                                              (map-elt state :request-count))
+                            :block-id block-id
+                            :label-left label-left
+                            :label-right label-right
+                            :body body)
+                           :navigation navigation
+                           :append append
+                           :create-new create-new
+                           :expanded expanded
+                           :no-undo t))
+                   (padding-start (map-nested-elt range '(:padding :start)))
+                   (padding-end (map-nested-elt range '(:padding :end)))
+                   (block-start (map-nested-elt range '(:block :start)))
+                   (block-end (map-nested-elt range '(:block :end))))
+         (save-restriction
+           ;; TODO: Move this to shell-maker?
+           (let ((inhibit-read-only t))
+             ;; comint relies on field property to
+             ;; derive `comint-next-prompt'.
+             ;; Marking as field to avoid false positives in
+             ;; `agent-shell-next-item' and `agent-shell-previous-item'.
+             (add-text-properties (or padding-start block-start)
+                                  (or padding-end block-end) '(field output)))
+           ;; Apply markdown overlay to body.
+           (when-let ((body-start (map-nested-elt range '(:body :start)))
+                      (body-end (map-nested-elt range '(:body :end))))
+             (narrow-to-region body-start body-end)
+             (let ((markdown-overlays-highlight-blocks agent-shell-highlight-blocks))
+               (markdown-overlays-put))
+             (widen))
+           ;;
+           ;; Note: For now, we're skipping applying markdown overlays
+           ;; on left labels as they currently carry propertized text
+           ;; for statuses (ie. boxed).
+           ;;
+           ;; Apply markdown overlay to right label.
+           (when-let ((label-right-start (map-nested-elt range '(:label-right :start)))
+                      (label-right-end (map-nested-elt range '(:label-right :end))))
+             (narrow-to-region label-right-start label-right-end)
+             (let ((markdown-overlays-highlight-blocks agent-shell-highlight-blocks))
+               (markdown-overlays-put))
+             (widen)))
+         (run-hook-with-args 'agent-shell-section-functions range)))
+      (unless auto-scroll
+        (goto-char saved-point)
+        (when saved-mark
+          (set-marker (mark-marker) saved-mark))
+        (setq mark-active saved-mark-active)
+        (when window
+          (set-window-start window saved-window-start t))))))
 
 (cl-defun agent-shell--update-text (&key state namespace-id block-id text append create-new)
   "Update plain text entry in the shell buffer.


### PR DESCRIPTION
Closes #556.

- What changed: `agent-shell-queue-request` now offers `@` (project files) and `/` (slash commands) completion in the queued-prompt minibuffer, mirroring the regular shell input.
- A buffer-local override `agent-shell-completion--shell-buffer` lets the existing CAPFs source data from a designated shell. New helpers `agent-shell-completion--setup-minibuffer` / `--cleanup-minibuffer` install/remove the hooks via `minibuffer-with-setup-hook` + `minibuffer-exit-hook`.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss. (in the issue linked)
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
