### PR TITLE
Prefer session load by default

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -549,10 +549,12 @@ configuration alist for backwards compatibility."
                         :key-type symbol :value-type sexp))
   :group 'agent-shell)
 
-(defcustom agent-shell-prefer-session-resume t
+(defcustom agent-shell-prefer-session-resume nil
   "Prefer ACP session resume over session load when both are available.
 
-When non-nil (and supported by agent), prefer ACP session resumes over loading."
+When nil, prefer session/load when available so reopened sessions replay
+history, and fall back to session/resume only when loading is unsupported.
+When non-nil (and supported by agent), prefer ACP session/resume over loading."
   :type 'boolean
   :group 'agent-shell)
 

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1389,6 +1389,7 @@ code block content
                                  (:modes . nil)))
                     (:supports-session-list . t)
                     (:supports-session-load . t)
+                    (:supports-session-resume . t)
                     (:active-requests)
                     (:event-subscriptions . nil))))
       (setq-local agent-shell--state state)


### PR DESCRIPTION
## Summary

Prefer `session/load` over `session/resume` by default when both ACP capabilities are available.

This keeps `session/resume` as the fallback for agents that do not support loading, but uses `session/load` for the normal “reopen an existing/listed session” path so the transcript history is replayed.

## Why

ACP distinguishes these two operations:

- [`session/load`](https://agentclientprotocol.com/protocol/schema#session-load) loads an existing session and should restore conversation history. The schema docs say the agent should “Stream the entire conversation history back to the client via notifications”.
- [`session/resume`](https://agentclientprotocol.com/protocol/schema#session-resume) resumes an existing session “without returning previous messages”. The schema docs describe it as continuing without replaying message history, unlike `session/load`.

The session-list flow is also documented as list → user selects session → load:

- [`session/list` docs](https://agentclientprotocol.com/protocol/session-list#interaction-with-other-session-methods): “`session/list` is a discovery mechanism only” and after the user selects a session, the client calls `session/load` with the chosen `sessionId`.
- The [`session/resume` RFD](https://agentclientprotocol.com/rfds/session-resume) says resume is similar to `session/load`, “except it does not return previous messages”, and is useful for clients that do not want history or agents that cannot implement full loading.

Currently `agent-shell-prefer-session-resume` defaults to `t`, so when an agent advertises both capabilities, agent-shell chooses `session/resume`. For agents such as OpenCode that support both `loadSession` and `sessionCapabilities.resume`, reopening a previous session from agent-shell can therefore restore the backend session context but leave the agent-shell buffer without the earlier conversation history.

That is surprising for the session-list/reopen flow, and it goes against the documented ACP behavior above: if the client wants the conversation replayed, it should use `session/load` when available.

## Change

- Change `agent-shell-prefer-session-resume` default from `t` to `nil`.
- Update the docstring to explain that `session/load` is preferred when available, while `session/resume` remains the fallback when loading is unsupported.
- Update the existing list/load test so it covers the important case where an agent advertises both load and resume, and verifies that `session/load` is selected.

## Test

Ran the targeted ERT test:

```sh
emacs --batch --eval '...' \
  -L /home/i-oliva/agent-shell \
  -l /home/i-oliva/agent-shell/tests/agent-shell-tests.el \
  --eval "(ert-run-tests-batch-and-exit 'agent-shell--initiate-session-prefers-list-and-load-when-supported)"
```

Result: passed.