### PR TITLE
Add a command that narrows to the most recent N (default 1) blocks in an `agent-shell` buffer.

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -8292,6 +8292,20 @@ commands when the agent has reported them."
       (agent-shell--enqueue-request :prompt prompt)
     (agent-shell--insert-to-shell-buffer :text prompt :submit t :no-focus t)))
 
+(defun agent-shell-narrow-to-block (count)
+  "Narrow to the last COUNT navigatable blocks in the current buffer.
+The buffer must be an `agent-shell-mode' buffer.  Narrow from the
+start of the COUNTth-from-last navigatable block to `point-max'."
+  (interactive "P")
+  (unless (derived-mode-p 'agent-shell-mode)
+    (error "Not in an agent-shell buffer."))
+  (save-excursion
+    (widen)
+    (goto-char (point-max))
+    (dotimes (_ (or count 1)) (agent-shell-ui-backward-block))
+    (when-let* ((block (agent-shell-ui--block-range :position (point))))
+      (narrow-to-region (map-elt block :start) (point-max)))))
+
 (defun agent-shell-quote-region ()
   "Quote the active region into the shell's latest prompt.
 


### PR DESCRIPTION
This is a tiny utility command that narrows to the most recent N (default 1) blocks in an `agent-shell` buffer.  It's useful, for example, for reviewing a plan produced by an agent after a bunch of interaction.  It makes it easy just to see the plan.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature: #671 
- [N/A] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [N/A] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [N/A] I've run `M-x checkdoc` and `M-x byte-compile-file`.
