### PR TITLE
Fix viewport previous-page navigation and stale position label

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -311,7 +311,12 @@ Optionally set its PROMPT and RESPONSE."
     (when response
       (insert response))
     (let ((inhibit-read-only t))
-      (markdown-overlays-put))))
+      (markdown-overlays-put))
+    ;; Re-render the header from the freshly-cached position.  Without
+    ;; this, callers that set content via this function (e.g.
+    ;; `agent-shell-viewport-refresh' on switch) leave the header showing
+    ;; the previously-rendered position.
+    (agent-shell-viewport--update-header)))
 
 (defun agent-shell-viewport--ensure-buffer ()
   "Ensure current buffer is a viewport and err otherwise."
@@ -839,11 +844,20 @@ buffer from the snapshot and switch to edit mode."
           (cl-return-from agent-shell-viewport-next-page))
       (when-let* ((next (with-current-buffer shell-buffer
                           (if backwards
-                              (when (save-excursion
-                                      (let ((orig-line (line-number-at-pos)))
-                                        (comint-previous-prompt 1)
-                                        (= orig-line (line-number-at-pos))))
-                                (error "No previous page"))
+                              (progn
+                                ;; Navigate relative to the interaction
+                                ;; containing point, not wherever point happens
+                                ;; to sit within it.  Without this, switching to
+                                ;; the viewport with point mid-interaction makes
+                                ;; the first backward step land on the current
+                                ;; interaction's prompt instead of the previous
+                                ;; interaction.
+                                (goto-char (shell-maker--prompt-begin-position))
+                                (when (save-excursion
+                                        (let ((orig-line (line-number-at-pos)))
+                                          (comint-previous-prompt 1)
+                                          (= orig-line (line-number-at-pos))))
+                                  (error "No previous page")))
                             (when (save-excursion
                                     (let ((orig-line (point)))
                                       (comint-next-prompt 1)
@@ -855,7 +869,6 @@ buffer from the snapshot and switch to edit mode."
         (goto-char (if start-at-top
                        (point-min)
                      (if backwards (point-max) (point-min))))
-        (agent-shell-viewport--update-header)
         next))))
 
 (defun agent-shell-viewport-set-session-model ()

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -3101,5 +3101,83 @@ agent activity; consecutive user chunks stay in the same turn."
         (should session-init-called)
         (should-not (map-elt agent-shell--state :pending-restore))))))
 
+(ert-deftest agent-shell-viewport-next-page-navigates-from-current-prompt-begin-test ()
+  "Test `agent-shell-viewport-next-page' navigates from the current prompt.
+
+When the shell point sits mid-interaction (e.g. after switching to the
+viewport without repositioning), navigation must start from the current
+interaction's prompt begin, otherwise a backward step lands on the
+current interaction instead of the previous one."
+  (let ((shell-buffer (generate-new-buffer " *agent-shell shell*"))
+        (viewport-buffer (generate-new-buffer " *agent-shell shell* [viewport]"))
+        (navigated-from nil)
+        (prompt-begin nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer shell-buffer
+            (insert "line one\nprompt two line\nresponse line three\nmore content")
+            (goto-char (point-min))
+            (forward-line 1)
+            (setq prompt-begin (point))
+            ;; Point sits mid/after the interaction, not at the prompt begin.
+            (goto-char (point-max)))
+          (with-current-buffer viewport-buffer
+            (cl-letf (((symbol-function 'agent-shell-viewport--update-header)
+                       (lambda () nil)))
+              (agent-shell-viewport-view-mode)))
+          (with-current-buffer viewport-buffer
+            (cl-letf (((symbol-function 'agent-shell-viewport--busy-p)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'agent-shell-viewport--shell-buffer)
+                       (lambda (&rest _) shell-buffer))
+                      ((symbol-function 'agent-shell-viewport--position)
+                       (lambda (&rest _) '((:current . 2) (:total . 2))))
+                      ((symbol-function 'shell-maker--prompt-begin-position)
+                       (lambda () prompt-begin))
+                      ((symbol-function 'comint-previous-prompt)
+                       (lambda (&rest _) (forward-line -1)))
+                      ((symbol-function 'agent-shell--next-command-and-response)
+                       (lambda (_backwards)
+                         (setq navigated-from (point))
+                         '("prompt two" . "response")))
+                      ((symbol-function 'agent-shell-viewport--initialize)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'agent-shell-viewport--update-header)
+                       (lambda () nil)))
+              (agent-shell-viewport-next-page :backwards t)
+              (should (equal navigated-from prompt-begin)))))
+      (kill-buffer viewport-buffer)
+      (kill-buffer shell-buffer))))
+
+(ert-deftest agent-shell-viewport-initialize-rerenders-header-position-test ()
+  "Test `agent-shell-viewport--initialize' re-renders the header position.
+
+A stale cached position must not survive a content refresh, otherwise
+the header shows a position that doesn't match the displayed
+interaction (e.g. \"1/2\" after switching to the latest interaction)."
+  (let ((viewport-buffer (generate-new-buffer " *agent-shell shell* [viewport]"))
+        (shell-buffer (generate-new-buffer " *agent-shell shell*"))
+        (rendered-position nil))
+    (unwind-protect
+        (with-current-buffer viewport-buffer
+          (cl-letf (((symbol-function 'agent-shell-viewport--update-header)
+                     (lambda () nil)))
+            (agent-shell-viewport-view-mode))
+          ;; Seed a stale cached position.
+          (setq agent-shell-viewport--position-cache '((:current . 1) (:total . 2)))
+          (cl-letf (((symbol-function 'agent-shell-viewport--shell-buffer)
+                     (lambda (&rest _) shell-buffer))
+                    ((symbol-function 'shell-maker-history-position)
+                     (lambda () '((:current . 2) (:total . 2))))
+                    ((symbol-function 'markdown-overlays-put)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'agent-shell-viewport--update-header)
+                     (lambda ()
+                       (setq rendered-position (agent-shell-viewport--position)))))
+            (agent-shell-viewport--initialize :prompt "p" :response "r")
+            (should (equal rendered-position '((:current . 2) (:total . 2))))))
+      (kill-buffer viewport-buffer)
+      (kill-buffer shell-buffer))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
Fixes #657.

Two issues when switching to the viewport with `agent-shell-other-buffer` and
then navigating:

- **First `previous-page` does nothing.** `agent-shell-viewport-next-page`
  navigated from the raw shell-buffer point, which `agent-shell-other-buffer`
  leaves mid-interaction. From there the first backward step only reaches the
  current interaction's prompt, so the page doesn't change until a second
  invocation. Fixed by normalizing the point to the current interaction's
  prompt start (`shell-maker--prompt-begin-position`) before stepping back.
  Scoped to the backward branch so forward navigation is unchanged.

- **Stale position label (e.g. `1/2`).** `agent-shell-viewport--initialize`
  refreshed the cached position but never re-rendered the header, so
  `agent-shell-viewport-refresh` (used on switch) left the previously-rendered
  label in place. Fixed by re-rendering the header at the end of
  `--initialize`; the now-redundant explicit call in `next-page` is dropped.

Adds regression tests for both.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed an issue for this bug (#657).
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss. (n/a — no visual change)
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary. (n/a)
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
