### PR TITLE
Fix transcript section heading glued to interrupted agent message

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -5943,10 +5943,9 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                :prompt content-blocks)
      :buffer (current-buffer)
      :on-success (lambda (acp-response)
-                   (when (equal (map-elt (agent-shell--state) :last-entry-type) "agent_message_chunk")
-                     (agent-shell--append-transcript
-                      :text "\n\n"
-                      :file-path agent-shell--transcript-file))
+                   (agent-shell--separate-transcript-after-agent-message
+                    :last-entry-type (map-elt (agent-shell--state) :last-entry-type)
+                    :file-path agent-shell--transcript-file)
                    ;; Tool call details are no longer needed after
                    ;; a session prompt request is finished.
                    ;; Avoid accumulating them unnecessarily.
@@ -5995,6 +5994,13 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                      (when success
                        (agent-shell--process-pending-request))))
      :on-failure (lambda (acp-error raw-message)
+                   ;; A failed/interrupted turn may have stopped mid
+                   ;; agent_message_chunk, leaving the transcript body
+                   ;; without a trailing newline.  Separate it so the
+                   ;; next section header lands on its own line.
+                   (agent-shell--separate-transcript-after-agent-message
+                    :last-entry-type (map-elt agent-shell--state :last-entry-type)
+                    :file-path agent-shell--transcript-file)
                    ;; Display pending requests on failure.
                    (agent-shell--display-pending-requests)
                    (funcall (agent-shell--make-error-handler :state agent-shell--state :shell-buffer shell-buffer)
@@ -8108,6 +8114,19 @@ For example:
         (write-region text nil file-path t 'no-message)
       (error
        (message "Error writing to transcript: %S" err)))))
+
+(cl-defun agent-shell--separate-transcript-after-agent-message (&key last-entry-type file-path)
+  "Append a blank-line separator to the transcript at FILE-PATH.
+
+Write the separator only when LAST-ENTRY-TYPE is
+\"agent_message_chunk\", i.e. the turn ended while streaming an
+agent message.  An agent message chunk may end without a trailing
+newline (for example when interrupted), and without this separator
+the next transcript section header lands on the same line as the
+message body.  Call this at turn end on both the success and
+failure paths."
+  (when (equal last-entry-type "agent_message_chunk")
+    (agent-shell--append-transcript :text "\n\n" :file-path file-path)))
 
 (defun agent-shell--extract-tool-parameters (raw-input)
   "Extract and format tool parameters from RAW-INPUT.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -1124,6 +1124,52 @@ code block content
   (should (equal (agent-shell--indent-markdown-headers "### Tool Call [completed]: grep")
                  "##### Tool Call [completed]: grep")))
 
+(ert-deftest agent-shell--separate-transcript-after-agent-message-test ()
+  "Ensure a turn ending mid-agent-message leaves a blank-line separator.
+
+Reproduces the interrupted-turn bug where an interrupted agent
+message had no trailing newline, so the next `## User' heading was
+glued onto the same line as the partial message:
+
+    Actually, I should## User (2026-06-20 19:45:42)
+
+The separator must be written whether the turn ends in success or
+failure (interrupt), so `agent-shell--append-transcript' can be
+driven by a single helper on both paths."
+  (let ((file (make-temp-file "agent-shell-transcript")))
+    (unwind-protect
+        ;; `agent-shell--ensure-transcript-file' guards on the major mode
+        ;; and creates the file with a header; the file is pre-seeded
+        ;; here, so stub it to just hand back the path and exercise the
+        ;; real conditional + real `write-region' append.
+        (cl-letf (((symbol-function 'agent-shell--ensure-transcript-file)
+                   (lambda () file)))
+          ;; Simulate content left by an interrupted agent_message_chunk:
+          ;; a header plus partial body with NO trailing newline.
+          (write-region (format "## Agent (%s)\n\nActually, I should"
+                                (format-time-string "%F %T"))
+                        nil file)
+          ;; The turn ending mid-message must add the blank-line separator.
+          (agent-shell--separate-transcript-after-agent-message
+           :last-entry-type "agent_message_chunk"
+           :file-path file)
+          (with-temp-buffer
+            (insert-file-contents file)
+            ;; The next `## User' must land on its own line, i.e. the
+            ;; agent's partial body must be followed by a blank line.
+            (should (string-suffix-p "Actually, I should\n\n"
+                                     (buffer-string))))
+          ;; When the turn did not end on an agent message, no separator
+          ;; is written (avoids spurious blank lines elsewhere).
+          (let ((size-before (file-attribute-size
+                              (file-attributes file))))
+            (agent-shell--separate-transcript-after-agent-message
+             :last-entry-type "tool_call"
+             :file-path file)
+            (should (= (file-attribute-size (file-attributes file))
+                       size-before))))
+      (delete-file file))))
+
 (ert-deftest agent-shell-mcp-servers-test ()
   "Test `agent-shell-mcp-servers' function normalization."
   ;; Test with nil


### PR DESCRIPTION
An interrupted `agent_message_chunk` leaves the transcript body without
a trailing newline, so the next prompt's heading lands on the same line
as the partial message, e.g.

    Actually, I should## User (2026-06-20 19:45:42)

Append a blank-line separator at turn end whenever the last streamed
entry was an `agent_message_chunk`. Centralize this in a helper called on
both the success and failure (interrupt) paths of the session/prompt
request.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
