### PR TITLE
Fix header foreground color (emacs 31)

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3288,6 +3288,18 @@ A buffer-local hash table mapping cache keys to header strings.")
               ((not (string-empty-p session-id))))
     (propertize session-id 'font-lock-face 'font-lock-constant-face)))
 
+(defun agent-shell--svg-fill-color (face)
+  "Return foreground color for FACE suitable as an SVG fill value.
+Resolves inherited attributes and falls back to the `default' face
+foreground when FACE has no concrete foreground (e.g., Emacs 31
+faces whose foreground arrives indirectly).  Without this fallback,
+`face-attribute' may return the symbol `unspecified', which a renderer
+treats as an invalid color and draws as black."
+  (let ((fg (face-attribute face :foreground nil t)))
+    (if (or (null fg) (eq fg 'unspecified))
+        (face-attribute 'default :foreground nil t)
+      fg)))
+
 (cl-defun agent-shell--make-header-model (state &key qualifier bindings)
   "Create a header model alist from STATE, QUALIFIER, and BINDINGS.
 The model contains all inputs needed to render the graphical header."
@@ -3431,20 +3443,20 @@ When provided, included in help-echo tooltips."
                                       ;; Agent name
                                       (dom-append-child text-node
                                                         (dom-node 'tspan
-                                                                  `((fill . ,(face-attribute 'font-lock-variable-name-face :foreground)))
+                                                                  `((fill . ,(agent-shell--svg-fill-color 'font-lock-variable-name-face)))
                                                                   (map-elt header-model :buffer-name)))
                                       ;; Model name (optional)
                                       (when (map-elt header-model :model-name)
                                         ;; Add separator arrow
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'default :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                       (dx . "8"))
                                                                     "➤"))
                                         ;; Add model name
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'font-lock-negation-char-face :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'font-lock-negation-char-face))
                                                                       (dx . "8"))
                                                                     (map-elt header-model :model-name))))
                                       ;; Session mode (optional)
@@ -3452,14 +3464,13 @@ When provided, included in help-echo tooltips."
                                         ;; Add separator arrow
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'default :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                       (dx . "8"))
                                                                     "➤"))
                                         ;; Add session mode text
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(or (face-attribute 'font-lock-type-face :foreground nil t)
-                                                                                   "#6699cc"))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'font-lock-type-face))
                                                                       (dx . "8"))
                                                                     (map-elt header-model :mode-name))))
                                       (when (map-elt header-model :context-indicator)
@@ -3467,22 +3478,21 @@ When provided, included in help-echo tooltips."
                                           ;; Add separator arrow
                                           (dom-append-child text-node
                                                             (dom-node 'tspan
-                                                                      `((fill . ,(face-attribute 'default :foreground))
+                                                                      `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                         (dx . "8"))
                                                                       "➤")))
                                         ;; Add context indicator
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute
+                                                                    `((fill . ,(agent-shell--svg-fill-color
                                                                                 (or (get-text-property 0 'face (map-elt header-model :context-indicator))
-                                                                                    'default)
-                                                                                :foreground nil t))
+                                                                                    'default)))
                                                                       (dx . "8"))
                                                                     (format-mode-line (map-elt header-model :context-indicator)))))
                                       (when (map-elt header-model :busy-indicator-frame)
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'default :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                       (dx . "8"))
                                                                     (map-elt header-model :busy-indicator-frame))))
                                       text-node))
@@ -3494,20 +3504,20 @@ When provided, included in help-echo tooltips."
                                       ;; Directory path
                                       (dom-append-child text-node
                                                         (dom-node 'tspan
-                                                                  `((fill . ,(face-attribute 'font-lock-string-face :foreground)))
+                                                                  `((fill . ,(agent-shell--svg-fill-color 'font-lock-string-face)))
                                                                   (map-elt header-model :project-name)))
                                       ;; Session ID (optional)
                                       (when (map-elt header-model :session-id)
                                         ;; Separator arrow (default foreground)
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'default :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                       (dx . "8"))
                                                                     "➤"))
                                         ;; Session ID text
                                         (dom-append-child text-node
                                                           (dom-node 'tspan
-                                                                    `((fill . ,(face-attribute 'font-lock-constant-face :foreground))
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'font-lock-constant-face))
                                                                       (dx . "8"))
                                                                     (substring-no-properties (map-elt header-model :session-id)))))
                                       text-node))
@@ -3522,7 +3532,7 @@ When provided, included in help-echo tooltips."
                                         (when qualifier
                                           (dom-append-child text-node
                                                             (dom-node 'tspan
-                                                                      `((fill . ,(face-attribute 'default :foreground)))
+                                                                      `((fill . ,(agent-shell--svg-fill-color 'default)))
                                                                       qualifier))
                                           (setq first nil))
                                         (dolist (binding bindings)
@@ -3530,7 +3540,7 @@ When provided, included in help-echo tooltips."
                                             ;; Add key (XML-escape angle brackets)
                                             (dom-append-child text-node
                                                               (dom-node 'tspan
-                                                                        `((fill . ,(face-attribute 'help-key-binding :foreground))
+                                                                        `((fill . ,(agent-shell--svg-fill-color 'help-key-binding))
                                                                           ,@(unless first '((dx . "8"))))
                                                                         (replace-regexp-in-string
                                                                          "<" "&lt;"
@@ -3541,7 +3551,7 @@ When provided, included in help-echo tooltips."
                                             ;; Add space and description
                                             (dom-append-child text-node
                                                               (dom-node 'tspan
-                                                                        `((fill . ,(face-attribute 'default :foreground))
+                                                                        `((fill . ,(agent-shell--svg-fill-color 'default))
                                                                           (dx . "8"))
                                                                         (map-elt binding :description)))))
                                         text-node)))


### PR DESCRIPTION
Fixes the header text foreground color in emacs 31

- I am running emacs 31.0.60 on macOS, compiled from the `emacs-31` branch (github mirror)
- In this version some of the agent-shell header text has the wrong foreground color (see screenshot)
- This PR fixes that issue
- Tested in emacs-31 and emacs-30

Old:
<img width="587" height="62" alt="Screenshot 2026-05-18 at 10 38 25" src="https://github.com/user-attachments/assets/b19cfd27-861b-4d3e-8dfc-5d1743231d24" /> 

New (new session):
<img width="512" height="60" alt="Screenshot 2026-05-18 at 22 07 15" src="https://github.com/user-attachments/assets/e71837ac-a08d-4413-8d65-e8366b669905" />

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
