### PR TITLE
Add desktop restore support for agent sessions

### DIFF
--- a/README.org
+++ b/README.org
@@ -759,6 +759,7 @@ always go to Evil modes if you need to with ~C-z~).
 | agent-shell-context-sources                   | Sources to consider when determining M-x agent-shell automatic context.         |
 | agent-shell-cursor-acp-command                | Command and parameters for the Cursor agent client.                             |
 | agent-shell-cursor-environment                | Environment variables for the Cursor agent client.                              |
+| agent-shell-desktop-save-buffers              | Whether Desktop should save and restore active agent shell sessions.            |
 | agent-shell-display-action                    | Display action for agent shell buffers.                                         |
 | agent-shell-droid-acp-command                 | Command and parameters for the Factory Droid ACP client.                        |
 | agent-shell-droid-authentication              | Configuration for Factory Droid authentication.                                 |

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -99,6 +99,10 @@
 ;; Declare as special so byte-compilation doesn't turn `let' bindings into
 ;; lexical bindings (which would not affect `auto-insert' behavior).
 (defvar auto-insert)
+(defvar desktop-buffer-mode-handlers)
+(defvar desktop-dirname)
+(defvar desktop-save-buffer)
+(declare-function desktop-file-name "desktop")
 
 (defcustom agent-shell-permission-icon "⚠"
   "Icon displayed when shell commands require permission to execute.
@@ -587,6 +591,16 @@ Available values:
                  (const :tag "Always start new session" new)
                  (const :tag "Load latest session" latest)
                  (const :tag "Prompt for session" prompt))
+  :group 'agent-shell)
+
+(defcustom agent-shell-desktop-save-buffers nil
+  "Whether Desktop should save and restore active agent shell sessions.
+
+When non-nil, `agent-shell-mode' buffers with an active session ID
+are saved by `desktop-save' and restored by `desktop-read' using
+that exact session ID.  Sessions that do not have an ID yet, such
+as uninitialized `new-deferred' shells, are not saved."
+  :type 'boolean
   :group 'agent-shell)
 
 (defvar agent-shell-idle-timeout 30
@@ -1182,6 +1196,111 @@ Includes shells accessed via viewport buffers, preserving visited order."
             (push shell-buffer seen)
             (push shell-buffer shell-buffers)))))
     (nreverse shell-buffers)))
+
+(defun agent-shell--desktop-save-buffer (desktop-directory)
+  "Return Desktop restore data for the current `agent-shell-mode' buffer.
+DESKTOP-DIRECTORY is the directory where Desktop writes its state."
+  (let ((state (agent-shell--state)))
+    (when-let ((session-id (and agent-shell-desktop-save-buffers
+                                (map-nested-elt state '(:session :id))))
+               (config-id (map-nested-elt state '(:agent-config :identifier))))
+      `((:version . 1)
+        (:directory . ,(desktop-file-name
+                        (file-name-as-directory
+                         (expand-file-name default-directory))
+                        desktop-directory))
+        (:session-id . ,session-id)
+        (:config-id . ,config-id)
+        (:buffer-name . ,(buffer-name))))))
+
+(defun agent-shell--desktop-existing-buffer (session-id config-id)
+  "Return an existing shell buffer for SESSION-ID and CONFIG-ID, or nil."
+  (seq-find
+   (lambda (buffer)
+     (with-current-buffer buffer
+       (and (derived-mode-p 'agent-shell-mode)
+            (equal (map-nested-elt (agent-shell--state) '(:session :id))
+                   session-id)
+            (eq (map-nested-elt (agent-shell--state)
+                                '(:agent-config :identifier))
+                config-id))))
+   (agent-shell-buffers)))
+
+(defun agent-shell--desktop-restore-message-buffer (buffer-name message)
+  "Return a scratch BUFFER-NAME containing Desktop restore MESSAGE."
+  (let ((buffer (generate-new-buffer
+                 (or buffer-name "*agent-shell desktop restore*"))))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "Could not restore agent-shell buffer.\n\n" message "\n"))
+      (setq buffer-read-only t)
+      (setq-local desktop-save-buffer nil))
+    buffer))
+
+(defun agent-shell--desktop-restore-buffer (_buffer-filename
+                                            buffer-name
+                                            buffer-misc)
+  "Restore `agent-shell' BUFFER-NAME from Desktop BUFFER-MISC."
+  (let* ((session-id (map-elt buffer-misc :session-id))
+         (config-id (map-elt buffer-misc :config-id))
+         (saved-directory (map-elt buffer-misc :directory))
+         (directory (and saved-directory
+                         (file-name-as-directory
+                          (expand-file-name saved-directory desktop-dirname))))
+         (config (and config-id
+                      (seq-find (lambda (candidate)
+                                  (eq (map-elt candidate :identifier)
+                                      config-id))
+                                agent-shell-agent-configs)))
+         (restore-buffer-name (or (map-elt buffer-misc :buffer-name)
+                                  buffer-name)))
+    (cond
+     ((not agent-shell-desktop-save-buffers)
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       "Agent-shell Desktop restore is disabled."))
+     ((not session-id)
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       "Desktop entry is missing an agent-shell session ID."))
+     ((not directory)
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       "Desktop entry is missing an agent-shell directory."))
+     ((not (file-directory-p directory))
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       (format "Agent-shell Desktop directory is not available: %s"
+               directory)))
+     ((not config-id)
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       "Desktop entry is missing an agent-shell config ID."))
+     ((not config)
+      (agent-shell--desktop-restore-message-buffer
+       restore-buffer-name
+       (format "No agent-shell config found for %S." config-id)))
+     (t
+      (let ((shell-buffer (or (agent-shell--desktop-existing-buffer
+                               session-id config-id)
+                              (let ((default-directory directory))
+                                (agent-shell--start :config config
+                                                    :no-focus t
+                                                    :new-session t
+                                                    :session-id session-id)))))
+        (when restore-buffer-name
+          (shell-maker-set-buffer-name shell-buffer restore-buffer-name))
+        shell-buffer)))))
+
+(add-hook 'agent-shell-mode-hook
+          (lambda ()
+            (setq-local desktop-save-buffer
+                        #'agent-shell--desktop-save-buffer)))
+
+(with-eval-after-load 'desktop
+  (add-to-list 'desktop-buffer-mode-handlers
+               '(agent-shell-mode . agent-shell--desktop-restore-buffer)))
 
 (defun agent-shell-other-buffer ()
   "Switch to other associated buffer (viewport vs shell)."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1,6 +1,7 @@
 ;;; agent-shell-tests.el --- Tests for agent-shell -*- lexical-binding: t; -*-
 
 (require 'ert)
+(require 'desktop)
 (require 'agent-shell)
 
 ;;; Code:
@@ -2674,6 +2675,167 @@ and it must handle that cleanly."
     (markdown-overlays-put)
     (let ((result (agent-shell--filter-buffer-substring (point-min) (point-max))))
       (should (equal result "Use foo-bar for that.")))))
+
+(ert-deftest agent-shell--desktop-save-buffer-records-session ()
+  "Desktop save data should identify the exact session to restore."
+  (require 'desktop)
+  (with-temp-buffer
+    (let ((agent-shell-desktop-save-buffers t))
+      (setq major-mode 'agent-shell-mode)
+      (setq default-directory temporary-file-directory)
+      (setq-local agent-shell--state
+                  (agent-shell--make-state
+                   :buffer (current-buffer)
+                   :agent-config '((:identifier . codex))))
+      (map-put! (map-elt agent-shell--state :session) :id "session-123")
+      (let ((misc (agent-shell--desktop-save-buffer temporary-file-directory)))
+        (should (equal (map-elt misc :version) 1))
+        (should (equal (map-elt misc :session-id) "session-123"))
+        (should (eq (map-elt misc :config-id) 'codex))
+        (should (equal (map-elt misc :buffer-name) (buffer-name)))))))
+
+(ert-deftest agent-shell--desktop-save-buffer-respects-disabled-custom ()
+  "Desktop save should skip shells when disabled."
+  (with-temp-buffer
+    (let ((agent-shell-desktop-save-buffers nil))
+      (setq major-mode 'agent-shell-mode)
+      (setq-local agent-shell--state
+                  (agent-shell--make-state
+                   :buffer (current-buffer)
+                   :agent-config '((:identifier . codex))))
+      (map-put! (map-elt agent-shell--state :session) :id "session-123")
+      (should-not (agent-shell--desktop-save-buffer temporary-file-directory)))))
+
+(ert-deftest agent-shell--desktop-save-buffer-skips-missing-session ()
+  "Desktop save should skip shells without an active session."
+  (with-temp-buffer
+    (let ((agent-shell-desktop-save-buffers t))
+      (setq major-mode 'agent-shell-mode)
+      (setq-local agent-shell--state
+                  (agent-shell--make-state
+                   :buffer (current-buffer)
+                   :agent-config '((:identifier . codex))))
+      (should-not (agent-shell--desktop-save-buffer temporary-file-directory)))))
+
+(ert-deftest agent-shell--desktop-mode-hook-enables-save-buffer ()
+  "Agent shell buffers should ask Desktop to call the save hook."
+  (with-temp-buffer
+    (setq major-mode 'agent-shell-mode)
+    (run-hooks 'agent-shell-mode-hook)
+    (should (eq desktop-save-buffer #'agent-shell--desktop-save-buffer))))
+
+(ert-deftest agent-shell--desktop-restore-reuses-existing-session-buffer ()
+  "Desktop restore should not create a duplicate for an already-live session."
+  (let ((buffer (generate-new-buffer " *agent-shell-desktop-existing*"))
+        (desktop-dirname temporary-file-directory)
+        (agent-shell-desktop-save-buffers t))
+    (unwind-protect
+        (with-current-buffer buffer
+          (setq major-mode 'agent-shell-mode)
+          (setq-local agent-shell--state
+                      (agent-shell--make-state
+                       :buffer buffer
+                       :agent-config '((:identifier . codex))))
+          (map-put! (map-elt agent-shell--state :session) :id "session-123")
+          (should
+           (eq (agent-shell--desktop-restore-buffer
+                nil "restored"
+                `((:directory . ,temporary-file-directory)
+                  (:session-id . "session-123")
+                  (:config-id . codex)))
+               buffer)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest agent-shell--desktop-restore-starts-exact-session ()
+  "Desktop restore should start the saved session id and buffer name."
+  (let ((desktop-dirname temporary-file-directory)
+        (agent-shell-desktop-save-buffers t)
+        (agent-shell-agent-configs
+         '(((:identifier . codex)
+            (:buffer-name . "Codex"))))
+        (captured-args nil)
+        (captured-directory nil)
+        (captured-name nil)
+        (result-buffer (generate-new-buffer " *agent-shell-desktop-restored*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--start)
+                   (lambda (&rest args)
+                     (setq captured-args args)
+                     (setq captured-directory default-directory)
+                     result-buffer))
+                  ((symbol-function 'shell-maker-set-buffer-name)
+                   (lambda (buffer name)
+                     (should (eq buffer result-buffer))
+                     (setq captured-name name))))
+          (should
+           (eq (agent-shell--desktop-restore-buffer
+                nil "restored"
+                `((:directory . ,temporary-file-directory)
+                  (:session-id . "session-123")
+                  (:buffer-name . "saved buffer")
+                  (:config-id . codex)))
+               result-buffer))
+          (should (equal captured-directory
+                         (file-name-as-directory
+                          (expand-file-name temporary-file-directory))))
+          (should (equal (plist-get captured-args :session-id) "session-123"))
+          (should (plist-get captured-args :no-focus))
+          (should (plist-get captured-args :new-session))
+          (should (equal captured-name "saved buffer"))
+          (should (equal (plist-get captured-args :config)
+                         '((:identifier . codex)
+                           (:buffer-name . "Codex")))))
+      (when (buffer-live-p result-buffer)
+        (kill-buffer result-buffer)))))
+
+(ert-deftest agent-shell--desktop-restore-respects-disabled-custom ()
+  "Desktop restore should not throw an error when disabled."
+  (let ((desktop-dirname temporary-file-directory)
+        (agent-shell-desktop-save-buffers nil))
+    (let ((buffer (agent-shell--desktop-restore-buffer
+                   nil "restored"
+                   `((:directory . ,temporary-file-directory)
+                     (:session-id . "session-123")
+                     (:config-id . codex)))))
+      (unwind-protect
+          (with-current-buffer buffer
+            (should (string-match-p "restore is disabled"
+                                    (buffer-string))))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
+(ert-deftest agent-shell--desktop-restore-missing-data-returns-message-buffer ()
+  "Desktop restore should return an explanatory buffer for invalid state."
+  (let ((desktop-dirname temporary-file-directory)
+        (agent-shell-desktop-save-buffers t))
+    (let ((buffer (agent-shell--desktop-restore-buffer
+                   nil "restored"
+                   `((:directory . ,temporary-file-directory)
+                     (:config-id . codex)))))
+      (unwind-protect
+          (with-current-buffer buffer
+            (should (string-match-p "missing an agent-shell session ID"
+                                    (buffer-string))))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
+(ert-deftest agent-shell--desktop-restore-missing-config-returns-message-buffer ()
+  "Desktop restore should return an explanatory buffer for unknown configs."
+  (let ((desktop-dirname temporary-file-directory)
+        (agent-shell-desktop-save-buffers t)
+        (agent-shell-agent-configs nil))
+    (let ((buffer (agent-shell--desktop-restore-buffer
+                   nil "restored"
+                   `((:directory . ,temporary-file-directory)
+                     (:session-id . "session-123")
+                     (:config-id . codex)))))
+      (unwind-protect
+          (with-current-buffer buffer
+            (should (string-match-p "No agent-shell config found"
+                                    (buffer-string))))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
 
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
I use desktop, and since it's built-in to Emacs, I figured desktop integration should probably live here. Let me know if you disagree, I can pull this out into a separate tiny package. I just find myself having dozens of agent-shells open quite often, my idle timer saves my desktop from time to time, but emacs also does crash on me sometimes, so being able to recover this way is nice.

Since restoring many sessions can be costly, I added a defcustom despite what the CONTRIBUTING.org guideline says, since I believe it is warranted, happy to change that though.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
