### PR TITLE
Preserve viewport edit draft when queued request executes

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -5931,6 +5931,16 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                                   :shell-buffer shell-buffer
                                   :existing-only t)))
       (with-current-buffer viewport-buffer
+        ;; When a command is sent (e.g. a queued request executing)
+        ;; while the user is composing in the viewport edit buffer,
+        ;; preserve the draft so it can be restored on the next return
+        ;; to edit mode instead of being wiped by the view-mode switch.
+        (when (and (derived-mode-p 'agent-shell-viewport-edit-mode)
+                   (not (string-empty-p (string-trim (buffer-string))))
+                   (not agent-shell-viewport--compose-snapshot))
+          (setq agent-shell-viewport--compose-snapshot
+                `((:content . ,(buffer-string))
+                  (:location . ,(point)))))
         (agent-shell-viewport-view-mode)
         (agent-shell-viewport--initialize
          :prompt  prompt)))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -606,6 +606,53 @@ bar
         (should (equal (map-elt (map-elt data :usage) :total-tokens)
                        1500))))))
 
+(ert-deftest agent-shell--send-command-preserves-viewport-edit-draft-test ()
+  "Sending a command must not discard an in-progress viewport edit draft.
+
+When a queued request is processed while the user is composing a
+message in the viewport edit buffer, `agent-shell--send-command'
+switches the viewport to view mode and re-initializes (erasing)
+the buffer.  The draft must be saved to the compose snapshot so
+it can be restored when the user returns to edit mode."
+  (let ((agent-shell-header-style 'graphical)
+        (agent-shell-show-busy-indicator nil)
+        (agent-shell--state (list (cons :buffer (current-buffer))
+                                  (cons :event-subscriptions nil)
+                                  (cons :client 'test-client)
+                                  (cons :session (list (cons :id "test-session")
+                                                       (cons :title "a title")))
+                                  (cons :last-entry-type nil)
+                                  (cons :tool-calls nil)
+                                  (cons :idle-timer nil))))
+    (cl-letf (((symbol-function 'agent-shell--state)
+               (lambda () agent-shell--state))
+              ((symbol-function 'agent-shell--send-request)
+               (lambda (&rest _)))
+              ((symbol-function 'agent-shell--append-transcript)
+               (lambda (&rest _)))
+              ((symbol-function 'agent-shell--set-session-title)
+               (lambda (&rest _)))
+              ((symbol-function 'agent-shell-viewport--update-header)
+               (lambda (&rest _)))
+              ((symbol-function 'agent-shell-viewport--position)
+               (lambda (&rest _) nil)))
+      (with-temp-buffer
+        (let ((viewport-buffer (current-buffer)))
+          (agent-shell-viewport-edit-mode)
+          (insert "my important draft")
+          (cl-letf (((symbol-function 'agent-shell-viewport--buffer)
+                     (lambda (&rest _) viewport-buffer)))
+            (agent-shell--send-command
+             :prompt "queued prompt"
+             :shell-buffer (current-buffer)))
+          ;; The buffer now shows the submitted prompt in view mode,
+          ;; and the in-progress draft was wiped from the buffer...
+          (should-not (string-match-p "my important draft" (buffer-string)))
+          ;; ...but the draft survived in the compose snapshot.
+          (should agent-shell-viewport--compose-snapshot)
+          (should (equal (map-elt agent-shell-viewport--compose-snapshot :content)
+                         "my important draft")))))))
+
 (ert-deftest agent-shell--format-diff-as-text-test ()
   "Test `agent-shell--format-diff-as-text' function."
   ;; Test nil input


### PR DESCRIPTION
## What

When a command is sent (e.g. a queued request executing) while the user is composing in the viewport edit buffer, the draft is now saved to the compose snapshot instead of being wiped by the switch to view mode. The draft is restored on the next return to edit mode.

## Why

`agent-shell--send-command` switches the viewport to view mode and re-initializes the buffer. If a queued request runs while the user is mid-composition in the viewport edit buffer, their in-progress draft was lost. Reusing the existing `agent-shell-viewport--compose-snapshot` mechanism preserves it.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
