### PR TITLE
Do not emit permission-request for auto-handled permissions

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1873,9 +1873,11 @@ COMMAND, when present, may be a shell command string or an argv vector."
                   (when-let ((diff (agent-shell--make-diff-info
                                     :acp-tool-call (map-nested-elt acp-request '(params toolCall)))))
                     (list (cons :diff diff)))))
-         (unless (and (functionp agent-shell-permission-responder-function)
+         (let* ((tool-call-id (map-nested-elt acp-request '(params toolCall toolCallId)))
+                (permission-handled
+                 (and (functionp agent-shell-permission-responder-function)
                       (funcall agent-shell-permission-responder-function
-                               (list (cons :tool-call (map-nested-elt state (list :tool-calls (map-nested-elt acp-request '(params toolCall toolCallId)))))
+                               (list (cons :tool-call (map-nested-elt state (list :tool-calls tool-call-id)))
                                      (cons :options (agent-shell--make-permission-actions
                                                      (map-nested-elt acp-request '(params options))))
                                      (cons :respond (lambda (option-id)
@@ -1884,43 +1886,43 @@ COMMAND, when present, may be a shell command string or an argv vector."
                                                        :request-id (map-elt acp-request 'id)
                                                        :option-id option-id
                                                        :state state
-                                                       :tool-call-id (map-nested-elt acp-request '(params toolCall toolCallId)))
-                                                      t)))))
-           (when (map-nested-elt acp-request '(params toolCall rawInput plan))
+                                                       :tool-call-id tool-call-id)
+                                                      t)))))))
+           (unless permission-handled
+             (when (map-nested-elt acp-request '(params toolCall rawInput plan))
+               (agent-shell--update-fragment
+                :state state
+                :block-id (concat tool-call-id "-plan")
+                :label-left (propertize "Proposed plan" 'font-lock-face 'font-lock-doc-markup-face)
+                :body (agent-shell--format-plan (map-nested-elt acp-request '(params toolCall rawInput plan)))
+                :expanded t))
+             ;; block-id must be the same as the one used
+             ;; in agent-shell--delete-fragment param.
              (agent-shell--update-fragment
               :state state
-              :block-id (concat (map-nested-elt acp-request '(params toolCall toolCallId)) "-plan")
-              :label-left (propertize "Proposed plan" 'font-lock-face 'font-lock-doc-markup-face)
-              :body (agent-shell--format-plan (map-nested-elt acp-request '(params toolCall rawInput plan)))
-              :expanded t))
-           ;; block-id must be the same as the one used
-           ;; in agent-shell--delete-fragment param.
-           (agent-shell--update-fragment
-            :state state
-            :block-id (format "permission-%s" (map-nested-elt acp-request '(params toolCall toolCallId)))
-            :body (with-current-buffer (map-elt state :buffer)
-                    (agent-shell--make-tool-call-permission-text
-                     :acp-request acp-request
-                     :client (map-elt state :client)
-                     :state state))
-            :expanded t
-            :navigation 'never)
-           (agent-shell-jump-to-latest-permission-button-row)
-           (when-let (((map-elt state :buffer))
-                      (viewport-buffer (agent-shell-viewport--buffer
-                                        :shell-buffer (map-elt state :buffer)
-                                        :existing-only t)))
-             (with-current-buffer viewport-buffer
-               (agent-shell-jump-to-latest-permission-button-row))))
-         (let* ((tool-call-id (map-nested-elt acp-request '(params toolCall toolCallId)))
-                (data (list (cons :request-id (map-elt acp-request 'id))
-                            (cons :tool-call-id tool-call-id)
-                            (cons :tool-call (map-nested-elt state (list :tool-calls tool-call-id))))))
-           (agent-shell--emit-event
-            :event 'permission-request
-            :data data)
-           (agent-shell--start-idle-timer :event 'permission-request :data data))
-         (map-put! state :last-entry-type "session/request_permission"))
+              :block-id (format "permission-%s" tool-call-id)
+              :body (with-current-buffer (map-elt state :buffer)
+                      (agent-shell--make-tool-call-permission-text
+                       :acp-request acp-request
+                       :client (map-elt state :client)
+                       :state state))
+              :expanded t
+              :navigation 'never)
+             (agent-shell-jump-to-latest-permission-button-row)
+             (when-let (((map-elt state :buffer))
+                        (viewport-buffer (agent-shell-viewport--buffer
+                                          :shell-buffer (map-elt state :buffer)
+                                          :existing-only t)))
+               (with-current-buffer viewport-buffer
+                 (agent-shell-jump-to-latest-permission-button-row)))
+             (let ((data (list (cons :request-id (map-elt acp-request 'id))
+                               (cons :tool-call-id tool-call-id)
+                               (cons :tool-call (map-nested-elt state (list :tool-calls tool-call-id))))))
+               (agent-shell--emit-event
+                :event 'permission-request
+                :data data)
+               (agent-shell--start-idle-timer :event 'permission-request :data data))
+             (map-put! state :last-entry-type "session/request_permission"))))
         ((equal (map-elt acp-request 'method) "fs/read_text_file")
          (agent-shell--on-fs-read-text-file-request
           :state state

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2302,6 +2302,7 @@ code block content
   "Test `agent-shell--on-request' calls handler and :respond auto-approves."
   (with-temp-buffer
     (let* ((responded-option-id nil)
+           (received-events nil)
            (handler-received nil)
            (agent-shell-permission-responder-function
             (lambda (request)
@@ -2330,6 +2331,11 @@ code block content
                 ((symbol-function 'agent-shell--send-permission-response)
                  (lambda (&rest args)
                    (setq responded-option-id (plist-get args :option-id)))))
+        (agent-shell-subscribe-to
+         :shell-buffer (current-buffer)
+         :event 'permission-request
+         :on-event (lambda (event)
+                     (push event received-events)))
         (agent-shell--on-request
          :state state
          :acp-request `((id . "req-1")
@@ -2348,7 +2354,9 @@ code block content
         (should (equal (map-elt (map-elt handler-received :tool-call) :kind) "read"))
         (should (equal (map-elt (map-elt handler-received :tool-call) :title) "Read file"))
         (should (= (length (map-elt handler-received :options)) 2))
-        (should (equal responded-option-id "opt-allow"))))))
+        (should (equal responded-option-id "opt-allow"))
+        (should-not received-events)
+        (should-not (map-elt state :idle-timer))))))
 
 (ert-deftest agent-shell--on-request-handler-nil-leaves-prompt-test ()
   "Test `agent-shell--on-request' leaves interactive prompt when handler returns nil."


### PR DESCRIPTION
When `agent-shell-permission-responder-function` handles a permission request, the prompt UI is skipped, but `agent-shell` still emitted `permission-request` and started the permission idle timer.

This made auto-approved permissions look pending to event subscribers.

This change treats a non-nil responder result as fully handled:
- skip rendering the permission prompt
- skip emitting `permission-request`
- skip starting the permission idle timer
- keep sending `permission-response` through the existing response path

The existing responder test now also verifies that auto-approved permissions do not emit a permission request event or leave an idle timer running.

Please view the change without whitespaces: https://github.com/xenodium/agent-shell/pull/600/changes?w=1


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.