### PR TITLE
Write .agent-shell/ to .git/info/exclude instead of .gitignore

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2646,13 +2646,26 @@ For example:
                         (expand-file-name ".agent-shell" (agent-shell-cwd)))))
 
 (defun agent-shell--ensure-gitignore (project-root)
-  "If .agent-shell/ is not ignored under PROJECT-ROOT, add it to .gitignore."
+  "If .agent-shell/ is not ignored under PROJECT-ROOT, add it to .git/info/exclude."
   (condition-case nil
       (when-let* (((eq 'Git (vc-responsible-backend project-root t)))
                   (default-directory project-root)
                   ((not (zerop (process-file "git" nil nil nil
-                                             "check-ignore" "-q" ".agent-shell")))))
-        (vc-ignore "/.agent-shell/" project-root))
+                                             "check-ignore" "-q" ".agent-shell"))))
+                  (git-dir (with-temp-buffer
+                              (when (zerop (process-file "git" nil t nil
+                                                         "rev-parse" "--git-dir"))
+                                (string-trim (buffer-string)))))
+                  (exclude-file (expand-file-name "info/exclude" git-dir)))
+        (make-directory (file-name-directory exclude-file) t)
+        (with-temp-buffer
+          (when (file-exists-p exclude-file)
+            (insert-file-contents exclude-file))
+          (goto-char (point-max))
+          (unless (bolp)
+            (insert "\n"))
+          (insert "/.agent-shell/\n")
+          (write-region nil nil exclude-file)))
     (error nil)))
 
 (cl-defun agent-shell--capture-screenshot (&key destination-dir)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2407,6 +2407,38 @@ code block content
     (let ((agent-shell-dot-subdir-function (lambda (_subdir) "  ")))
       (should-error (agent-shell--dot-subdir "screenshots") :type 'error))))
 
+(ert-deftest agent-shell--ensure-gitignore-writes-to-git-exclude-test ()
+  "Test that `agent-shell--ensure-gitignore' writes /.agent-shell/ to .git/info/exclude."
+  (let ((temp-dir (make-temp-file "agent-shell-test" t)))
+    (unwind-protect
+        (let ((default-directory temp-dir))
+          (process-file "git" nil nil nil "init")
+          (agent-shell--ensure-gitignore temp-dir)
+          (should (string-match-p
+                   (regexp-quote "/.agent-shell/")
+                   (with-temp-buffer
+                     (insert-file-contents
+                      (expand-file-name ".git/info/exclude" temp-dir))
+                     (buffer-string)))))
+      (delete-directory temp-dir t))))
+
+
+(ert-deftest agent-shell--ensure-gitignore-noop-when-already-ignored-test ()
+  "Test that `agent-shell--ensure-gitignore' does not add a duplicate entry."
+  (let ((temp-dir (make-temp-file "agent-shell-test" t)))
+    (unwind-protect
+        (let* ((default-directory temp-dir)
+               (exclude-file (expand-file-name ".git/info/exclude" temp-dir)))
+          (process-file "git" nil nil nil "init")
+          (make-directory (expand-file-name ".agent-shell" temp-dir) t)
+          (write-region "/.agent-shell/\n" nil exclude-file t 'no-message)
+          (agent-shell--ensure-gitignore temp-dir)
+          (should (= 1 (with-temp-buffer
+                         (insert-file-contents exclude-file)
+                         (count-matches (regexp-quote "/.agent-shell/")
+                                        (point-min) (point-max))))))
+      (delete-directory temp-dir t))))
+
 (ert-deftest agent-shell--on-request-calls-permission-request-handler-test ()
   "Test `agent-shell--on-request' calls handler and :respond auto-approves."
   (with-temp-buffer


### PR DESCRIPTION
This modifies `agent-shell--ensure-gitignore` to now write to `.git/info/exclude`, as is more appropriate for user workflow specific tools being local to the clone and never tracked. Any users already using `.agent-shell` in the `.gitignore` will be unaffected. The code is modeled off similar code in `magit`. Also added a couple of tests.

Closes #517 

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
