### PR TITLE
feat: Add GitHub Actions workflow for ERT tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: '29.1'
+
+      - name: Clone dependencies
+        run: |
+          git clone --depth 1 https://github.com/xenodium/acp.el ../acp
+          git clone --depth 1 https://github.com/xenodium/shell-maker ../shell-maker
+          git clone --depth 1 https://bitbucket.org/olanilsson/ert-junit ../ert-junit
+
+      - name: Run tests
+        run: |
+          emacs --batch -Q \
+            -L . \
+            -L ../acp \
+            -L ../shell-maker \
+            -L ../ert-junit \
+            --load ert-junit \
+            --load tests/agent-shell-fakes.el \
+            $(find tests -name '*-tests.el' | sort | sed 's/^/--load /') \
+            -f ert-junit-run-tests-batch-and-exit \
+            test-results.xml
+
+      - name: Report test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: ERT Tests
+          path: test-results.xml
+          reporter: java-junit


### PR DESCRIPTION
This adds a single GitHub Action workflow to run the test suite and display the output. The output is displayed via `dorny/test-reporter`, which is what parses the JUnit XML and surfaces the results in GitHub checks and PR UI.

I tried several different methods of getting the test output to work properly. Emacs NEWS 29 says that they added a feature to enable JUnit integration without needing `ert-junit`, but for the life of me I couldn't get it to output the results file, so I went back to using `ert-junit`.

I also need to pull in `acp.el` and `shell-maker` as dependencies. I tried doing so via MELPA as well, which worked, but thought `git clone` made more sense. Unfortunately, that meant I also had to clone `ert-junit` the same way or have a very strange dependency installation system.

This could be made better by moving most of these kinds of scripts into a `Makefile`, which is what I've seen is pretty common in other Emacs packages, but I didn't want to add that to this PR without discussing it first.

I opted for version 29.1 basically because I needed to choose one, but we can change that to any stable version, or test on multiple versions for that matter.

[Example summary](https://github.com/phairoh/agent-shell/actions/runs/27103685741)
[Example details](https://github.com/phairoh/agent-shell/actions/runs/27103685741/job/79988896703)

Closes #628 

Something to note is that this could blow up your email depending on your settings. I just noticed that I got a bunch of failed tests emails from GitHub for all the times I was testing this. We may want to adjust the `on` conditions as well.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
