### PR TITLE
Don't trigger completion on path separators in file paths

### DIFF
--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -46,7 +46,9 @@ the word, nil otherwise."
   (save-excursion
     (when-let* ((end (progn (skip-chars-forward char-class) (point)))
                 (start (progn (skip-chars-backward char-class) (point)))
-                ((eq (char-before start) trigger-char)))
+                ((eq (char-before start) trigger-char))
+                ((or (= start (1+ (line-beginning-position)))
+                     (memq (char-before (1- start)) '(?\s ?\t ?\n)))))
       `((:start . ,start) (:end . ,end)))))
 
 (defun agent-shell--capf-exit-with-space (_string _status)

--- a/tests/agent-shell-completion-tests.el
+++ b/tests/agent-shell-completion-tests.el
@@ -1,0 +1,31 @@
+;;; agent-shell-completion-tests.el --- Tests for agent-shell completion -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'map)
+(require 'agent-shell-completion)
+
+;;; Code:
+
+(ert-deftest agent-shell--completion-bounds-ignores-path-separators-test ()
+  "Test `/` in file paths does not trigger command completion."
+  (let ((command-chars "[:alnum:]_-")
+        (path-chars "[:alnum:]/_.-"))
+    (with-temp-buffer
+      (insert "@path/abc")
+      (goto-char (point-max))
+      (should-not (agent-shell--completion-bounds command-chars ?/))
+      (let ((bounds (agent-shell--completion-bounds path-chars ?@)))
+        (should bounds)
+        (should (equal (map-elt bounds :start) 2))
+        (should (equal (map-elt bounds :end) 10)))))
+
+  (with-temp-buffer
+    (insert " /help")
+    (goto-char (point-max))
+    (let ((bounds (agent-shell--completion-bounds "[:alnum:]_-" ?/)))
+      (should bounds)
+      (should (equal (map-elt bounds :start) 3))
+      (should (equal (map-elt bounds :end) 7)))))
+
+(provide 'agent-shell-completion-tests)
+;;; agent-shell-completion-tests.el ends here


### PR DESCRIPTION
A `/` separator inside a file path (for example `@path/abc`) was triggering command completion. This restricts the trigger to a separator that follows whitespace or the start of the line, so separators inside file paths are ignored.

Includes a regression test (`agent-shell--completion-bounds-ignores-path-separators-test`).

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
