### PR TITLE
Fix source-block face background not rendering when theme loads after…

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -144,13 +144,11 @@
   :group 'agent-shell-markdown)
 
 (defface agent-shell-markdown-source-block
-  `((t :background ,(face-attribute 'org-block :background nil t) :extend t))
+  '((t :inherit org-block :foreground unspecified :extend t))
   "Background face applied to rendered fenced source-block bodies.
-Background is taken from `org-block' so only the block color is
-inherited, letting font-lock keep its own foreground colors.
-`:extend t' makes the background color reach the right edge of
-the window, so the block reads as a contiguous panel rather than
-a per-char highlight."
+Inherits background from `org-block'.  `:foreground unspecified'
+preserves font-lock colors.  `:extend t' fills the line to the
+window edge."
   :group 'agent-shell-markdown)
 
 (defface agent-shell-markdown-source-block-language


### PR DESCRIPTION
The previous fix sampled org-block's background at load time using face-attribute. If the package loads before the user's theme is applied (common with lazy-loading setups), face-attribute returns unspecified and no background is rendered.

Switching to :inherit org-block resolves this by deferring face attribute lookup to render time, so the face always reflects the active theme. :foreground unspecified is added explicitly to prevent org-block's foreground (if set by the theme) from overriding font-lock syntax highlighting colors inside the block.

With the fix:
<img width="1911" height="1159" alt="screenshot-20260604-173045" src="https://github.com/user-attachments/assets/e910dfc9-56b5-47ae-8990-f45a9334ef80" />

Without the fix:
<img width="1911" height="1161" alt="screenshot-20260604-174903" src="https://github.com/user-attachments/assets/b7423446-3f5c-4301-8745-bfcee1efd296" />

The difference is subtle, but it's there.


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
