### PR TITLE
hermes: add default-session-mode-id to match other agents

### DIFF
--- a/agent-shell-hermes.el
+++ b/agent-shell-hermes.el
@@ -57,6 +57,22 @@ starting the Hermes agent process."
   :type '(repeat string)
   :group 'agent-shell)
 
+(defcustom agent-shell-hermes-default-session-mode-id "accept_edits"
+  "Default ACP session mode for the Hermes agent.
+
+Controls edit approval behavior (file patch/write permission prompts).
+
+Possible values are one of:
+
+\\='default'       Ask every time for any file edit.
+\\='accept_edits'  Auto-approve workspace and /tmp edits; prompt only for
+                  sensitive paths like .git/.ssh/.env. (Default.)
+\\='dont_ask'      Auto-approve all non-sensitive edits for the entire session."
+  :type '(choice (const :tag "Ask every time" nil)
+                 (const :tag "Accept edits (workspace+tmp)" "accept_edits")
+                 (const :tag "Don't ask (session-wide)" "dont_ask"))
+  :group 'agent-shell)
+
 (defun agent-shell-hermes-make-agent-config ()
   "Create a Hermes agent configuration.
 
@@ -71,6 +87,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-hermes--welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-hermes-make-client :buffer buffer))
+   :default-session-mode-id (lambda () agent-shell-hermes-default-session-mode-id)
    :install-instructions
    "Defaults to running 'hermes acp' locally.
 Customize \\\\[customize-variable] `agent-shell-hermes-acp-command' for remote setups (e.g., via SSH)."))


### PR DESCRIPTION
## Summary

Add `agent-shell-hermes-default-session-mode-id` defcustom so the Hermes agent follows the same pattern as Claude, OpenAI, Mistral, and OpenCode integrations.

Defaults to `"accept_edits"` (auto-approve edits in workspace and /tmp, except sensitive paths like .git/.ssh/.env).

## Motivation

All other agent integrations already support `:default-session-mode-id` on their agent configuration. Hermes was the only one missing this knob, which means new sessions always started with mode `"default"` — no way for users to configure a sensible default without patching Hermes ACP source code.

## Changes

- Add `agent-shell-hermes-default-session-mode-id` defcustom in `agent-shell-hermes.el`
- Wire it into `agent-shell-hermes-make-agent-config` via `:default-session-mode-id`
- Defaults to `"accept_edits"` for a better out-of-box experience (workspace + /tmp edits auto-approved, sensitive paths still prompt)


Relates to #626

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
