### PR TITLE
Expose thought level (reasoning effort) in header, mode line and keymaps

### DIFF
--- a/README.org
+++ b/README.org
@@ -592,6 +592,21 @@ All of the above settings can be applied on a per-project basis using [[https://
                   ("C-c C-k" . agent-shell-interrupt)))
   #+end_src
 
+*** Session controls
+
+When the active agent advertises the corresponding session option, you can switch it from the shell buffer:
+
+- =C-c C-v= - Set model.
+- =C-c C-m= - Set session mode.
+- =C-c C-t= - Set thought level (reasoning effort).
+- =C-<tab>= - Cycle session mode.
+
+The current selections are shown in the header right after the agent name; click any segment to open a popup menu. The thought level segment only appears for models that expose it (e.g. Claude Sonnet/Opus with effort levels; Codex's reasoning_effort).
+
+From the viewport (=agent-shell-viewport-view-mode= / =agent-shell-viewport-edit-mode=), the same controls are bound to:
+
+- View mode: =v= (model), =s= (mode), =t= (thought level).
+- Edit mode: =C-c C-v=, =C-c C-m=, =C-c C-t=.
 
 *** Evil
 Evil users may want to rebind ~RET~ for inserting a new line in =insert

--- a/agent-shell-config.el
+++ b/agent-shell-config.el
@@ -210,6 +210,14 @@ session :mode-id."
   (or (map-elt (agent-shell--config-option-by-category state "mode") :current-value)
       (map-nested-elt state '(:session :mode-id))))
 
+(defun agent-shell--current-thought-level-id (state)
+  "Return current thought level ID from STATE or nil if not advertised.
+
+The option is identified by ACP category \"thought_level\" per the spec:
+https://agentclientprotocol.com/protocol/session-config-options"
+  (map-elt (agent-shell--config-option-by-category state "thought_level")
+           :current-value))
+
 (defun agent-shell--get-available-models (state)
   "Return available models from STATE, preferring config options.
 
@@ -218,6 +226,14 @@ values to legacy model shape.  Otherwise returns session :models."
   (if-let ((model-option (agent-shell--config-option-by-category state "model")))
       (agent-shell--config-option-as-models model-option)
     (map-nested-elt state '(:session :models))))
+
+(defun agent-shell--get-available-thought-levels (state)
+  "Return available thought level values from STATE.
+
+Each value is an alist with :value, :name, optional :description where
+:value is the agent value and :name is a human-readable name."
+  (map-elt (agent-shell--config-option-by-category state "thought_level")
+           :options))
 
 ;;; Formatting
 

--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -70,6 +70,7 @@
 (declare-function agent-shell-select-config "agent-shell")
 (declare-function agent-shell-set-session-mode "agent-shell")
 (declare-function agent-shell-set-session-model "agent-shell")
+(declare-function agent-shell-set-session-thought-level "agent-shell")
 (declare-function agent-shell-ui-backward-block "agent-shell")
 (declare-function agent-shell-ui-forward-block "agent-shell")
 (declare-function agent-shell-ui-mode "agent-shell")
@@ -886,6 +887,24 @@ buffer from the snapshot and switch to edit mode."
            (with-current-buffer viewport-buffer
              (agent-shell-viewport--update-header))))))))
 
+(defun agent-shell-viewport-set-session-thought-level ()
+  "Set thought level (reasoning effort) for the current session."
+  (declare (modes agent-shell-viewport-view-mode
+                  agent-shell-viewport-edit-mode))
+  (interactive)
+  (agent-shell-viewport--ensure-buffer)
+  (let* ((shell-buffer (or (agent-shell--current-shell)
+                           (user-error "Not in an agent-shell buffer")))
+         (viewport-buffer (agent-shell-viewport--buffer
+                          :shell-buffer shell-buffer
+                          :existing-only t)))
+    (with-current-buffer shell-buffer
+      (agent-shell-set-session-thought-level
+       (lambda ()
+         (when viewport-buffer
+           (with-current-buffer viewport-buffer
+             (agent-shell-viewport--update-header))))))))
+
 (defun agent-shell-viewport-cycle-session-mode ()
   "Cycle through available session modes."
   (declare (modes agent-shell-viewport-view-mode
@@ -1016,6 +1035,7 @@ VIEWPORT-BUFFER is the viewport buffer to check."
     (define-key map (kbd "C-<tab>") #'agent-shell-viewport-cycle-session-mode)
     (define-key map (kbd "C-c C-m") #'agent-shell-viewport-set-session-mode)
     (define-key map (kbd "C-c C-v") #'agent-shell-viewport-set-session-model)
+    (define-key map (kbd "C-c C-t") #'agent-shell-viewport-set-session-thought-level)
     (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
     (define-key map (kbd "M-p") #'agent-shell-viewport-previous-history)
     (define-key map (kbd "M-n") #'agent-shell-viewport-next-history)
@@ -1052,6 +1072,7 @@ VIEWPORT-BUFFER is the viewport buffer to check."
     (define-key map (kbd "a") #'agent-shell-viewport-reply-again)
     (define-key map (kbd "c") #'agent-shell-viewport-reply-continue)
     (define-key map (kbd "s") #'agent-shell-viewport-set-session-mode)
+    (define-key map (kbd "t") #'agent-shell-viewport-set-session-thought-level)
     (define-key map (kbd "o") #'agent-shell-other-buffer)
     (define-key map (kbd "C-c C-o") #'agent-shell-other-buffer)
     (define-key map (kbd "?") #'agent-shell-viewport-help-menu)
@@ -1122,6 +1143,8 @@ VIEWPORT-BUFFER is the viewport buffer to check."
                          (:description . "Set model"))
                         ((:function . agent-shell-viewport-set-session-mode)
                          (:description . "Set mode"))
+                        ((:function . agent-shell-viewport-set-session-thought-level)
+                         (:description . "Set thought level"))
                         ((:function . agent-shell-viewport-cycle-session-mode)
                          (:description . "Cycle mode"))
                         ((:function . agent-shell-viewport-interrupt)
@@ -1180,6 +1203,8 @@ VIEWPORT-BUFFER is the viewport buffer to check."
                          (:description . "Set model"))
                         ((:function . agent-shell-viewport-set-session-mode)
                          (:description . "Set mode"))
+                        ((:function . agent-shell-viewport-set-session-thought-level)
+                         (:description . "Set thought level"))
                         ((:function . agent-shell-viewport-cycle-session-mode)
                          (:description . "Cycle mode"))
                         ((:function . agent-shell-other-buffer)
@@ -1288,14 +1313,19 @@ Automatically determines qualifier and bindings based on current major mode."
          (mode-binding (when keymap
                          (key-description (where-is-internal
                                            'agent-shell-viewport-set-session-mode
-                                           keymap t)))))
+                                           keymap t))))
+         (thought-level-binding (when keymap
+                                  (key-description (where-is-internal
+                                                    'agent-shell-viewport-set-session-thought-level
+                                                    keymap t)))))
     (when-let* ((shell-buffer (agent-shell-viewport--shell-buffer))
                 (header (with-current-buffer shell-buffer
                           (agent-shell--make-header (agent-shell--state)
                                                     :qualifier qualifier
                                                     :bindings bindings
                                                     :model-binding model-binding
-                                                    :mode-binding mode-binding))))
+                                                    :mode-binding mode-binding
+                                                    :thought-level-binding thought-level-binding))))
       (setq-local header-line-format header))))
 
 (defvar-local agent-shell-viewport--clean-up t)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1311,6 +1311,7 @@ If DELETE is non-nil, delete the text between START and END."
   "C-c C-c" #'agent-shell-interrupt
   "C-c C-m" #'agent-shell-set-session-mode
   "C-c C-v" #'agent-shell-set-session-model
+  "C-c C-t" #'agent-shell-set-session-thought-level
   "C-c C-o" #'agent-shell-other-buffer
   "C-c C-s" #'agent-shell-set-session-config-option
   "<remap> <yank>" #'agent-shell-yank-dwim)
@@ -3324,6 +3325,8 @@ The model contains all inputs needed to render the graphical header."
     (:icon-name . ,(map-nested-elt state '(:agent-config :icon-name)))
     (:model-id . ,(map-nested-elt state '(:session :model-id)))
     (:model-name . ,(agent-shell-get-model-name state))
+    (:thought-level-id . ,(agent-shell--current-thought-level-id state))
+    (:thought-level-name . ,(agent-shell-get-thought-level-name state))
     (:mode-id . ,(map-nested-elt state '(:session :mode-id)))
     (:mode-name . ,(agent-shell-get-mode-name state))
     (:project-name . ,(agent-shell--project-name))
@@ -3349,7 +3352,7 @@ Joins all values from the model alist."
   (mapconcat (lambda (pair) (format "%s" (cdr pair)))
              model "|"))
 
-(cl-defun agent-shell--make-header (state &key qualifier bindings model-binding mode-binding)
+(cl-defun agent-shell--make-header (state &key qualifier bindings model-binding mode-binding thought-level-binding)
   "Return header text for current STATE.
 
 STATE should contain :agent-config with :icon-name, :buffer-name, and
@@ -3363,11 +3366,13 @@ BINDINGS is a list of alists defining key bindings to display, each with:
 
 MODEL-BINDING: Optional key description string for the model menu command.
 MODE-BINDING: Optional key description string for the session mode menu command.
+THOUGHT-LEVEL-BINDING: Optional key description string for the thought level
+menu command.
 When provided, included in help-echo tooltips."
   (unless state
     (error "STATE is required"))
   (let* ((header-model (agent-shell--make-header-model state :qualifier qualifier :bindings bindings))
-         (text-header (format " %s%s%s @ %s%s%s%s"
+         (text-header (format " %s%s%s%s @ %s%s%s%s"
                               (propertize (map-elt header-model :buffer-name)
                                           'font-lock-face 'font-lock-variable-name-face)
                               (if (map-elt header-model :model-name)
@@ -3380,6 +3385,18 @@ When provided, included in help-echo tooltips."
                                                             'local-map (let ((map (make-sparse-keymap)))
                                                                          (define-key map [header-line mouse-1]
                                                                                      (agent-shell--mode-line-model-menu))
+                                                                         map)))
+                                "")
+                              (if (map-elt header-model :thought-level-name)
+                                  (concat " ➤ " (propertize (map-elt header-model :thought-level-name)
+                                                            'font-lock-face 'font-lock-keyword-face
+                                                            'help-echo (concat "Click to open thought level menu "
+                                                                               (when thought-level-binding
+                                                                                 (propertize thought-level-binding 'face 'help-key-binding)))
+                                                            'mouse-face 'mode-line-highlight
+                                                            'local-map (let ((map (make-sparse-keymap)))
+                                                                         (define-key map [header-line mouse-1]
+                                                                                     (agent-shell--mode-line-thought-level-menu))
                                                                          map)))
                                 "")
                               (if (map-elt header-model :mode-name)
@@ -3476,6 +3493,18 @@ When provided, included in help-echo tooltips."
                                                                     `((fill . ,(agent-shell--svg-fill-color 'font-lock-negation-char-face))
                                                                       (dx . "8"))
                                                                     (map-elt header-model :model-name))))
+                                      ;; Thought level (optional)
+                                      (when (map-elt header-model :thought-level-id)
+                                        (dom-append-child text-node
+                                                          (dom-node 'tspan
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'default))
+                                                                      (dx . "8"))
+                                                                    "➤"))
+                                        (dom-append-child text-node
+                                                          (dom-node 'tspan
+                                                                    `((fill . ,(agent-shell--svg-fill-color 'font-lock-keyword-face))
+                                                                      (dx . "8"))
+                                                                    (map-elt header-model :thought-level-name))))
                                       ;; Session mode (optional)
                                       (when (map-elt header-model :mode-id)
                                         ;; Add separator arrow
@@ -3599,7 +3628,10 @@ Returns a MIME type like \"image/png\" or \"image/jpeg\"."
                                                                    agent-shell-mode-map t))
                                   :mode-binding (key-description (where-is-internal
                                                                   'agent-shell-set-session-mode
-                                                                  agent-shell-mode-map t))))
+                                                                  agent-shell-mode-map t))
+                                  :thought-level-binding (key-description (where-is-internal
+                                                                           'agent-shell-set-session-thought-level
+                                                                           agent-shell-mode-map t))))
   (when (memq agent-shell-header-style '(text none nil))
     (force-mode-line-update)))
 
@@ -4177,6 +4209,22 @@ Call ON-SUCCESS after state is updated from the response."
      :on-failure (or on-failure
                      (lambda (acp-error _raw-message)
                        (message "Failed to change session mode: %s" acp-error))))))
+
+(cl-defun agent-shell--config-option-set-thought-level-id (&key thought-level-id on-success on-failure)
+  "Set current thought level to THOUGHT-LEVEL-ID."
+  (if-let ((option (agent-shell--config-option-by-category (agent-shell--state) "thought_level")))
+      (agent-shell--set-session-config-option
+       :config-id (map-elt option :id)
+       :value thought-level-id
+       :on-success (lambda ()
+                     (message "Thought level: %s"
+                              (agent-shell--config-option-value-name option thought-level-id))
+                     (when on-success
+                       (funcall on-success)))
+       :on-failure on-failure)
+    ;; In contrast to model and mode, there is no dedicated request type to change the
+    ;; thought level, so it is not a config option, it cannot be changed
+    (user-error "Agent does not advertise a thought level option for this session")))
 
 (cl-defun agent-shell--set-default-model (&key shell-buffer model-id on-model-changed)
   "Set default model to MODEL-ID in SHELL-BUFFER.
@@ -6554,6 +6602,12 @@ Prefers config option data when available."
          (agent-shell--get-available-modes state))
         mode-id)))
 
+(defun agent-shell-get-thought-level-name (state)
+  "Return current thought level display name from STATE or nil."
+  (when-let* ((option (agent-shell--config-option-by-category state "thought_level"))
+              (current (map-elt option :current-value)))
+    (agent-shell--config-option-value-name option current)))
+
 (defun agent-shell--busy-indicator-frame ()
   "Return busy frame string or nil if not busy."
   (when-let* ((agent-shell-show-busy-indicator)
@@ -6607,6 +6661,26 @@ For example: clicking \"[Accept Edits]\" shows a popup with all available modes.
      (reverse (agent-shell--get-available-modes (agent-shell--state))))
     menu))
 
+(defun agent-shell--mode-line-thought-level-menu ()
+  "Build a menu keymap for selecting a thought level from the mode line.
+
+Clicking the thought level segment in the header/mode-line shows this
+popup."
+  (let ((menu (make-sparse-keymap "Thought level"))
+        (shell-buffer (agent-shell--shell-buffer))
+        (current-id (agent-shell--current-thought-level-id (agent-shell--state))))
+    (seq-do
+     (lambda (value)
+       (define-key menu (vector (intern (concat "thought-level-" (map-elt value :value))))
+                   `(menu-item ,(map-elt value :name)
+                               (lambda () (interactive)
+                                 (with-current-buffer ,shell-buffer
+                                   (agent-shell--config-option-set-thought-level-id
+                                    :thought-level-id ,(map-elt value :value))))
+                               :button (:toggle . ,(equal (map-elt value :value) current-id)))))
+     (reverse (agent-shell--get-available-thought-levels (agent-shell--state))))
+    menu))
+
 (defun agent-shell--mode-line-format ()
   "Return `agent-shell''s mode-line format.
 
@@ -6639,6 +6713,19 @@ Shows \" ⧉\" when a command prefix is used."
                                                    (define-key map [mode-line mouse-1]
                                                                (agent-shell--mode-line-model-menu))
                                                    map))))
+            (when-let ((thought-level-name (agent-shell-get-thought-level-name (agent-shell--state))))
+              (concat " ➤ " (propertize thought-level-name
+                                        'face 'font-lock-keyword-face
+                                        'help-echo (concat "Click to open thought level menu "
+                                                           (propertize (key-description (where-is-internal
+                                                                                         'agent-shell-set-session-thought-level
+                                                                                         agent-shell-mode-map t))
+                                                                       'face 'help-key-binding))
+                                        'mouse-face 'mode-line-highlight
+                                        'local-map (let ((map (make-sparse-keymap)))
+                                                     (define-key map [mode-line mouse-1]
+                                                                 (agent-shell--mode-line-thought-level-menu))
+                                                     map))))
             (when-let ((mode-name (agent-shell--resolve-session-mode-name
                                    (agent-shell--current-mode-id (agent-shell--state))
                                    (agent-shell--get-available-modes (agent-shell--state)))))
@@ -6774,6 +6861,40 @@ Optionally, get notified of completion with ON-SUCCESS function."
      :model-id selected-model-id
      :on-success on-success)))
 
+(defun agent-shell-set-session-thought-level (&optional on-success)
+  "Set thought level (reasoning effort) for the current session.
+
+Optionally, get notified of completion with ON-SUCCESS function."
+  (declare (modes agent-shell-mode))
+  (interactive)
+  (unless (derived-mode-p 'agent-shell-mode)
+    (user-error "Not in an agent-shell buffer"))
+  (unless (map-nested-elt (agent-shell--state) '(:session :id))
+    (user-error "No active session"))
+  (unless (agent-shell--get-available-thought-levels (agent-shell--state))
+    (user-error "Agent does not advertise a thought level option for this session"))
+  (let* ((current-id (agent-shell--current-thought-level-id (agent-shell--state)))
+         (option (agent-shell--config-option-by-category (agent-shell--state) "thought_level"))
+         (default-name (and current-id
+                            (agent-shell--config-option-value-name option current-id)))
+         (choices (mapcar (lambda (value)
+                            (cons (map-elt value :name)
+                                  (map-elt value :value)))
+                          (agent-shell--get-available-thought-levels (agent-shell--state))))
+         (selection (completing-read "Set thought level: "
+                                     (mapcar #'car choices)
+                                     nil t nil nil default-name))
+         (selected-id (cdr (seq-find (lambda (choice)
+                                       (string= selection (car choice)))
+                                     choices))))
+    (unless selected-id
+      (user-error "Unknown thought level: %s" selection))
+    (when (and current-id (string= selected-id current-id))
+      (error "Thought level already %s" selection))
+    (agent-shell--config-option-set-thought-level-id
+     :thought-level-id selected-id
+     :on-success on-success)))
+
 (defun agent-shell-set-session-config-option (&optional on-success)
   "Set a session config option.
 
@@ -6880,6 +7001,7 @@ with ON-SUCCESS function."
     ("m" "Cycle modes" agent-shell-cycle-session-mode :transient t)
     ("M" "Set mode" agent-shell-set-session-mode :transient t)
     ("v" "Set model" agent-shell-set-session-model :transient t)
+    ("t" "Set thought level" agent-shell-set-session-thought-level :transient t)
     ("o" "Set option" agent-shell-set-session-config-option :transient t)
     ("C" "Interrupt" agent-shell-interrupt :transient t)]
    ["Shell"


### PR DESCRIPTION
This PR adds the current thought level / reasoning effort to the UI. While set-config-option allowed changing this before, the current value was not visible anywhere and changing it was not ergonomic. However, this setting exists across various agents and is quite useful to adapt to the prompt to save on tokens or force deeper "thinking".

<img width="612" height="89" alt="grafik" src="https://github.com/user-attachments/assets/a2ce07c0-ab7a-46f4-88c2-ba813b6b875a" />

<img width="624" height="217" alt="Screenshot 2026-05-22 at 21 34 39" src="https://github.com/user-attachments/assets/a69ca2c9-b6ce-43ba-8ab9-a20c0b425b04" />

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

Fixes #439 
