### PR TITLE
Fix previous-item skipping the current fragment's heading

### DIFF
--- a/agent-shell-ui.el
+++ b/agent-shell-ui.el
@@ -905,21 +905,26 @@ that span a line break."
       found)))
 
 (defun agent-shell-ui-backward-block ()
-  "Jump to the previous block."
+  "Jump to the previous block.
+
+When point is strictly inside a navigatable block, jump to that
+block's beginning instead of the previous block."
   (interactive)
   (when-let* ((start-point (point))
               (found (save-mark-and-excursion
-                       ;; In navigatable block already
-                       ;; move to beginning.
-                       (when-let* ((state (get-text-property (point) 'agent-shell-ui-state))
-                                   (block (agent-shell-ui--block-range :position (point))))
-                         (goto-char (map-elt block :start)))
-                       (when-let* ((prev (text-property-search-backward
-                                          'agent-shell-ui-state nil
-                                          (lambda (_old-val new-val)
-                                            (and new-val (map-elt new-val :navigatable)))
-                                          t)))
-                         (prop-match-beginning prev)))))
+                       (let* ((state (get-text-property (point) 'agent-shell-ui-state))
+                              (block (and state (agent-shell-ui--block-range :position (point))))
+                              (block-start (and block (map-elt block :start))))
+                         (if (and block-start
+                                  (map-elt state :navigatable)
+                                  (< block-start start-point))
+                             block-start
+                           (when-let* ((prev (text-property-search-backward
+                                              'agent-shell-ui-state nil
+                                              (lambda (_old-val new-val)
+                                                (and new-val (map-elt new-val :navigatable)))
+                                              t)))
+                             (prop-match-beginning prev)))))))
     (when found
       (deactivate-mark)
       (goto-char found)

--- a/tests/agent-shell-ui-tests.el
+++ b/tests/agent-shell-ui-tests.el
@@ -264,6 +264,65 @@ but `:qualified-id` is stable.  Toggle resolves the target via
           (should (agent-shell-ui-tests--fragment-collapsed-p "ns" "1")))
       (kill-buffer buf))))
 
+;;; backward-block
+
+(defun agent-shell-ui-tests--fragment-start (qualified-id)
+  "Return the start position of fragment QUALIFIED-ID, or nil."
+  (save-mark-and-excursion
+    (goto-char (point-min))
+    (when-let* ((match (text-property-search-forward
+                        'agent-shell-ui-state nil
+                        (lambda (_ state)
+                          (equal (map-elt state :qualified-id) qualified-id))
+                        t)))
+      (prop-match-beginning match))))
+
+(ert-deftest agent-shell-ui-backward-block-from-inside-goes-to-own-start-test ()
+  "`agent-shell-ui-backward-block' from inside a block goes to its own start.
+
+From the block's start it then jumps to the previous block."
+  (let ((buf (agent-shell-ui-tests--make-buffer-with-fragments
+              '(((:namespace-id . "ns") (:block-id . "1")
+                 (:label-left . "First") (:body . "body one") (:expanded . t))
+                ((:namespace-id . "ns") (:block-id . "2")
+                 (:label-left . "Second") (:body . "body two") (:expanded . t))))))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((first-start (agent-shell-ui-tests--fragment-start "ns-1"))
+                (second-start (agent-shell-ui-tests--fragment-start "ns-2")))
+            ;; Strictly inside the second block -> its own start.
+            (goto-char (+ second-start 3))
+            (should (equal (agent-shell-ui-backward-block) second-start))
+            ;; At the second block's start -> the previous block.
+            (goto-char second-start)
+            (should (equal (agent-shell-ui-backward-block) first-start))))
+      (kill-buffer buf))))
+
+(ert-deftest agent-shell-ui-backward-block-skips-non-navigatable-block-test ()
+  "`agent-shell-ui-backward-block' skips non-navigatable blocks.
+
+From inside a non-navigatable block it lands on the previous
+navigatable block, not on the non-navigatable block's own start."
+  (let ((buf (generate-new-buffer " *test-ui-fragments*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (agent-shell-ui-mode 1)
+          (agent-shell-ui-update-fragment
+           (agent-shell-ui-make-fragment-model
+            :namespace-id "ns" :block-id "1"
+            :label-left "First" :body "body one")
+           :expanded t :navigation 'always)
+          (agent-shell-ui-update-fragment
+           (agent-shell-ui-make-fragment-model
+            :namespace-id "ns" :block-id "2"
+            :label-left "Second" :body "body two")
+           :expanded t :navigation 'never)
+          (let ((first-start (agent-shell-ui-tests--fragment-start "ns-1"))
+                (non-nav-start (agent-shell-ui-tests--fragment-start "ns-2")))
+            (goto-char (+ non-nav-start 3))
+            (should (equal (agent-shell-ui-backward-block) first-start))))
+      (kill-buffer buf))))
+
 ;;; provide
 
 (provide 'agent-shell-ui-tests)


### PR DESCRIPTION
Fixes #655.

`agent-shell-ui-backward-block` moved point to the current block's start and
then searched backward, so from inside a fragment it returned the *previous*
fragment's start — `agent-shell-previous-item` and
`agent-shell-viewport-previous-item` skipped the heading of the fragment that
contains point.

This returns the current fragment's start when point is strictly inside it.
From a fragment's start it still moves to the previous fragment, so repeated
presses walk fragment-to-fragment as before. `agent-shell-ui-forward-block` is
left unchanged: going forward the current fragment's start is already behind
point, so the next stop is genuinely the next fragment.

Adds a regression test on `agent-shell-ui-backward-block`.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed an issue for this bug (#655).
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss. (n/a — no visual change)
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary. (n/a)
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
