### PR TITLE
Fix file paths in README for model registration

### DIFF
--- a/README.org
+++ b/README.org
@@ -488,7 +488,7 @@ If ~opencode~ is not found by ~agent-shell~, you can add it to the search path
 
 To register the local Qwen2.5:7b model in opencode, two files needs to be edited:
 
-~./config/opencode/opencode.json~
+~/.config/opencode/opencode.json~
 #+BEGIN_SRC js
      {
          "$schema": "https://opencode.ai/config.json",
@@ -512,7 +512,7 @@ To register the local Qwen2.5:7b model in opencode, two files needs to be edited
      }
 #+END_SRC
 
-and a dummy auth file ~./local/share/opencode/auth.json~
+and a dummy auth file ~/.local/share/opencode/auth.json~
 
 #+begin_src js
 {


### PR DESCRIPTION
Corrected file paths for Qwen2.5:7b model registration.

Thank you for contributing to agent-shell!

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
