### PR TITLE
ci: Post test results on fork PRs

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,34 @@
+name: Test Report
+
+# Posts ERT test results as a check on PRs, including PRs from forks.
+#
+# Why this is a separate workflow: GitHub gives a read-only GITHUB_TOKEN to
+# any workflow triggered by `pull_request` from a fork, ignoring the
+# `permissions:` block. dorny/test-reporter creates a check run, which needs
+# `checks: write`, so it can't run inside test.yml on fork PRs. A
+# `workflow_run` workflow runs in the base-repo context with full
+# permissions, so it can post the check after Tests finishes. test.yml just
+# uploads the JUnit XML as an artifact; this workflow downloads and reports it.
+#
+# `workflows: ['Tests']` must match `name:` in test.yml.
+
+on:
+  workflow_run:
+    workflows: ['Tests']
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v3
+        with:
+          artifact: test-results   # downloads from the triggering run
+          name: ERT Tests
+          path: test-results.xml
+          reporter: java-junit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
 
 permissions:
-  checks: write
-  pull-requests: write
+  contents: read
 
 jobs:
   test:
@@ -38,17 +37,9 @@ jobs:
             -f ert-junit-run-tests-batch-and-exit \
             test-results.xml
 
-      - name: Report test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        # Reporter needs `checks: write' on GITHUB_TOKEN; for PRs from
-        # forks GitHub downgrades the token to read-only, so this step
-        # fails with "Resource not accessible by integration".
-        # `continue-on-error' keeps the workflow green in that case —
-        # the actual test pass/fail is still reflected by the `Run
-        # tests' step above.
-        continue-on-error: true
+      - name: Upload test results
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
         with:
-          name: ERT Tests
+          name: test-results
           path: test-results.xml
-          reporter: java-junit


### PR DESCRIPTION
This fixes test reporting for pull requests from forks. The reporter step [currently fails](https://github.com/xenodium/agent-shell/actions/runs/27449600926/job/81141921498#step:6:30) with `Resource not accessible by integration` because GitHub gives forked PR workflows a read-only token. That's hidden today by `continue-on-error: true`.

Sorry, I've setup CI a million times but never on a public open source project.

This splits the single workflow into 2:
- `test.yml` runs the tests and uploads the JUnit XML as an artifact
- `test-report.yml` triggers on `workflow_run` completion

Also bumps `dorny/test-reporter` from v1 to v3 since v1 is on an end-of-life Node runtime and v3 is what the action documents for the `workflow_run` + `artifact:` pattern.

### Heads-up
- `test-report.yml` only activates after it's merged in to `main`. It won't trigger on this PR or an PR opened before this one gets merged in, and even then they'd have to rebase onto the changes
- The check may appear attached to the `Test Report` workflow rather than the `Tests` run. That's a GitHub Checks API limitation, not a config issue. The check is still created against the commit and shows in the PR's checks list.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
