### PR TITLE
add clipboard image support for Windows

### DIFF
--- a/README.org
+++ b/README.org
@@ -546,6 +546,7 @@ You can send a screenshot from your clipboard to your shell with =agent-shell-se
 - =wl-paste= for Wayland desktops,
 - =xclip= for Xorg,
 - =pngpaste= for MacOS.
+- =powershell= for Windows.
 
 *** Inhibiting minor modes during file writes
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -422,7 +422,13 @@ Assume screenshot file path will be appended to this list."
                                                         "-t" "image/png" "-o")))
                            (unless (zerop exit-code)
                              (error "Command xclip failed with exit code %d" exit-code))
-                           (write-region (point-min) (point-max) file-path nil 'silent)))))))
+                           (write-region (point-min) (point-max) file-path nil 'silent))))))
+   (list (cons :command "powershell")
+         (cons :save (lambda (file-path)
+                       (when-let* ((cmd (format "& {(Get-Clipboard -Format image).Save(%s)}" (shell-quote-argument file-path)))
+                                   (exit-code (call-process "powershell" nil nil nil "-Command" cmd))
+                                   ((not (zerop exit-code))))
+                         (error "Command powershell failed with exit code %d" exit-code))))))
   "Handlers for saving clipboard images to a file.
 
 Each handler is an alist with the following keys:


### PR DESCRIPTION
I've used `when-let*` instead of `when-let` instead of contributing guidelines as `when-let` (and others) will be obsolete with Emacs 31.1.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.

<!-- Message of single commit: -->

add clipboard image support for Windows