### PR TITLE
Adjust region line counting when ending at the beginning of a line

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -7143,8 +7143,7 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                       (let ((char-start (map-elt region :char-start))
                                             (char-end (map-elt region :char-end))
                                             (max-preview-lines 5))
-                                        (if (equal (line-number-at-pos char-start)
-                                                   (line-number-at-pos char-end))
+                                        (if (= (count-lines char-start char-end) 1)
                                             ;; Same line region? Avoid numbering.
                                             (buffer-substring char-start char-end)
                                           (agent-shell--get-numbered-region
@@ -7170,7 +7169,11 @@ If CAP is non-nil, truncate at CAP."
     (save-excursion
       (goto-char from)
       (let* ((start-line (line-number-at-pos from))
-             (end-line (line-number-at-pos to))
+             (end-line (save-excursion
+                         (goto-char to)
+                         (when (and (bolp) (not (bobp)))
+                           (backward-char))
+                         (line-number-at-pos)))
              (lines '())
              (current-line start-line))
         (goto-char (point-min))
@@ -7394,8 +7397,12 @@ Available values:
         (:language . ,language)
         (:char-start . ,start)
         (:char-end . ,end)
-        (:line-start . ,(save-excursion (goto-char start) (line-number-at-pos)))
-        (:line-end . ,(save-excursion (goto-char end) (line-number-at-pos)))
+        (:line-start . ,(line-number-at-pos start))
+        (:line-end . ,(save-excursion
+                        (goto-char end)
+                        (when (and (bolp) (not (bobp)))
+                          (backward-char))
+                        (line-number-at-pos)))
         (:content . ,content)))))
 
 (cl-defun agent-shell--align-alist (&key data columns (separator "  ") joiner)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -425,11 +425,12 @@
 (ert-deftest agent-shell--get-numbered-region-test ()
   "Test `agent-shell--get-numbered-region' preserves selection and respects TRIM."
   (with-temp-buffer
-    ;; Lines: 1="", 2="foo", 3="", 4="bar", 5="" (trailing newline).
+    ;; Lines: 1="", 2="foo", 3="", 4="bar", 5="" (including trailing newline).
     (insert "
 foo
 
 bar
+
 ")
     ;; Without TRIM: empty boundary lines (1 and 5) are preserved.
     (should (equal (agent-shell--get-numbered-region
@@ -449,7 +450,25 @@ bar
                     :trim t)
                    "   2: foo
    3: 
-   4: bar"))))
+   4: bar")))
+  (with-temp-buffer
+    (insert "foo
+bar
+baz
+")
+    (let (from to)
+      (goto-char (point-min))
+      (forward-line 1)
+      (setq from (point))
+      (forward-line 1)
+      (setq to (point))
+      ;; When selecting whole lines including trailing newline, adjust
+      ;; region-end
+      (should (equal (agent-shell--get-numbered-region
+                    :buffer (current-buffer)
+                    :from from
+                    :to to)
+                   "   2: bar")))))
 
 (ert-deftest agent-shell--expand-truncated-regions-test ()
   "Test `agent-shell--expand-truncated-regions' substitutes marked spans for their full text."


### PR DESCRIPTION
If a region contains some number of whole lines including the final
newline, avoid including the rest of the line that the region-end is
"on".

Fix #646

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [X] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.