### PR TITLE
Fix / completion regression in viewport buffers

### DIFF
--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -98,7 +98,8 @@ buffer.  Returns nil if the override is set but its buffer is dead."
 (defun agent-shell--command-completion-at-point ()
   "Complete available commands after /."
   (when-let* ((bounds (agent-shell--completion-bounds "[:alnum:]_-" ?/))
-              (source (or (agent-shell-completion--source-buffer)
+              (source (or (and (buffer-live-p agent-shell-completion--shell-buffer)
+                               agent-shell-completion--shell-buffer)
                           (agent-shell--shell-buffer :no-error t :no-create t)))
               (commands (map-elt (buffer-local-value 'agent-shell--state source)
                                  :available-commands))


### PR DESCRIPTION
When agent-shell-completion--shell-buffer is unset (nil), fall back to agent-shell--shell-buffer so viewport buffers navigate to the correct shell buffer instead of reading their own (empty) state.

Fixes regression that happened with #565

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
