### PR TITLE
Reindent Elisp files

### DIFF
--- a/agent-shell-styles.el
+++ b/agent-shell-styles.el
@@ -73,7 +73,7 @@ Returns a propertized string or nil."
                                         (map-elt status-config :face) nil t)))
                         (agent-shell--add-text-properties
                          (propertize (format label-format
-                                            (agent-shell--short-kind-label kind))
+                                             (agent-shell--short-kind-label kind))
                                      'font-lock-face 'default)
                          'font-lock-face `((:box (:color ,box-color))))))))
     (concat status-text kind-text)))
@@ -102,16 +102,14 @@ Returns a propertized string or nil."
          (label-format (if (display-graphic-p) " %s " "[%s]"))
          (status-text (when status
                         (propertize (format label-format
-                                           (map-elt status-config :label))
+                                            (map-elt status-config :label))
                                     'font-lock-face
-                                    `(:background ,bg :foreground ,fg
-                                      :weight bold))))
+                                    `(:background ,bg :foreground ,fg :weight bold))))
          (kind-text (when kind
                       (propertize (format label-format
-                                         (agent-shell--short-kind-label kind))
+                                          (agent-shell--short-kind-label kind))
                                   'font-lock-face
-                                  `(:background ,bg :foreground ,fg
-                                    :slant italic)))))
+                                  `(:background ,bg :foreground ,fg :slant italic)))))
     (concat status-text kind-text)))
 
 (defun agent-shell--unicode-icons-status-kind-label (status kind)
@@ -154,11 +152,11 @@ Returns a propertized string or nil."
          (label-format (if (display-graphic-p) " %s " "[%s]"))
          (status-text (when status
                         (propertize (format label-format
-                                           (map-elt status-config :label))
+                                            (map-elt status-config :label))
                                     'font-lock-face face)))
          (kind-text (when kind
                       (propertize (format label-format
-                                         (agent-shell--short-kind-label kind))
+                                          (agent-shell--short-kind-label kind))
                                   'font-lock-face face))))
     (concat status-text kind-text)))
 

--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -862,8 +862,8 @@ buffer from the snapshot and switch to edit mode."
   (let* ((shell-buffer (or (agent-shell--current-shell)
                            (user-error "Not in an agent-shell buffer")))
          (viewport-buffer (agent-shell-viewport--buffer
-                          :shell-buffer shell-buffer
-                          :existing-only t)))
+                           :shell-buffer shell-buffer
+                           :existing-only t)))
     (with-current-buffer shell-buffer
       (agent-shell-set-session-model
        (lambda ()
@@ -879,8 +879,8 @@ buffer from the snapshot and switch to edit mode."
   (let* ((shell-buffer (or (agent-shell--current-shell)
                            (user-error "Not in an agent-shell buffer")))
          (viewport-buffer (agent-shell-viewport--buffer
-                          :shell-buffer shell-buffer
-                          :existing-only t)))
+                           :shell-buffer shell-buffer
+                           :existing-only t)))
     (with-current-buffer shell-buffer
       (agent-shell-set-session-mode
        (lambda ()
@@ -915,8 +915,8 @@ buffer from the snapshot and switch to edit mode."
   (let* ((shell-buffer (or (agent-shell--current-shell)
                            (user-error "Not in an agent-shell buffer")))
          (viewport-buffer (agent-shell-viewport--buffer
-                          :shell-buffer shell-buffer
-                          :existing-only t)))
+                           :shell-buffer shell-buffer
+                           :existing-only t)))
     (with-current-buffer shell-buffer
       (agent-shell-cycle-session-mode
        (lambda ()

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1396,7 +1396,7 @@ If DELETE is non-nil, delete the text between START and END."
             (exclude (seq-find (lambda (ov)
                                  (memq (overlay-get ov 'markdown-overlays-markup-type)
                                        '(fence language inline-code
-                                         bold italic strikethrough header)))
+                                               bold italic strikethrough header)))
                                (overlays-at pos))))
         (unless exclude
           (setq text (concat text (buffer-substring pos (min next end)))))
@@ -2753,7 +2753,7 @@ Returns propertized labels in :status and :title propertized."
                     ;; "[read] file.el"
                     (if (and (map-elt tool-call :kind)
                              (string-match-p (concat "\\`" (regexp-quote
-                                                           (map-elt tool-call :kind)) " ")
+                                                            (map-elt tool-call :kind)) " ")
                                              (downcase text)))
                         (string-trim-left (substring text (length (map-elt tool-call :kind))))
                       text)))
@@ -6396,7 +6396,7 @@ Returns non-nil if a permission button was found, nil otherwise."
                          (when-let* ((next-change (next-single-property-change (point) 'agent-shell-permission-button)))
                            (goto-char next-change)))
                        (when-let* ((next (text-property-search-forward
-                                         'agent-shell-permission-button t t)))
+                                          'agent-shell-permission-button t t)))
                          (prop-match-beginning next)))))
     (deactivate-mark)
     (goto-char found)


### PR DESCRIPTION
Except in agent-shell-ui.el, where the automatic indentation would be
ugly.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.