### PR TITLE
Fix context-limit header color (emacs-31)

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -42,6 +42,7 @@
 (require 'acp)
 (eval-when-compile
   (require 'cl-lib))
+(require 'color)
 (require 'dired)
 (require 'diff)
 (require 'json)
@@ -3289,16 +3290,18 @@ A buffer-local hash table mapping cache keys to header strings.")
     (propertize session-id 'font-lock-face 'font-lock-constant-face)))
 
 (defun agent-shell--svg-fill-color (face)
-  "Return foreground color for FACE suitable as an SVG fill value.
-Resolves inherited attributes and falls back to the `default' face
-foreground when FACE has no concrete foreground (e.g., Emacs 31
-faces whose foreground arrives indirectly).  Without this fallback,
-`face-attribute' may return the symbol `unspecified', which a renderer
-treats as an invalid color and draws as black."
-  (let ((fg (face-attribute face :foreground nil t)))
-    (if (or (null fg) (eq fg 'unspecified))
-        (face-attribute 'default :foreground nil t)
-      fg)))
+  "Return foreground color for FACE as an `#rrggbb' hex string for SVG.
+Resolves FACE's `:inherit' chain and merges with the `default' face
+so the result is always specified, then converts to hex.  The hex
+form is important because Emacs face foregrounds are often X11 color
+names (e.g., `Green3' for the standard `success' face) that SVG does
+not recognize — passing them through unconverted causes the renderer
+to fall back to black."
+  (let* ((name (face-attribute face :foreground nil 'default))
+         (rgb (and (stringp name) (color-name-to-rgb name))))
+    (if rgb
+        (apply #'color-rgb-to-hex (append rgb '(2)))
+      "#ffffff")))
 
 (cl-defun agent-shell--make-header-model (state &key qualifier bindings)
   "Create a header model alist from STATE, QUALIFIER, and BINDINGS.


### PR DESCRIPTION
This PR fixes the context-limit header color in Emacs 31. Turns out I didn't test this correctly in my previous PR and it was still broken.

Instead of passing the color name to SVG, we now convert to hex first, which fixes the issue. Tested in Emacs 31 and 30.

<img width="535" height="53" alt="Screenshot 2026-05-19 at 15 18 34" src="https://github.com/user-attachments/assets/d7123bfc-2341-4b82-9399-585d4f425a6a" />
<img width="518" height="52" alt="Screenshot 2026-05-19 at 15 18 56" src="https://github.com/user-attachments/assets/ad635ec0-d275-4d87-a161-e01463259b8c" />
<img width="524" height="53" alt="Screenshot 2026-05-19 at 15 19 13" src="https://github.com/user-attachments/assets/793960b0-e332-4ec8-a229-60e4f05d4da8" />


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
