### PR TITLE
CI: Use native ERT JUnit Reporting

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -32,3 +32,4 @@ jobs:
           name: ERT Tests
           path: test-results.xml
           reporter: java-junit
+          use-actions-summary: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,20 +22,19 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/xenodium/acp.el ../acp
           git clone --depth 1 https://github.com/xenodium/shell-maker ../shell-maker
-          git clone --depth 1 https://bitbucket.org/olanilsson/ert-junit ../ert-junit
 
       - name: Run tests
+        env:
+          EMACS_TEST_JUNIT_REPORT: '1'
         run: |
           emacs --batch -Q \
             -L . \
             -L ../acp \
             -L ../shell-maker \
-            -L ../ert-junit \
-            --load ert-junit \
+            --eval '(setq ert-load-file-name "test-results")' \
             --load tests/agent-shell-fakes.el \
             $(find tests -name '*-tests.el' | sort | sed 's/^/--load /') \
-            -f ert-junit-run-tests-batch-and-exit \
-            test-results.xml
+            -f ert-run-tests-batch-and-exit
 
       - name: Upload test results
         if: success() || failure()


### PR DESCRIPTION
I originally couldn't get native JUnit reporting to produce a file, so I fell back to `ert-junit`, which is unmaintained and crashes when a test errors, so `test-results.xml` was never generated on those runs. As it turns out native JUnit was fine all along, I just wasn't setting the output name via `ert-load-file-name` (the `EMACS_TEST_JUNIT_REPORT` env var enables it but doesn't control the filename). This PR drops `ert-junit` and uses the built-in reporter.

Also, in `test-report.yml`, `dorny/test-reporter@v3` defaults `use-actions-summary: true`, which doesn't attach the test report to the commit so you have to go digging for it. Setting it to false fixes this. **NOTE**: this will only take effect once it's on `main`.

What Passing tests will look like when you click on the checkbox next to the commit:
<img width="653" height="167" alt="screenshot-20260617-152239" src="https://github.com/user-attachments/assets/0066d081-4924-4247-a9b9-9a36accd4c26" />

Failing tests:
<img width="649" height="170" alt="screenshot-20260617-153349" src="https://github.com/user-attachments/assets/1ec0353f-1b39-4eec-9e4a-7dc9f123f6ce" />


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
