### PR TITLE
Fix `agent-shell-hermes-acp-command`

### DIFF
--- a/agent-shell-hermes.el
+++ b/agent-shell-hermes.el
@@ -41,7 +41,7 @@
 (declare-function agent-shell--dwim "agent-shell")
 
 (defcustom agent-shell-hermes-acp-command
-  '(hermes acp)
+  '("hermes" "acp")
   "Command and parameters for the Hermes agent client.
 
 The first element is the command name, and the rest are command parameters."


### PR DESCRIPTION
The previous value for `agent-shell-hermes-acp-command` was broken, consisting of symbols instead of strings.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
