### PR TITLE
Update codex-acp repository links

### DIFF
--- a/README.org
+++ b/README.org
@@ -102,7 +102,7 @@ Optionally: You may also need [[https://code.claude.com/docs/en/overview][Claude
 
 *** Codex
 
-For OpenAI's Codex, install [[https://github.com/zed-industries/codex-acp][zed/codex-acp]] and ensure the `codex-acp` executable is in PATH.
+For OpenAI's Codex, install [[https://github.com/agentclientprotocol/codex-acp][agentclientprotocol/codex-acp]] and ensure the `codex-acp` executable is in PATH.
 
 *** Gemini CLI
 
@@ -1020,7 +1020,7 @@ Sometimes including a traffic screenshot in an issue is enough. Other times incl
 If you're able to determine the agent is missing a feature (or a bug is present) in their [[https://agentclientprotocol.com][Agent Client Protocol]] implementation, please file an issue directly with the agent folks. For example:
 
 - [[https://github.com/agentclientprotocol/claude-agent-acp][claude-agent-acp]]: For Claude Agent.
-- [[https://github.com/zed-industries/codex-acp][codex-acp]]: For Codex.
+- [[https://github.com/agentclientprotocol/codex-acp][codex-acp]]: For Codex.
 - [[https://github.com/google-gemini/gemini-cli][Gemini CLI]].
 - [[https://block.github.io/goose/docs/getting-started/installation][Goose]].
 - [[https://github.com/QwenLM/qwen-code][Qwen Code]].

--- a/agent-shell-openai.el
+++ b/agent-shell-openai.el
@@ -153,7 +153,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
                                         (acp-make-authenticate-request :method-id "chatgpt"))))
    :client-maker (lambda (buffer)
                    (agent-shell-openai-make-codex-client :buffer buffer))
-   :install-instructions "See https://github.com/zed-industries/codex-acp for installation."))
+   :install-instructions "See https://github.com/agentclientprotocol/codex-acp for installation."))
 
 (defun agent-shell-openai-start-codex ()
   "Start an interactive Codex agent shell."


### PR DESCRIPTION
## Summary

Updates Codex ACP references from `zed-industries/codex-acp` to the new `agentclientprotocol/codex-acp` repository.

Changed:
- Codex install instructions in `agent-shell-openai.el`
- Codex setup link in `README.org`
- Codex feature-request pointer in `README.org`

## Validation

- Verified `https://github.com/agentclientprotocol/codex-acp` exists via GitHub CLI.
- Confirmed no remaining `zed-industries/codex-acp` references with `rg`.
- Ran `git diff --check`.
- Ran byte-compile for `agent-shell-openai.el` with local dependency paths:
  `Emacs -Q --batch -L . -L ../acp.el -L ../shell-maker -f batch-byte-compile agent-shell-openai.el`

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
