### PR TITLE
Don't italicize intraword underscores

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -357,28 +357,31 @@ Markup characters are deleted; remaining inner text carries face
 properties.  Spans that fall inside any of AVOID-RANGES are left
 untouched.  Returns non-nil if at least one replacement was made.
 
+A `_X_' span must be followed by punctuation, whitespace, or a line
+end, so intraword underscores such as \"_hello_world\" are left as
+literal text rather than emphasized.
+
 For example, the buffer \"hello *world*.\" becomes \"hello
 world.\" with face `agent-shell-markdown-italic' on \"world\"."
   (let ((case-fold-search nil)
         (changed nil))
     (goto-char (point-min))
     (while (re-search-forward
-            (rx (or (group (or bol (one-or-more (any "\n \t")))
-                           (group "*")
-                           (group (one-or-more (not (any "\n*")))) "*")
-                    (group (or bol (one-or-more (any "\n \t")))
-                           (group "_")
-                           (group (one-or-more (not (any "\n_")))) "_")))
+            (rx (or (seq (or bol (one-or-more (any "\n \t")))
+                         (group "*" (group (one-or-more (not (any "\n*")))) "*"))
+                    (seq (or bol (one-or-more (any "\n \t")))
+                         (group "_" (group (one-or-more (not (any "\n_")))) "_")
+                         (or (syntax punctuation) (syntax whitespace) line-end))))
             nil t)
-      (let* ((markup-start (or (match-beginning 2) (match-beginning 5)))
-             (markup-end (match-end 0))
+      (let* ((markup-start (or (match-beginning 1) (match-beginning 3)))
+             (markup-end (or (match-end 1) (match-end 3)))
              (avoid (agent-shell-markdown--in-avoid-range-p
                      markup-start markup-end avoid-ranges)))
         (if avoid
             (goto-char (cdr avoid))
           (let ((text (buffer-substring
-                       (or (match-beginning 3) (match-beginning 6))
-                       (or (match-end 3) (match-end 6)))))
+                       (or (match-beginning 2) (match-beginning 4))
+                       (or (match-end 2) (match-end 4)))))
             (delete-region markup-start markup-end)
             (goto-char markup-start)
             (insert text)

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -40,6 +40,11 @@
                  '(("hello " nil)
                    ("world" (agent-shell-markdown-italic))))))
 
+(ert-deftest agent-shell-markdown-convert-italic-underscore-intraword ()
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert "Echo _hello_world"))
+                 '(("Echo _hello_world" nil)))))
+
 (ert-deftest agent-shell-markdown-convert-multiple ()
   (should (equal (agent-shell-markdown--deconstruct
                   (agent-shell-markdown-convert "_my_ **text**"))


### PR DESCRIPTION
## Summary
- prevent `_..._` italic conversion when the closing underscore is followed by a word character
- keep intraword underscores like `_hello_world` literal instead of stripping underscores and italicizing the prefix
- add a regression test covering the intraword underscore case

## Test Plan
- [x] `emacs --batch -L . -L tests -l ert -l tests/agent-shell-markdown-tests.el -f ert-run-tests-batch-and-exit`
- [x] full ERT suite on this branch (`243 tests: 241 passed, 2 skipped`)

Closes #640
