### PR TITLE
fix: no-op devcontainer-resolve-path when no .devcontainer/devcontain…

### DIFF
--- a/agent-shell-devcontainer.el
+++ b/agent-shell-devcontainer.el
@@ -42,22 +42,30 @@ See https://containers.dev for more information on devcontainers."
 (defun agent-shell-devcontainer-resolve-path (path)
   "Resolve PATH from a devcontainer in the local filesystem, and vice versa.
 
+When the current working directory has no .devcontainer/devcontainer.json,
+PATH is returned unchanged.  This makes it safe to set this function as
+`agent-shell-path-resolver-function' globally, even when mixing
+devcontainer- and non-devcontainer projects in the same Emacs session.
+
 For example:
 
 - /workspace/README.md => /home/xenodium/projects/kitchen-sink/README.md
-- /home/xenodium/projects/kitchen-sink/README.md => /workspace/README.md"
-  (let* ((cwd (agent-shell-cwd))
-         (devcontainer-path (agent-shell-devcontainer--get-workspace-path cwd)))
-    (if (string-prefix-p cwd path)
-        (string-replace cwd devcontainer-path path)
-      (if agent-shell-text-file-capabilities
-          (if-let* ((is-dev-container (string-prefix-p devcontainer-path path))
-                    (local-path (expand-file-name (string-replace devcontainer-path cwd path))))
-              (or
-               (and (file-in-directory-p local-path cwd) local-path)
-               (error "Resolves to path outside of working directory: %s" path))
-            (error "Unexpected path outside of workspace folder: %s" path))
-        (error "Refuse to resolve to local filesystem with text file capabilities disabled: %s" path)))))
+- /home/xenodium/projects/kitchen-sink/README.md => /workspace/README.md
+- /any/path => /any/path  (when CWD is not a devcontainer project)"
+  (let ((cwd (agent-shell-cwd)))
+    (if (not (file-exists-p (expand-file-name ".devcontainer/devcontainer.json" cwd)))
+        path
+      (let ((devcontainer-path (agent-shell-devcontainer--get-workspace-path cwd)))
+        (if (string-prefix-p cwd path)
+            (string-replace cwd devcontainer-path path)
+          (if agent-shell-text-file-capabilities
+              (if-let* ((is-dev-container (string-prefix-p devcontainer-path path))
+                        (local-path (expand-file-name (string-replace devcontainer-path cwd path))))
+                  (or
+                   (and (file-in-directory-p local-path cwd) local-path)
+                   (error "Resolves to path outside of working directory: %s" path))
+                (error "Unexpected path outside of workspace folder: %s" path))
+            (error "Refuse to resolve to local filesystem with text file capabilities disabled: %s" path)))))))
 
 (defalias
   'agent-shell--resolve-devcontainer-path

--- a/tests/agent-shell-devcontainer-tests.el
+++ b/tests/agent-shell-devcontainer-tests.el
@@ -7,9 +7,11 @@
 
 (ert-deftest agent-shell-devcontainer-resolve-path-test ()
   "Test `agent-shell-devcontainer-resolve-path' function."
-  ;; Mock agent-shell-devcontainer--get-workspace-path
+  ;; Mock agent-shell-devcontainer--get-workspace-path and pretend
+  ;; .devcontainer/devcontainer.json exists so the no-op gate passes.
   (cl-letf (((symbol-function 'agent-shell-devcontainer--get-workspace-path)
-             (lambda (_) "/workspace")))
+             (lambda (_) "/workspace"))
+            ((symbol-function 'file-exists-p) (lambda (_) t)))
 
     ;; Need to run in an existing directory (requirement of `file-in-directory-p')
     (let ((default-directory "/tmp"))
@@ -48,6 +50,24 @@
 
         ;; Does not resolve unexpected paths
         (should-error (agent-shell-devcontainer-resolve-path "/unexpected") :type 'error)))))
+
+(ert-deftest agent-shell-devcontainer-resolve-path-no-op-without-devcontainer-test ()
+  "Resolver returns PATH unchanged when CWD has no .devcontainer/devcontainer.json."
+  (let ((tmp (file-name-as-directory (make-temp-file "agent-shell-test-" t))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell-cwd) (lambda () tmp))
+                  ;; Would error if called; verifies no-op short-circuits before this.
+                  ((symbol-function 'agent-shell-devcontainer--get-workspace-path)
+                   (lambda (_) (error "Should not be called when no devcontainer.json"))))
+          (let ((agent-shell-text-file-capabilities t))
+            (should (equal (agent-shell-devcontainer-resolve-path "/workspace/d/f.el")
+                           "/workspace/d/f.el"))
+            (should (equal (agent-shell-devcontainer-resolve-path (concat tmp "f.el"))
+                           (concat tmp "f.el"))))
+          (let ((agent-shell-text-file-capabilities nil))
+            (should (equal (agent-shell-devcontainer-resolve-path "/workspace/d/f.el")
+                           "/workspace/d/f.el"))))
+      (delete-directory tmp t))))
 
 (provide 'agent-shell-devcontainer-tests)
 ;;; agent-shell-devcontainer-tests.el ends here


### PR DESCRIPTION
Allows `agent-shell-path-resolver-function' to be set globally to `agent-shell-devcontainer-resolve-path' without breaking sessions in projects that have no devcontainer.

Thank you for contributing to agent-shell!

Resolves #573 

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
