### PR TITLE
Fix MD rendering for non-streamed bodies

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3456,7 +3456,14 @@ turn)."
                 ;; Skip rendering when body is collapsed; it will be
                 ;; rendered on expand via
                 ;; `agent-shell-ui-post-expand-fragment-at-point-hook'.
-                (unless (text-property-any (point-min) (point-max) 'invisible t)
+                ;; Check only the first char: a collapsed body has
+                ;; `invisible t' on every char, while a visible body
+                ;; may carry `invisible t' only on trailing whitespace
+                ;; (from `agent-shell-ui--apply-trailing-whitespace-invisible').
+                ;; `text-property-any' would match that trailing
+                ;; whitespace and incorrectly skip rendering for
+                ;; non-streamed bodies (e.g. plan blocks).
+                (unless (eq (get-text-property (point-min) 'invisible) t)
                   (agent-shell--render-markdown :render-images render-body-images))))
             ;; Note: For now, we're skipping applying markdown
             ;; on left labels as they currently carry propertized text
@@ -3540,7 +3547,8 @@ turn)."
                ;; Skip rendering when body is collapsed; it will be
                ;; rendered on expand via
                ;; `agent-shell-ui-post-expand-fragment-at-point-hook'.
-               (unless (text-property-any (point-min) (point-max) 'invisible t)
+               ;; See viewport counterpart above for rationale.
+               (unless (eq (get-text-property (point-min) 'invisible) t)
                  (agent-shell--render-markdown))
                (widen))
              ;;


### PR DESCRIPTION
Fix: Markdown rendering is skipped for non-streamed bodies (e.g. plan blocks)

This makes tables, for example, look terrible.

`text-property-any` matched `invisible t` on trailing whitespace set by `agent-shell-ui--apply-trailing-whitespace-invisible`, causing the collapsed-body guard to skip markdown rendering.  Check only the first character instead   a truly collapsed body has `invisible t` on every char, while a visible body only has it on trailing newlines.

Frankly, I'm not completely confident in this change.  I was having a problem where tables included in "Proposed plan" results from Claude were not being rendered.  Raw Markdown content was being shown, and that was nearly impossible to read.  Other tables rendered just fine.  This is the best fix I was able to figure out (with Claude's help, I will admit).  Please let me know what you think.  If this isn't the right way to fix this problem, I'd be grateful for hints about a better approach.

Thanks.


Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x ] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [N/A] I've filed a feature request/discussion for a new feature.
- [N/A] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [N/A] I've added tests where applicable.
- [N/A] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
