### PR TITLE
Display math rendering (LaTeX → SVG)

### DIFF
--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -135,6 +135,21 @@ Also used as the automatic fallback when the LaTeX toolchain
 \(`agent-shell-markdown-math-latex-program' /
 `agent-shell-markdown-math-dvisvgm-program') is unavailable.")
 
+(defvar agent-shell-markdown-math-render-on-non-graphic nil
+  "When non-nil, render equation images even on a non-graphical frame.
+
+By default equations are only compiled when the selected frame is
+graphical (`display-graphic-p').  In an Emacs daemon a buffer may
+be rendered while a TTY frame is selected, yet later viewed in a
+graphical frame; without this the equation would never have been
+produced and stays raw text in the GUI too.
+
+Set non-nil (typically in a daemon setup) to always compile the
+SVG when the build supports it: it is ignored on a TTY frame (the
+raw LaTeX shows) but appears as soon as a graphical frame views
+the buffer.  The trade-off is that a purely terminal session then
+spawns LaTeX compiles whose images it never displays.")
+
 (defvar agent-shell-markdown-math-latex-program "latex"
   "Program that compiles a LaTeX document to DVI.")
 
@@ -399,18 +414,31 @@ For example:
         (apply #'color-rgb-to-hex (append rgb '(2)))
       fallback)))
 
+(defun agent-shell-markdown--math-renderable-p ()
+  "Return non-nil when equation images should be produced.
+
+Requires SVG image support in this Emacs build, plus either a
+graphical selected frame or
+`agent-shell-markdown-math-render-on-non-graphic' (the daemon /
+mixed TTY+GUI case — the image is ignored on a TTY frame but shows
+once a graphical frame views the buffer)."
+  (and (image-type-available-p 'svg)
+       (or (display-graphic-p)
+           agent-shell-markdown-math-render-on-non-graphic)))
+
 (defun agent-shell-markdown--latex-placeholder-image (latex)
   "Return a placeholder SVG image boxing the raw LATEX, or nil.
 
 This does NOT typeset LATEX — it draws the source inside a
 bordered panel.  Used when `agent-shell-markdown-math-use-placeholder'
 is set or the LaTeX toolchain is unavailable, so math still has a
-visible (if un-typeset) rendering.  Returns nil when no graphical
-display is available, so callers fall back to the raw text.
+visible (if un-typeset) rendering.  Returns nil when equations
+aren't renderable (see `agent-shell-markdown--math-renderable-p'),
+so callers fall back to the raw text.
 
 LATEX is the equation source with the surrounding delimiters
 already stripped, e.g. \"E=mc^2\"."
-  (when (display-graphic-p)
+  (when (agent-shell-markdown--math-renderable-p)
     (let* ((lines (split-string latex "\n"))
            ;; `frame-char-width' / `-height' give per-char pixel
            ;; dimensions on a graphical frame and stay robust off it
@@ -520,14 +548,15 @@ is preserved."
 (defun agent-shell-markdown--math-render (buffer start end latex)
   "Render LATEX over BUFFER's START..END as an equation image.
 
-On a non-graphical display, does nothing (the raw faced text
-stands in).  With `agent-shell-markdown-math-use-placeholder' set
+Does nothing when equations aren't renderable (see
+`agent-shell-markdown--math-renderable-p') — the raw faced text
+stands in.  With `agent-shell-markdown-math-use-placeholder' set
 or no LaTeX toolchain, overlays the placeholder panel.  Otherwise
 overlays the cached SVG immediately when available, else schedules
 an async compile (see `agent-shell-markdown--math-compile') that
 overlays the result once ready — START / END are captured as
 markers so the overlay lands even after more output streams in."
-  (when (display-graphic-p)
+  (when (agent-shell-markdown--math-renderable-p)
     (cond
      ((or agent-shell-markdown-math-use-placeholder
           (not (agent-shell-markdown--math-tools-available-p)))

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -188,8 +188,30 @@ spawns LaTeX compiles whose images it never displays.")
   "Program that converts DVI to SVG.")
 
 (defvar agent-shell-markdown-math-scale 1.4
-  "`dvisvgm' output scale for rendered equations.
-Larger values produce bigger images.")
+  "`dvisvgm' output scale for compiled equation SVGs.
+
+This is a render-quality / vector-precision knob, not a size knob:
+the displayed equation is rescaled to the buffer font at display
+time (see `agent-shell-markdown--math-display-scale'), and this
+factor cancels out of that computation.  To change how big
+equations appear on screen, use `agent-shell-markdown-math-font-scale'.")
+
+(defvar agent-shell-markdown-math-font-scale 1.0
+  "Size of rendered equations relative to the buffer font.
+
+Equation images are scaled so LaTeX's 10pt body font maps onto the
+buffer's font height; this multiplier rides on top of that match.
+1.0 makes equation text the same size as the surrounding text;
+greater than 1 enlarges, less than 1 shrinks.  Because the match is
+recomputed from the current font, equations track the buffer font
+across themes and faces (run `agent-shell-markdown-math-refresh'
+after a pure font-size change — see its docstring).")
+
+(defvar agent-shell-markdown-math--svg-px-per-pt nil
+  "Cached pixels-per-point Emacs uses to render SVG images.
+Measured once on a graphical frame by
+`agent-shell-markdown--math-svg-px-per-pt' (so HiDPI / image
+scaling is captured exactly); nil until then.")
 
 (defvar agent-shell-markdown-math-preamble
   "\\documentclass[border=2pt]{standalone}
@@ -681,9 +703,54 @@ existing display-math cache keys stay stable."
   (expand-file-name (concat key ".svg")
                     (agent-shell-markdown--math-cache-dir)))
 
+(defun agent-shell-markdown--math-svg-px-per-pt ()
+  "Return how many pixels Emacs renders one SVG point as.
+
+Measured once from a reference SVG declared at a known point size
+\(so HiDPI and `image-scaling-factor' are captured exactly — the
+same factor applies to equation images, so it cancels in the size
+ratio) and cached in `agent-shell-markdown-math--svg-px-per-pt'.
+Falls back to 96/72 (the usual 96-DPI ratio) when not on a
+graphical frame or measurement fails; the fallback is not cached,
+so a later graphical frame can still measure."
+  (or agent-shell-markdown-math--svg-px-per-pt
+      (and (display-graphic-p)
+           (ignore-errors
+             (let* ((svg (concat "<svg xmlns='http://www.w3.org/2000/svg' "
+                                 "width='100pt' height='100pt'>"
+                                 "<rect width='100pt' height='100pt'/></svg>"))
+                    (size (image-size (create-image svg 'svg t) t)))
+               (setq agent-shell-markdown-math--svg-px-per-pt
+                     (/ (cdr size) 100.0)))))
+      (/ 96.0 72.0)))
+
+(defun agent-shell-markdown--math-display-scale ()
+  "Return the `create-image' :scale that sizes equations to the buffer font.
+
+Maps LaTeX's 10pt body font onto the buffer's font pixel height,
+times `agent-shell-markdown-math-font-scale'.  Derivation: an
+equation's displayed font height is
+\(10 * `agent-shell-markdown-math-scale' * px-per-pt * scale) px,
+so scale = target / (10 * math-scale * px-per-pt); the compile
+scale cancels, so it doesn't affect on-screen size.  Returns 1.0
+when the font height can't be determined (batch / non-graphical),
+leaving the image at its natural size."
+  (let ((target (and (display-graphic-p)
+                     (ignore-errors (default-font-height)))))
+    (if target
+        (/ (* target agent-shell-markdown-math-font-scale)
+           (* 10.0 agent-shell-markdown-math-scale
+              (agent-shell-markdown--math-svg-px-per-pt)))
+      1.0)))
+
 (defun agent-shell-markdown--math-load-svg-image (file)
-  "Return an SVG image created from FILE, centred for inline display."
-  (create-image file 'svg nil :scale 1.0 :ascent 'center))
+  "Return an SVG image created from FILE, sized to the buffer font.
+The image is scaled (see `agent-shell-markdown--math-display-scale')
+so the equation's body font matches the surrounding text, and
+centred vertically for inline display."
+  (create-image file 'svg nil
+                :scale (agent-shell-markdown--math-display-scale)
+                :ascent 'center))
 
 (defun agent-shell-markdown--math-cached-image (key)
   "Return the rendered image for KEY from memory or disk, or nil.
@@ -856,11 +923,16 @@ is reused from cache)."
               (setq pos end))))))))
 
 (defun agent-shell-markdown-math-refresh ()
-  "Re-render all displayed equations for the current foreground/background.
-Call after a theme or appearance change so equation images pick up
-the new colors.  Unchanged equations are served from cache, so this
-is cheap when nothing actually changed."
+  "Re-render all displayed equations for the current colors and font.
+Call after a theme, appearance, or font-size change so equation
+images pick up the new colors and size.  The in-memory image cache
+and the pixels-per-point calibration are dropped so images are
+rebuilt at the current font scale from the on-disk SVGs (cheap — no
+LaTeX recompile unless the color also changed); equations otherwise
+unchanged stay fast."
   (interactive)
+  (setq agent-shell-markdown-math--svg-px-per-pt nil)
+  (clrhash agent-shell-markdown-math--image-cache)
   (setq agent-shell-markdown-math--rendered-colors
         (agent-shell-markdown-math--current-colors))
   (dolist (buffer (buffer-list))

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -64,6 +64,7 @@
 (require 'svg)
 
 (declare-function agent-shell-markdown--in-avoid-range-p "agent-shell-markdown")
+(declare-function agent-shell--cache-dir "agent-shell")
 
 (defface agent-shell-markdown-math
   '((t :inherit font-lock-constant-face))
@@ -203,10 +204,15 @@ equation to match the buffer foreground.  Equations are typeset as
 
 (defvar agent-shell-markdown-math-cache-directory nil
   "Directory for cached equation SVGs and scratch compiles.
-When nil, a subdirectory of the variable `temporary-file-directory'
-is used.  Point this at a persistent location to keep the cache
-across sessions (each unique equation then compiles at most once
-ever).")
+When nil, agent-shell's shared cache directory is used (via
+`agent-shell--cache-dir'), so equation SVGs persist across sessions
+alongside agent-shell's other cached assets and each unique
+equation compiles at most once ever.
+
+That helper lives in `agent-shell.el', which is always loaded in a
+real session.  The renderer's test harness loads this module
+without `agent-shell.el'; set this variable there (or stub
+`agent-shell--cache-dir') if a code path needs the directory.")
 
 ;; key (sha1 of latex + color + scale + preamble) -> image object.  An
 ;; equation is compiled at most once per key; subsequent renders (same
@@ -650,11 +656,11 @@ already stripped, e.g. \"E=mc^2\"."
 
 (defun agent-shell-markdown--math-cache-dir ()
   "Return the equation cache directory, creating it if needed.
-Honours `agent-shell-markdown-math-cache-directory', else a
-subdirectory of the variable `temporary-file-directory'."
+Honours `agent-shell-markdown-math-cache-directory', else
+agent-shell's shared cache directory (`agent-shell--cache-dir'), so
+the cache persists across sessions next to other cached assets."
   (let ((dir (or agent-shell-markdown-math-cache-directory
-                 (expand-file-name "agent-shell-markdown-math"
-                                   temporary-file-directory))))
+                 (agent-shell--cache-dir "markdown-math"))))
     (unless (file-directory-p dir)
       (make-directory dir t))
     dir))

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -989,12 +989,13 @@ and untouched buffers refresh lazily when next displayed."
 
 (defun agent-shell-markdown-math--maybe-refresh (&rest _)
   "Re-render equations if the appearance changed since they were rendered.
-Hooked to buffer display (`window-buffer-change-functions') and theme
-enabling (`enable-theme-functions').  A no-op when math rendering is
-off; otherwise the actual comparison and refresh are deferred to the
-next idle moment, by which point a freshly applied theme is fully in
-effect (and rapid repeat triggers collapse, since the first refresh
-updates the recorded appearance)."
+Hooked to buffer display (`window-buffer-change-functions'), theme
+enabling (`enable-theme-functions'), and buffer zoom
+\(`text-scale-mode-hook').  A no-op when math rendering is off;
+otherwise the actual comparison and refresh are deferred to the next
+idle moment, by which point a freshly applied theme / text scale is
+fully in effect (and rapid repeat triggers collapse, since the first
+refresh updates the recorded appearance)."
   (when agent-shell-markdown-render-math
     (run-at-time 0 nil #'agent-shell-markdown-math--refresh-if-changed)))
 
@@ -1021,13 +1022,16 @@ change is picked up just like a color change."
 ;; the next time the buffer is shown in a window and repaint if stale.
 ;; `enable-theme-functions' (Emacs 29+, cross-platform) covers the one case
 ;; display alone misses: a theme enabled while the buffer stays visible and
-;; untouched.  Both go through the same appearance-changed check (colors +
-;; font height), so they're cheap no-ops when nothing changed (or math
-;; rendering is off), and a font-size change re-sizes equations on the next
-;; buffer display.
+;; untouched.  `text-scale-mode-hook' covers the other: a buffer-local zoom
+;; (`text-scale-adjust', C-x C-+/-) changes the font height without a
+;; display or theme event, so without this hook equations only re-size on
+;; the next buffer switch.  All three go through the same appearance-changed
+;; check (colors + font height), so they're cheap no-ops when nothing
+;; changed (or math rendering is off).
 (add-hook 'window-buffer-change-functions
           #'agent-shell-markdown-math--maybe-refresh)
 (add-hook 'enable-theme-functions #'agent-shell-markdown-math--maybe-refresh)
+(add-hook 'text-scale-mode-hook #'agent-shell-markdown-math--maybe-refresh)
 
 (provide 'agent-shell-markdown-math)
 

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -94,6 +94,36 @@ $$$\".  Opt into `$$...$$' with:
 
   (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
 
+(defvar agent-shell-markdown-render-math nil
+  "Master switch for rendering display math in agent responses.
+
+Nil (the default) disables math rendering entirely — delimiters
+and fenced math blocks are left as plain text / ordinary code
+blocks.  Set non-nil to opt in; what then gets recognized is
+controlled by `agent-shell-markdown-math-delimiters' (`\\[...\\]'
+on by default, `$$...$$' opt-in) and
+`agent-shell-markdown-math-fence-languages' (`math' / `latex' /
+`tex' fenced blocks, on by default).
+
+Consumed as the default of the `render-math' keyword of
+`agent-shell-markdown-replace-markup'.")
+
+(defvar agent-shell-markdown-math-fence-languages '("math" "latex" "tex")
+  "Fenced-code-block languages rendered as display math.
+
+A fenced block whose info string is one of these (compared
+case-insensitively), e.g.
+
+  ```math
+  E = mc^2
+  ```
+
+is typeset as an equation instead of shown as a code block — but
+only when `agent-shell-markdown-render-math' is non-nil.  Several
+agents emit `math'/`latex' fences (GitHub renders ```math as
+display math), so this complements the `\\[...\\]' / `$$...$$'
+delimiter styles.  Set to nil to leave such fences as code.")
+
 (defvar agent-shell-markdown-math-use-placeholder nil
   "When non-nil, draw the placeholder panel instead of typesetting LaTeX.
 Also used as the automatic fallback when the LaTeX toolchain
@@ -283,14 +313,39 @@ place, faced `agent-shell-markdown-math' and frozen."
                          (+ start (plist-get block :open))
                          (- end close))))
                 ((not (string-empty-p latex))))
-      (add-face-text-property start end 'agent-shell-markdown-math)
-      (add-text-properties
-       start end
-       `(help-echo ,latex
-         agent-shell-markdown-math-source ,latex
-         agent-shell-markdown-frozen t
-         rear-nonsticky (agent-shell-markdown-frozen)))
-      (agent-shell-markdown--math-render (current-buffer) start end latex))))
+      (agent-shell-markdown--apply-math-region (current-buffer) start end latex))))
+
+(defun agent-shell-markdown--math-fence-language-p (lang)
+  "Return non-nil if fenced-block language LANG renders as display math.
+Compares LANG case-insensitively against
+`agent-shell-markdown-math-fence-languages'.  LANG may be nil or
+empty (a fence with no info string), which is not a math language."
+  (and lang
+       (not (string-empty-p lang))
+       (member (downcase lang) agent-shell-markdown-math-fence-languages)
+       t))
+
+(defun agent-shell-markdown--apply-math-region (buffer start end latex)
+  "Mark BUFFER's START..END as display math with source LATEX and render it.
+
+Keeps the underlying text in place, faces the region
+`agent-shell-markdown-math', tags it `agent-shell-markdown-frozen'
+\(so later passes / streaming calls skip it) with LATEX stashed in
+`agent-shell-markdown-math-source', then hands off to
+`agent-shell-markdown--math-render' for the equation image.
+
+Shared by the delimiter pass (`--style-math-blocks') and the
+fenced-block path (`agent-shell-markdown--style-source-blocks',
+for ```math / ```latex)."
+  (with-current-buffer buffer
+    (add-face-text-property start end 'agent-shell-markdown-math)
+    (add-text-properties
+     start end
+     `(help-echo ,latex
+       agent-shell-markdown-math-source ,latex
+       agent-shell-markdown-frozen t
+       rear-nonsticky (agent-shell-markdown-frozen)))
+    (agent-shell-markdown--math-render buffer start end latex)))
 
 (defun agent-shell-markdown--svg-color (face attribute fallback)
   "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -187,15 +187,6 @@ spawns LaTeX compiles whose images it never displays.")
 (defvar agent-shell-markdown-math-dvisvgm-program "dvisvgm"
   "Program that converts DVI to SVG.")
 
-(defvar agent-shell-markdown-math-scale 1.4
-  "`dvisvgm' output scale for compiled equation SVGs.
-
-This is a render-quality / vector-precision knob, not a size knob:
-the displayed equation is rescaled to the buffer font at display
-time (see `agent-shell-markdown--math-display-scale'), and this
-factor cancels out of that computation.  To change how big
-equations appear on screen, use `agent-shell-markdown-math-font-scale'.")
-
 (defvar agent-shell-markdown-math-font-scale 1.0
   "Size of rendered equations relative to the buffer font.
 
@@ -706,14 +697,16 @@ the cache persists across sessions next to other cached assets."
       (make-directory dir t))
     dir))
 
-(defun agent-shell-markdown--math-cache-key (latex color scale &optional inline)
-  "Return a stable cache key for LATEX rendered in COLOR at SCALE.
+(defun agent-shell-markdown--math-cache-key (latex color &optional inline)
+  "Return a stable cache key for LATEX rendered in COLOR.
 The preamble is folded in so changing it invalidates the cache.
 INLINE (text style vs display) is folded in too, since the same
-LATEX renders differently in each — appended only when set so
-existing display-math cache keys stay stable."
-  (secure-hash 'sha1 (format "%s\0%s\0%s\0%s%s"
-                             latex color scale
+LATEX renders differently in each.  The key names the
+font-independent on-disk SVG; display size is applied later (see
+`agent-shell-markdown--math-image-cache-key'), so it is not part of
+this key."
+  (secure-hash 'sha1 (format "%s\0%s\0%s%s"
+                             latex color
                              agent-shell-markdown-math-preamble
                              (if inline "\0inline" ""))))
 
@@ -746,20 +739,19 @@ so a later graphical frame can still measure."
 (defun agent-shell-markdown--math-display-scale ()
   "Return the `create-image' :scale that sizes equations to the buffer font.
 
-Maps LaTeX's 10pt body font onto the buffer's font pixel height,
-times `agent-shell-markdown-math-font-scale'.  Derivation: an
-equation's displayed font height is
-\(10 * `agent-shell-markdown-math-scale' * px-per-pt * scale) px,
-so scale = target / (10 * math-scale * px-per-pt); the compile
-scale cancels, so it doesn't affect on-screen size.  Returns 1.0
-when the font height can't be determined (batch / non-graphical),
+Maps the LaTeX document's 10pt body font (the `standalone' default,
+compiled at dvisvgm scale 1, so 10pt of LaTeX = 10 SVG points) onto
+the buffer's font pixel height, times
+`agent-shell-markdown-math-font-scale'.  An equation's displayed
+font height is (10 * px-per-pt * scale) px, so
+scale = target * font-scale / (10 * px-per-pt).  Returns 1.0 when
+the font height can't be determined (batch / non-graphical),
 leaving the image at its natural size."
   (let ((target (and (display-graphic-p)
                      (ignore-errors (default-font-height)))))
     (if target
         (/ (* target agent-shell-markdown-math-font-scale)
-           (* 10.0 agent-shell-markdown-math-scale
-              (agent-shell-markdown--math-svg-px-per-pt)))
+           (* 10.0 (agent-shell-markdown--math-svg-px-per-pt)))
       1.0)))
 
 (defun agent-shell-markdown--math-load-svg-image (file &optional scale)
@@ -851,32 +843,31 @@ display renders of the same source don't collide in the cache."
          (agent-shell-markdown--latex-placeholder-image latex)))
        (t
         (let* ((color (car appearance))
-               (scale agent-shell-markdown-math-scale)
-               (key (agent-shell-markdown--math-cache-key latex color scale inline))
+               (key (agent-shell-markdown--math-cache-key latex color inline))
                (image (agent-shell-markdown--math-cached-image key)))
           (if image
               (agent-shell-markdown--math-overlay-image buffer start end image)
             (agent-shell-markdown--math-schedule
-             key latex color scale buffer
+             key latex color buffer
              (copy-marker start) (copy-marker end) inline))))))))
 
-(defun agent-shell-markdown--math-schedule (key latex color scale
+(defun agent-shell-markdown--math-schedule (key latex color
                                                 buffer start end &optional inline)
   "Queue BUFFER's START..END for KEY and start a compile if none is running.
 
-KEY identifies the equation; LATEX, COLOR, SCALE, and INLINE are
-forwarded to `agent-shell-markdown--math-compile' for the render.
-Multiple regions sharing KEY (the same equation rendered more than
-once) are coalesced onto a single in-flight compile; all are
-overlaid when it finishes."
+KEY identifies the equation; LATEX, COLOR, and INLINE are forwarded
+to `agent-shell-markdown--math-compile' for the render.  Multiple
+regions sharing KEY (the same equation rendered more than once) are
+coalesced onto a single in-flight compile; all are overlaid when it
+finishes."
   (let ((pending (gethash key agent-shell-markdown-math--pending)))
     (puthash key (cons (list buffer start end) pending)
              agent-shell-markdown-math--pending)
     (unless pending
-      (agent-shell-markdown--math-compile key latex color scale inline))))
+      (agent-shell-markdown--math-compile key latex color inline))))
 
-(defun agent-shell-markdown--math-compile (key latex color scale &optional inline)
-  "Asynchronously compile LATEX (in COLOR, at SCALE) to the cache SVG for KEY.
+(defun agent-shell-markdown--math-compile (key latex color &optional inline)
+  "Asynchronously compile LATEX (in COLOR) to the cache SVG for KEY.
 
 Writes a standalone LaTeX document, runs
 `agent-shell-markdown-math-latex-program' then
@@ -906,13 +897,16 @@ portable; it can slot in here without changing callers."
                       (if inline "" "\\displaystyle ")
                       latex)
               "\\end{document}\n"))
+    ;; Compile at dvisvgm scale 1: the SVG is vector (glyphs are outline
+    ;; paths via --no-fonts), so the scale doesn't affect quality, and the
+    ;; displayed size is set later by `--math-display-scale'.  Fixing it at 1
+    ;; means the SVG carries the equation's natural point dimensions.
     (let ((command
-           (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --scale=%s -o %s %s"
+           (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --scale=1 -o %s %s"
                    (shell-quote-argument dir)
                    (shell-quote-argument agent-shell-markdown-math-latex-program)
                    (shell-quote-argument tex)
                    (shell-quote-argument agent-shell-markdown-math-dvisvgm-program)
-                   scale
                    (shell-quote-argument svg)
                    (shell-quote-argument dvi))))
       (condition-case err

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -248,11 +248,13 @@ without `agent-shell.el'; set this variable there (or stub
 (defvar agent-shell-markdown-math--pending (make-hash-table :test 'equal)
   "In-memory map of cache key to regions awaiting an in-flight compile.")
 
-(defvar agent-shell-markdown-math--rendered-colors nil
-  "The (FOREGROUND . BACKGROUND) the displayed equations were rendered for.
-Updated whenever an equation renders; compared on theme / frame /
-appearance changes to decide whether equations need re-rendering
-\(see `agent-shell-markdown-math--maybe-refresh').")
+(defvar agent-shell-markdown-math--rendered-appearance nil
+  "The appearance signature the displayed equations were rendered for.
+A list (FOREGROUND BACKGROUND FONT-HEIGHT) — see
+`agent-shell-markdown-math--current-appearance'.  Updated whenever
+an equation renders; compared on theme / frame / font changes to
+decide whether equations need re-rendering (see
+`agent-shell-markdown-math--maybe-refresh').")
 
 (defvar-local agent-shell-markdown-math--present nil
   "Non-nil in a buffer that has rendered display-math regions.
@@ -264,6 +266,18 @@ Both are `#rrggbb' strings resolved from the `default' face of the
 selected frame."
   (cons (agent-shell-markdown--svg-color 'default :foreground "#000000")
         (agent-shell-markdown--svg-color 'default :background "#ffffff")))
+
+(defun agent-shell-markdown-math--current-appearance ()
+  "Return the appearance signature equations should render for now.
+A list (FOREGROUND BACKGROUND FONT-HEIGHT): the colors equations
+are tinted with (see `agent-shell-markdown-math--current-colors')
+and the buffer font pixel height they are sized to (nil off a
+graphical frame).  Comparing this against
+`agent-shell-markdown-math--rendered-appearance' detects a color
+*or* font-size change so the lazy refresh can re-render."
+  (let ((colors (agent-shell-markdown-math--current-colors)))
+    (list (car colors) (cdr colors)
+          (and (display-graphic-p) (ignore-errors (default-font-height))))))
 
 (defun agent-shell-markdown--math-delimiter-flush-p (start end)
   "Return non-nil if the delimiter spanning START..END is flush on its line.
@@ -801,10 +815,11 @@ INLINE non-nil typesets LATEX in text style instead of display
 style; it feeds both the cache key and the compile, so inline and
 display renders of the same source don't collide in the cache."
   (when (agent-shell-markdown--math-renderable-p)
-    ;; Record the colors this render is for, so a later theme / frame /
-    ;; appearance change can detect the difference and re-render.
-    (let ((colors (agent-shell-markdown-math--current-colors)))
-      (setq agent-shell-markdown-math--rendered-colors colors)
+    ;; Record the appearance (colors + font height) this render is for,
+    ;; so a later theme / frame / font change can detect the difference
+    ;; and re-render.
+    (let ((appearance (agent-shell-markdown-math--current-appearance)))
+      (setq agent-shell-markdown-math--rendered-appearance appearance)
       (cond
        ((or agent-shell-markdown-math-use-placeholder
             (not (agent-shell-markdown--math-tools-available-p)))
@@ -812,7 +827,7 @@ display renders of the same source don't collide in the cache."
          buffer start end
          (agent-shell-markdown--latex-placeholder-image latex)))
        (t
-        (let* ((color (car colors))
+        (let* ((color (car appearance))
                (scale agent-shell-markdown-math-scale)
                (key (agent-shell-markdown--math-cache-key latex color scale inline))
                (image (agent-shell-markdown--math-cached-image key)))
@@ -933,8 +948,8 @@ unchanged stay fast."
   (interactive)
   (setq agent-shell-markdown-math--svg-px-per-pt nil)
   (clrhash agent-shell-markdown-math--image-cache)
-  (setq agent-shell-markdown-math--rendered-colors
-        (agent-shell-markdown-math--current-colors))
+  (setq agent-shell-markdown-math--rendered-appearance
+        (agent-shell-markdown-math--current-appearance))
   (dolist (buffer (buffer-list))
     (when (buffer-local-value 'agent-shell-markdown-math--present buffer)
       (agent-shell-markdown-math--refresh-buffer buffer))))
@@ -946,15 +961,19 @@ enabling (`enable-theme-functions').  A no-op when math rendering is
 off; otherwise the actual comparison and refresh are deferred to the
 next idle moment, by which point a freshly applied theme is fully in
 effect (and rapid repeat triggers collapse, since the first refresh
-updates the recorded colors)."
+updates the recorded appearance)."
   (when agent-shell-markdown-render-math
     (run-at-time 0 nil #'agent-shell-markdown-math--refresh-if-changed)))
 
 (defun agent-shell-markdown-math--refresh-if-changed ()
-  "Run `agent-shell-markdown-math-refresh' iff the current colors changed."
+  "Run `agent-shell-markdown-math-refresh' iff the appearance changed.
+The appearance signature folds in both colors and the buffer font
+height (see `agent-shell-markdown-math--current-appearance'), so a
+font-size change is picked up the next time a hook fires (e.g. on
+switching to the buffer), just like a color change."
   (when (and agent-shell-markdown-render-math
-             (not (equal (agent-shell-markdown-math--current-colors)
-                         agent-shell-markdown-math--rendered-colors)))
+             (not (equal (agent-shell-markdown-math--current-appearance)
+                         agent-shell-markdown-math--rendered-appearance)))
     (agent-shell-markdown-math-refresh)))
 
 ;; Re-render lazily, when an equation buffer is next displayed, rather than
@@ -965,8 +984,10 @@ updates the recorded colors)."
 ;; the next time the buffer is shown in a window and repaint if stale.
 ;; `enable-theme-functions' (Emacs 29+, cross-platform) covers the one case
 ;; display alone misses: a theme enabled while the buffer stays visible and
-;; untouched.  Both go through the same colors-actually-changed check, so
-;; they're cheap no-ops when nothing changed (or math rendering is off).
+;; untouched.  Both go through the same appearance-changed check (colors +
+;; font height), so they're cheap no-ops when nothing changed (or math
+;; rendering is off), and a font-size change re-sizes equations on the next
+;; buffer display.
 (add-hook 'window-buffer-change-functions
           #'agent-shell-markdown-math--maybe-refresh)
 (add-hook 'enable-theme-functions #'agent-shell-markdown-math--maybe-refresh)

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -213,7 +213,17 @@ scaling is captured exactly); nil until then.")
 The `standalone' class crops the page tightly to the equation, so
 no `preview' package is required.  `xcolor' is used to tint the
 equation to match the buffer foreground.  Equations are typeset as
-`\\displaystyle' inline math inside the document body.")
+`\\displaystyle' inline math inside the document body.
+
+See also `agent-shell-markdown-math-appended-preamble' for adding
+extra packages without replacing this base.")
+
+(defvar agent-shell-markdown-math-appended-preamble ""
+  "Extra LaTeX code appended after `agent-shell-markdown-math-preamble'.
+Use this to load additional packages (e.g. `\\\\usepackage{braket}',
+`\\\\usepackage{physics}') without replacing the base preamble.
+The value is folded into the cache key, so changing it
+automatically invalidates cached SVGs.")
 
 (defvar agent-shell-markdown-math-cache-directory nil
   "Directory for cached equation SVGs and scratch compiles.
@@ -706,9 +716,10 @@ which is both font- AND color-independent (equations are compiled
 with dvisvgm `--currentcolor', then sized and tinted at display
 time — see `agent-shell-markdown--math-image-cache-key'), so
 neither size nor color is part of this key."
-  (secure-hash 'sha1 (format "%s\0%s%s"
+  (secure-hash 'sha1 (format "%s\0%s%s%s"
                              latex
                              agent-shell-markdown-math-preamble
+                             agent-shell-markdown-math-appended-preamble
                              (if inline "\0inline" ""))))
 
 (defun agent-shell-markdown--math-svg-file (key)
@@ -906,6 +917,9 @@ portable; it can slot in here without changing callers."
          (cleanup (lambda () (ignore-errors (delete-directory dir t)))))
     (with-temp-file tex
       (insert agent-shell-markdown-math-preamble "\n"
+              (if (string-empty-p agent-shell-markdown-math-appended-preamble)
+                  ""
+                (concat agent-shell-markdown-math-appended-preamble "\n"))
               "\\begin{document}\n"
               ;; Display math is typeset `\displaystyle' (full-size sums /
               ;; fractions / integrals); inline `\(...\)' is left in text

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -697,16 +697,17 @@ the cache persists across sessions next to other cached assets."
       (make-directory dir t))
     dir))
 
-(defun agent-shell-markdown--math-cache-key (latex color &optional inline)
-  "Return a stable cache key for LATEX rendered in COLOR.
+(defun agent-shell-markdown--math-cache-key (latex &optional inline)
+  "Return a stable cache key for LATEX.
 The preamble is folded in so changing it invalidates the cache.
 INLINE (text style vs display) is folded in too, since the same
-LATEX renders differently in each.  The key names the
-font-independent on-disk SVG; display size is applied later (see
-`agent-shell-markdown--math-image-cache-key'), so it is not part of
-this key."
-  (secure-hash 'sha1 (format "%s\0%s\0%s%s"
-                             latex color
+LATEX renders differently in each.  The key names the on-disk SVG,
+which is both font- AND color-independent (equations are compiled
+with dvisvgm `--currentcolor', then sized and tinted at display
+time — see `agent-shell-markdown--math-image-cache-key'), so
+neither size nor color is part of this key."
+  (secure-hash 'sha1 (format "%s\0%s%s"
+                             latex
                              agent-shell-markdown-math-preamble
                              (if inline "\0inline" ""))))
 
@@ -754,40 +755,49 @@ leaving the image at its natural size."
            (* 10.0 (agent-shell-markdown--math-svg-px-per-pt)))
       1.0)))
 
-(defun agent-shell-markdown--math-load-svg-image (file &optional scale)
-  "Return an SVG image created from FILE, sized to the buffer font.
-Scaled by SCALE (default `agent-shell-markdown--math-display-scale')
-so the equation's body font matches the surrounding text, and
-centred vertically for inline display."
-  (create-image file 'svg nil
-                :scale (or scale (agent-shell-markdown--math-display-scale))
-                :ascent 'center))
+(defun agent-shell-markdown--math-load-svg-image (file &optional scale color)
+  "Return an SVG image from FILE, tinted COLOR and sized to the buffer font.
+The on-disk SVG emits its default ink as the literal token
+`currentColor' (dvisvgm `--currentcolor'); when COLOR (a `#rrggbb'
+string) is given it is substituted in, so the equation matches the
+buffer foreground without recompiling.  Scaled by SCALE (default
+`agent-shell-markdown--math-display-scale') so the body font matches
+the surrounding text, and centred vertically for inline display."
+  (let ((data (with-temp-buffer
+                (insert-file-contents file)
+                (buffer-string))))
+    (when color
+      (setq data (replace-regexp-in-string "currentColor" color data t t)))
+    (create-image data 'svg t
+                  :scale (or scale (agent-shell-markdown--math-display-scale))
+                  :ascent 'center)))
 
-(defun agent-shell-markdown--math-image-cache-key (key scale)
-  "Return the in-memory image-cache key for content KEY at display SCALE.
-KEY names the font-independent on-disk SVG; the cached image object
-bakes in a display `:scale', so the in-memory key adds SCALE.  This
-lets images at different font sizes coexist, so a font change just
-creates a new entry — no cache clearing, and a sibling buffer's
-warm images survive."
-  (format "%s@%s" key scale))
+(defun agent-shell-markdown--math-image-cache-key (key scale color)
+  "Return the in-memory image-cache key for content KEY at SCALE and COLOR.
+KEY names the font- and color-independent on-disk SVG; the cached
+image object bakes in a display `:scale' and a tint COLOR, so the
+in-memory key adds both.  Images at different font sizes or colors
+coexist, so a font or theme change just creates a new entry — no
+cache clearing, and a sibling buffer's warm images survive."
+  (format "%s@%s@%s" key scale color))
 
 (defun agent-shell-markdown--math-cached-image (key)
-  "Return the rendered image for content KEY at the current font scale.
-Checks the in-memory cache (keyed by KEY and the display scale via
-`agent-shell-markdown--math-image-cache-key', so each font size has
-its own image), else loads KEY's on-disk SVG and caches a freshly
-scaled image.  Returns nil when the SVG isn't on disk yet (its
-compile hasn't finished).  Computes the scale from the current
-buffer, so call it within the target buffer to honour a buffer-local
-text scale."
+  "Return the rendered image for content KEY at the current font and color.
+Checks the in-memory cache (keyed by KEY, the display scale, and the
+buffer foreground via `agent-shell-markdown--math-image-cache-key',
+so each size / color has its own image), else loads KEY's on-disk
+SVG and caches a freshly scaled, tinted image.  Returns nil when the
+SVG isn't on disk yet (its compile hasn't finished).  Reads the
+scale and color from the current buffer / frame, so call it within
+the target buffer to honour a buffer-local text scale."
   (let* ((scale (agent-shell-markdown--math-display-scale))
-         (image-key (agent-shell-markdown--math-image-cache-key key scale)))
+         (color (car (agent-shell-markdown-math--current-colors)))
+         (image-key (agent-shell-markdown--math-image-cache-key key scale color)))
     (or (gethash image-key agent-shell-markdown-math--image-cache)
         (let ((file (agent-shell-markdown--math-svg-file key)))
           (when (file-exists-p file)
             (puthash image-key
-                     (agent-shell-markdown--math-load-svg-image file scale)
+                     (agent-shell-markdown--math-load-svg-image file scale color)
                      agent-shell-markdown-math--image-cache))))))
 
 (defun agent-shell-markdown--math-overlay-image (buffer start end image)
@@ -828,11 +838,14 @@ markers so the overlay lands even after more output streams in.
 
 INLINE non-nil typesets LATEX in text style instead of display
 style; it feeds both the cache key and the compile, so inline and
-display renders of the same source don't collide in the cache."
+display renders of the same source don't collide in the cache.
+Color is not baked in here — `agent-shell-markdown--math-cached-image'
+tints the color-independent SVG to the buffer foreground at display
+time."
   (when (agent-shell-markdown--math-renderable-p)
     ;; Record the appearance (colors + font height) this render is for,
     ;; so a later theme / frame / font change can detect the difference
-    ;; and re-render.
+    ;; and re-render (a color change re-tints; it no longer recompiles).
     (let ((appearance (agent-shell-markdown-math--current-appearance)))
       (setq agent-shell-markdown-math--rendered-appearance appearance)
       (cond
@@ -842,21 +855,20 @@ display renders of the same source don't collide in the cache."
          buffer start end
          (agent-shell-markdown--latex-placeholder-image latex)))
        (t
-        (let* ((color (car appearance))
-               (key (agent-shell-markdown--math-cache-key latex color inline))
+        (let* ((key (agent-shell-markdown--math-cache-key latex inline))
                (image (agent-shell-markdown--math-cached-image key)))
           (if image
               (agent-shell-markdown--math-overlay-image buffer start end image)
             (agent-shell-markdown--math-schedule
-             key latex color buffer
+             key latex buffer
              (copy-marker start) (copy-marker end) inline))))))))
 
-(defun agent-shell-markdown--math-schedule (key latex color
+(defun agent-shell-markdown--math-schedule (key latex
                                                 buffer start end &optional inline)
   "Queue BUFFER's START..END for KEY and start a compile if none is running.
 
-KEY identifies the equation; LATEX, COLOR, and INLINE are forwarded
-to `agent-shell-markdown--math-compile' for the render.  Multiple
+KEY identifies the equation; LATEX and INLINE are forwarded to
+`agent-shell-markdown--math-compile' for the render.  Multiple
 regions sharing KEY (the same equation rendered more than once) are
 coalesced onto a single in-flight compile; all are overlaid when it
 finishes."
@@ -864,10 +876,10 @@ finishes."
     (puthash key (cons (list buffer start end) pending)
              agent-shell-markdown-math--pending)
     (unless pending
-      (agent-shell-markdown--math-compile key latex color inline))))
+      (agent-shell-markdown--math-compile key latex inline))))
 
-(defun agent-shell-markdown--math-compile (key latex color &optional inline)
-  "Asynchronously compile LATEX (in COLOR) to the cache SVG for KEY.
+(defun agent-shell-markdown--math-compile (key latex &optional inline)
+  "Asynchronously compile LATEX to the color-independent cache SVG for KEY.
 
 Writes a standalone LaTeX document, runs
 `agent-shell-markdown-math-latex-program' then
@@ -877,6 +889,12 @@ every region queued for KEY (see
 `agent-shell-markdown--math-schedule').  On failure the queued
 regions keep their raw faced text.  The scratch directory is
 removed when the process exits.
+
+No color is baked in: the equation's default ink is emitted as the
+literal `currentColor' (dvisvgm `--currentcolor'), so the SVG is
+color-independent and is tinted to the buffer foreground at display
+time (`agent-shell-markdown--math-load-svg-image').  A theme change
+therefore re-tints from cache without recompiling.
 
 Future optimization: a precompiled-preamble `.fmt' (mylatexformat)
 would cut per-equation latency, but plain compilation keeps this
@@ -892,8 +910,9 @@ portable; it can slot in here without changing callers."
               ;; Display math is typeset `\displaystyle' (full-size sums /
               ;; fractions / integrals); inline `\(...\)' is left in text
               ;; style so it sits compactly within the surrounding line.
-              (format "{\\color[HTML]{%s}$%s%s$}\n"
-                      (upcase (substring color 1))
+              ;; No `\color' — `--currentcolor' below turns the default
+              ;; (black) ink into the `currentColor' token, tinted at display.
+              (format "$%s%s$\n"
                       (if inline "" "\\displaystyle ")
                       latex)
               "\\end{document}\n"))
@@ -901,8 +920,10 @@ portable; it can slot in here without changing callers."
     ;; paths via --no-fonts), so the scale doesn't affect quality, and the
     ;; displayed size is set later by `--math-display-scale'.  Fixing it at 1
     ;; means the SVG carries the equation's natural point dimensions.
+    ;; `--currentcolor' rewrites the default ink to the `currentColor' token
+    ;; so the file is color-independent (tinted at display time).
     (let ((command
-           (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --scale=1 -o %s %s"
+           (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --currentcolor --scale=1 -o %s %s"
                    (shell-quote-argument dir)
                    (shell-quote-argument agent-shell-markdown-math-latex-program)
                    (shell-quote-argument tex)

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -23,11 +23,16 @@
 ;; Display-math support for `agent-shell-markdown': intercept LaTeX
 ;; display equations in agent output and overlay them with an image.
 ;;
-;; Two delimiter styles are recognized, toggled independently via
-;; `agent-shell-markdown-math-delimiters':
+;; Two block-level delimiter styles are recognized, toggled
+;; independently via `agent-shell-markdown-math-delimiters':
 ;;
 ;;   bracket  `\[X\]'    (default; unambiguous)
-;;   dollar   `$$X$$'    (opt-in; can clash with prose / currency)
+;;   dollar   `$$X$$'    (default; safe because matched block-level only)
+;;
+;; Inline math `\(X\)' is recognized separately (toggle
+;; `agent-shell-markdown-math-render-inline', default on) and typeset
+;; in text style.  Inline `$X$' is intentionally not matched — a lone
+;; `$' is too common in prose to be safe.
 ;;
 ;; The raw LaTeX is kept in the buffer (so copy / save round-trips the
 ;; source) and, on a graphical display, an equation image is layered on
@@ -74,6 +79,12 @@ on a non-graphical display."
   "Map of display-math delimiter styles to their (OPEN . CLOSE) tokens.
 `dollar' is `$$...$$'; `bracket' is `\\[...\\]'.  The keys of this
 map are the values accepted in `agent-shell-markdown-math-delimiters'.")
+
+(defconst agent-shell-markdown--math-inline-open "\\("
+  "Opening delimiter for inline math (a literal backslash and paren).")
+
+(defconst agent-shell-markdown--math-inline-close "\\)"
+  "Closing delimiter for inline math (a literal backslash and paren).")
 
 (defvar agent-shell-markdown-math-delimiters '(bracket dollar)
   "Display-math delimiter styles recognized when rendering markdown.
@@ -128,6 +139,25 @@ only when `agent-shell-markdown-render-math' is non-nil.  Several
 agents emit `math'/`latex' fences (GitHub renders ```math as
 display math), so this complements the `\\[...\\]' / `$$...$$'
 delimiter styles.  Set to nil to leave such fences as code.")
+
+(defvar agent-shell-markdown-math-render-inline t
+  "When non-nil, recognize inline math `\\(...\\)' in agent responses.
+
+Only effective when the master switch
+`agent-shell-markdown-render-math' is non-nil.  Inline math is
+typeset in text style (no `\\displaystyle') and overlaid in place,
+so it sits within the surrounding line rather than on its own.
+
+Unlike the block-level delimiters, `\\(...\\)' is matched anywhere
+on a line (it is inline by nature), but its body may not cross a
+line break — the closer must appear on the same line as the
+opener, which bounds the match and keeps a stray `\\(' from
+swallowing the rest of a streaming response.
+
+Inline `$...$' is deliberately NOT recognized: a lone `$' is far
+too common in prose, currency, and shell snippets to match safely.
+Only the unambiguous `\\(...\\)' form is detected; `$...$' support
+can be added later if agents prove to need it.")
 
 (defvar agent-shell-markdown-math-use-placeholder nil
   "When non-nil, draw the placeholder panel instead of typesetting LaTeX.
@@ -339,6 +369,114 @@ returns ((1 . 11))."
             (cons (plist-get block :start) (plist-get block :end)))
           (agent-shell-markdown--math-blocks avoid-ranges)))
 
+(defun agent-shell-markdown--math-inline-spans (&optional avoid-ranges)
+  "Return inline-math spans `\\(...\\)' in the current buffer.
+
+Each element is a plist (:start S :end E :open O :close C), with
+the same shape as `agent-shell-markdown--math-blocks': S..E spans
+the whole delimited span (delimiters included) and the LaTeX body
+is the buffer text in [S+O, E-C).
+
+Inline math is matched anywhere on a line, but only when the
+closing `\\)' appears on the SAME line as the opening `\\(' — a
+single-line bound that keeps a stray opener from swallowing the
+buffer and means the renderer's start-of-last-line watermark
+already covers the still-streaming case (no open-span bookkeeping
+needed, unlike `agent-shell-markdown--math-blocks').
+
+A delimiter inside any of AVOID-RANGES (a sorted vector, typically
+fenced code, display math, or inline code) is ignored, and a
+candidate whose body would overlap an avoid-range is rejected, so
+returned spans never overlap AVOID-RANGES or each other.
+
+For example, with buffer \"see \\=\\(E=mc^2\\=\\) here\", returns
+\((:start 5 :end 15 :open 2 :close 2))."
+  (let ((spans '())
+        (open agent-shell-markdown--math-inline-open)
+        (close agent-shell-markdown--math-inline-close)
+        (case-fold-search nil))
+    (save-excursion
+      (goto-char (point-min))
+      (let ((open-re (regexp-quote open))
+            (close-re (regexp-quote close)))
+        (while (re-search-forward open-re nil t)
+          (let* ((open-start (match-beginning 0))
+                 (open-end (match-end 0))
+                 (avoid (agent-shell-markdown--in-avoid-range-p
+                         open-start open-end avoid-ranges)))
+            (if avoid
+                (goto-char (cdr avoid))
+              ;; Look for the closer on this line only; skip a closer
+              ;; that sits inside an avoid-range (it is protected text).
+              (let ((eol (line-end-position))
+                    (close-end nil))
+                (save-excursion
+                  (goto-char open-end)
+                  (while (and (not close-end)
+                              (re-search-forward close-re eol t))
+                    (let ((in (agent-shell-markdown--in-avoid-range-p
+                               (match-beginning 0) (match-end 0) avoid-ranges)))
+                      (if in
+                          (goto-char (cdr in))
+                        (setq close-end (match-end 0))))))
+                (cond
+                 ;; Clean closer on the line and nothing protected sits
+                 ;; between the delimiters: a valid inline span.
+                 ((and close-end
+                       (not (seq-some
+                             (lambda (range)
+                               (and (< (car range) close-end)
+                                    (> (cdr range) open-start)))
+                             avoid-ranges)))
+                  (push (list :start open-start :end close-end
+                              :open (length open) :close (length close))
+                        spans)
+                  (goto-char close-end))
+                 ;; No usable closer on the line (false positive, or the
+                 ;; span is still streaming on the buffer's last line):
+                 ;; resume just after the opener so a later real span is
+                 ;; still found.  The start-of-last-line watermark re-scans
+                 ;; an unclosed tail on the next chunk.
+                 (t (goto-char open-end)))))))))
+    (nreverse spans)))
+
+(defun agent-shell-markdown--math-inline-ranges (&optional avoid-ranges)
+  "Return list of (start . end) ranges covering inline-math spans.
+Thin adapter over `agent-shell-markdown--math-inline-spans' for
+callers that only need the protected spans.  AVOID-RANGES is
+forwarded."
+  (mapcar (lambda (span)
+            (cons (plist-get span :start) (plist-get span :end)))
+          (agent-shell-markdown--math-inline-spans avoid-ranges)))
+
+(cl-defun agent-shell-markdown--style-inline-math (&key avoid-ranges)
+  "Overlay inline-math spans `\\(...\\)' with a text-style equation image.
+
+Mirrors `agent-shell-markdown--style-math-blocks' but for inline
+`\\(...\\)' spans (see `agent-shell-markdown--math-inline-spans'):
+the raw delimited text is kept and the region handed to
+`agent-shell-markdown--apply-math-region' with INLINE non-nil, so
+it is typeset in text style.  Spans inside AVOID-RANGES, or with an
+empty body, are left untouched.
+
+A span that lands on already-`agent-shell-markdown-frozen' text is
+also skipped.  AVOID-RANGES alone can't catch this: an earlier
+pass (notably inline code) may have rewritten its region in the
+same call, collapsing the range markers we were handed — the live
+`frozen' property is the reliable signal, so a backticked
+`\\(x\\)' stays literal code."
+  (dolist (span (agent-shell-markdown--math-inline-spans avoid-ranges))
+    (when-let* ((start (plist-get span :start))
+                ((not (get-text-property start 'agent-shell-markdown-frozen)))
+                (end (plist-get span :end))
+                (latex (string-trim
+                        (buffer-substring-no-properties
+                         (+ start (plist-get span :open))
+                         (- end (plist-get span :close)))))
+                ((not (string-empty-p latex))))
+      (agent-shell-markdown--apply-math-region
+       (current-buffer) start end latex t))))
+
 (cl-defun agent-shell-markdown--style-math-blocks (&key avoid-ranges)
   "Overlay display-math blocks with an equation image.
 
@@ -389,8 +527,8 @@ empty (a fence with no info string), which is not a math language."
        (member (downcase lang) agent-shell-markdown-math-fence-languages)
        t))
 
-(defun agent-shell-markdown--apply-math-region (buffer start end latex)
-  "Mark BUFFER's START..END as display math with source LATEX and render it.
+(defun agent-shell-markdown--apply-math-region (buffer start end latex &optional inline)
+  "Mark BUFFER's START..END as math with source LATEX and render it.
 
 Keeps the underlying text in place, faces the region
 `agent-shell-markdown-math', tags it `agent-shell-markdown-frozen'
@@ -398,9 +536,15 @@ Keeps the underlying text in place, faces the region
 `agent-shell-markdown-math-source', then hands off to
 `agent-shell-markdown--math-render' for the equation image.
 
-Shared by the delimiter pass (`--style-math-blocks') and the
-fenced-block path (`agent-shell-markdown--style-source-blocks',
-for ```math / ```latex)."
+INLINE non-nil typesets LATEX in text style (for `\\(...\\)'
+inline math) rather than as a display equation; it is stashed in
+`agent-shell-markdown-math-inline' so a later refresh re-renders in
+the same style.
+
+Shared by the delimiter pass (`--style-math-blocks'), the inline
+pass (`--style-inline-math'), and the fenced-block path
+\(`agent-shell-markdown--style-source-blocks', for ```math /
+```latex)."
   (with-current-buffer buffer
     (setq agent-shell-markdown-math--present t)
     (add-face-text-property start end 'agent-shell-markdown-math)
@@ -408,9 +552,10 @@ for ```math / ```latex)."
      start end
      `(help-echo ,latex
        agent-shell-markdown-math-source ,latex
+       agent-shell-markdown-math-inline ,inline
        agent-shell-markdown-frozen t
        rear-nonsticky (agent-shell-markdown-frozen)))
-    (agent-shell-markdown--math-render buffer start end latex)))
+    (agent-shell-markdown--math-render buffer start end latex inline)))
 
 (defun agent-shell-markdown--svg-color (face attribute fallback)
   "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
@@ -514,12 +659,16 @@ subdirectory of the variable `temporary-file-directory'."
       (make-directory dir t))
     dir))
 
-(defun agent-shell-markdown--math-cache-key (latex color scale)
+(defun agent-shell-markdown--math-cache-key (latex color scale &optional inline)
   "Return a stable cache key for LATEX rendered in COLOR at SCALE.
-The preamble is folded in so changing it invalidates the cache."
-  (secure-hash 'sha1 (format "%s\0%s\0%s\0%s"
+The preamble is folded in so changing it invalidates the cache.
+INLINE (text style vs display) is folded in too, since the same
+LATEX renders differently in each — appended only when set so
+existing display-math cache keys stay stable."
+  (secure-hash 'sha1 (format "%s\0%s\0%s\0%s%s"
                              latex color scale
-                             agent-shell-markdown-math-preamble)))
+                             agent-shell-markdown-math-preamble
+                             (if inline "\0inline" ""))))
 
 (defun agent-shell-markdown--math-svg-file (key)
   "Return the cache SVG path for KEY."
@@ -563,7 +712,7 @@ is preserved."
               (when wrap-prefix
                 (put-text-property s e 'wrap-prefix wrap-prefix)))))))))
 
-(defun agent-shell-markdown--math-render (buffer start end latex)
+(defun agent-shell-markdown--math-render (buffer start end latex &optional inline)
   "Render LATEX over BUFFER's START..END as an equation image.
 
 Does nothing when equations aren't renderable (see
@@ -573,7 +722,11 @@ or no LaTeX toolchain, overlays the placeholder panel.  Otherwise
 overlays the cached SVG immediately when available, else schedules
 an async compile (see `agent-shell-markdown--math-compile') that
 overlays the result once ready — START / END are captured as
-markers so the overlay lands even after more output streams in."
+markers so the overlay lands even after more output streams in.
+
+INLINE non-nil typesets LATEX in text style instead of display
+style; it feeds both the cache key and the compile, so inline and
+display renders of the same source don't collide in the cache."
   (when (agent-shell-markdown--math-renderable-p)
     ;; Record the colors this render is for, so a later theme / frame /
     ;; appearance change can detect the difference and re-render.
@@ -588,30 +741,30 @@ markers so the overlay lands even after more output streams in."
        (t
         (let* ((color (car colors))
                (scale agent-shell-markdown-math-scale)
-               (key (agent-shell-markdown--math-cache-key latex color scale))
+               (key (agent-shell-markdown--math-cache-key latex color scale inline))
                (image (agent-shell-markdown--math-cached-image key)))
           (if image
               (agent-shell-markdown--math-overlay-image buffer start end image)
             (agent-shell-markdown--math-schedule
              key latex color scale buffer
-             (copy-marker start) (copy-marker end)))))))))
+             (copy-marker start) (copy-marker end) inline))))))))
 
 (defun agent-shell-markdown--math-schedule (key latex color scale
-                                                buffer start end)
+                                                buffer start end &optional inline)
   "Queue BUFFER's START..END for KEY and start a compile if none is running.
 
-KEY identifies the equation; LATEX, COLOR, and SCALE are forwarded
-to `agent-shell-markdown--math-compile' for the render.  Multiple
-regions sharing KEY (the same equation rendered more than once)
-are coalesced onto a single in-flight compile; all are overlaid
-when it finishes."
+KEY identifies the equation; LATEX, COLOR, SCALE, and INLINE are
+forwarded to `agent-shell-markdown--math-compile' for the render.
+Multiple regions sharing KEY (the same equation rendered more than
+once) are coalesced onto a single in-flight compile; all are
+overlaid when it finishes."
   (let ((pending (gethash key agent-shell-markdown-math--pending)))
     (puthash key (cons (list buffer start end) pending)
              agent-shell-markdown-math--pending)
     (unless pending
-      (agent-shell-markdown--math-compile key latex color scale))))
+      (agent-shell-markdown--math-compile key latex color scale inline))))
 
-(defun agent-shell-markdown--math-compile (key latex color scale)
+(defun agent-shell-markdown--math-compile (key latex color scale &optional inline)
   "Asynchronously compile LATEX (in COLOR, at SCALE) to the cache SVG for KEY.
 
 Writes a standalone LaTeX document, runs
@@ -634,8 +787,13 @@ portable; it can slot in here without changing callers."
     (with-temp-file tex
       (insert agent-shell-markdown-math-preamble "\n"
               "\\begin{document}\n"
-              (format "{\\color[HTML]{%s}$\\displaystyle %s$}\n"
-                      (upcase (substring color 1)) latex)
+              ;; Display math is typeset `\displaystyle' (full-size sums /
+              ;; fractions / integrals); inline `\(...\)' is left in text
+              ;; style so it sits compactly within the surrounding line.
+              (format "{\\color[HTML]{%s}$%s%s$}\n"
+                      (upcase (substring color 1))
+                      (if inline "" "\\displaystyle ")
+                      latex)
               "\\end{document}\n"))
     (let ((command
            (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --scale=%s -o %s %s"
@@ -683,10 +841,12 @@ is reused from cache)."
                             'agent-shell-markdown-math-source nil))
             (let ((latex (get-text-property
                           pos 'agent-shell-markdown-math-source))
+                  (inline (get-text-property
+                           pos 'agent-shell-markdown-math-inline))
                   (end (or (next-single-property-change
                             pos 'agent-shell-markdown-math-source nil (point-max))
                            (point-max))))
-              (agent-shell-markdown--math-render buffer pos end latex)
+              (agent-shell-markdown--math-render buffer pos end latex inline)
               (setq pos end))))))))
 
 (defun agent-shell-markdown-math-refresh ()

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -703,11 +703,12 @@ is cheap when nothing actually changed."
 
 (defun agent-shell-markdown-math--maybe-refresh (&rest _)
   "Re-render equations if the appearance changed since they were rendered.
-Hooked to theme / frame-creation / system-appearance changes.  A
-no-op when math rendering is off; otherwise the actual comparison
-and refresh are deferred to the next idle moment, by which point the
-new theme / frame is fully in effect (and rapid repeat triggers
-collapse, since the first refresh updates the recorded colors)."
+Hooked to buffer display (`window-buffer-change-functions') and theme
+enabling (`enable-theme-functions').  A no-op when math rendering is
+off; otherwise the actual comparison and refresh are deferred to the
+next idle moment, by which point a freshly applied theme is fully in
+effect (and rapid repeat triggers collapse, since the first refresh
+updates the recorded colors)."
   (when agent-shell-markdown-render-math
     (run-at-time 0 nil #'agent-shell-markdown-math--refresh-if-changed)))
 
@@ -718,16 +719,19 @@ collapse, since the first refresh updates the recorded colors)."
                          agent-shell-markdown-math--rendered-colors)))
     (agent-shell-markdown-math-refresh)))
 
-;; Re-render on the events that change the default face's colors: a theme
-;; being enabled (Emacs 29+), a new frame opening (e.g. a graphical client
-;; attaching to a daemon after a TTY render), and macOS light/dark
-;; switches.  Each handler is gated by `agent-shell-markdown-render-math'
-;; and a colors-actually-changed check, so they're cheap no-ops otherwise.
+;; Re-render lazily, when an equation buffer is next displayed, rather than
+;; eagerly on every event that might recolor the default face.
+;; `window-buffer-change-functions' is the workhorse: whatever changed the
+;; colors (a theme, a macOS/Linux system light/dark toggle on any platform,
+;; a graphical client attaching to a daemon after a TTY render), we notice
+;; the next time the buffer is shown in a window and repaint if stale.
+;; `enable-theme-functions' (Emacs 29+, cross-platform) covers the one case
+;; display alone misses: a theme enabled while the buffer stays visible and
+;; untouched.  Both go through the same colors-actually-changed check, so
+;; they're cheap no-ops when nothing changed (or math rendering is off).
+(add-hook 'window-buffer-change-functions
+          #'agent-shell-markdown-math--maybe-refresh)
 (add-hook 'enable-theme-functions #'agent-shell-markdown-math--maybe-refresh)
-(add-hook 'after-make-frame-functions #'agent-shell-markdown-math--maybe-refresh)
-(when (boundp 'ns-system-appearance-change-functions)
-  (add-hook 'ns-system-appearance-change-functions
-            #'agent-shell-markdown-math--maybe-refresh))
 
 (provide 'agent-shell-markdown-math)
 

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -248,13 +248,15 @@ without `agent-shell.el'; set this variable there (or stub
 (defvar agent-shell-markdown-math--pending (make-hash-table :test 'equal)
   "In-memory map of cache key to regions awaiting an in-flight compile.")
 
-(defvar agent-shell-markdown-math--rendered-appearance nil
-  "The appearance signature the displayed equations were rendered for.
+(defvar-local agent-shell-markdown-math--rendered-appearance nil
+  "The appearance signature this buffer's equations were rendered for.
 A list (FOREGROUND BACKGROUND FONT-HEIGHT) — see
-`agent-shell-markdown-math--current-appearance'.  Updated whenever
-an equation renders; compared on theme / frame / font changes to
-decide whether equations need re-rendering (see
-`agent-shell-markdown-math--maybe-refresh').")
+`agent-shell-markdown-math--current-appearance'.  Buffer-local:
+each buffer tracks its own last-rendered appearance, so a refresh
+can re-render just the affected buffer and leave the others to
+re-render lazily when they are next displayed (see
+`agent-shell-markdown-math--refresh-if-changed').  Updated whenever
+an equation renders.")
 
 (defvar-local agent-shell-markdown-math--present nil
   "Non-nil in a buffer that has rendered display-math regions.
@@ -937,22 +939,29 @@ is reused from cache)."
               (agent-shell-markdown--math-render buffer pos end latex inline)
               (setq pos end))))))))
 
-(defun agent-shell-markdown-math-refresh ()
-  "Re-render all displayed equations for the current colors and font.
-Call after a theme, appearance, or font-size change so equation
-images pick up the new colors and size.  The in-memory image cache
-and the pixels-per-point calibration are dropped so images are
-rebuilt at the current font scale from the on-disk SVGs (cheap — no
-LaTeX recompile unless the color also changed); equations otherwise
-unchanged stay fast."
+(defun agent-shell-markdown-math-refresh (&optional buffer)
+  "Re-render displayed equations for the current colors and font.
+With BUFFER, re-render only that buffer; otherwise (the interactive
+default) every buffer that has rendered equations.  Call after a
+theme, appearance, or font-size change so equation images pick up
+the new colors and size.
+
+The in-memory image cache and the pixels-per-point calibration are
+dropped so images are rebuilt at the current font scale from the
+on-disk SVGs (cheap — no LaTeX recompile unless the color also
+changed); each re-rendered buffer records its new appearance via
+`agent-shell-markdown--math-render', so unchanged buffers stay
+fast and untouched buffers refresh lazily when next displayed."
   (interactive)
   (setq agent-shell-markdown-math--svg-px-per-pt nil)
   (clrhash agent-shell-markdown-math--image-cache)
-  (setq agent-shell-markdown-math--rendered-appearance
-        (agent-shell-markdown-math--current-appearance))
-  (dolist (buffer (buffer-list))
-    (when (buffer-local-value 'agent-shell-markdown-math--present buffer)
-      (agent-shell-markdown-math--refresh-buffer buffer))))
+  (dolist (buf (if buffer
+                   (list buffer)
+                 (seq-filter
+                  (lambda (b)
+                    (buffer-local-value 'agent-shell-markdown-math--present b))
+                  (buffer-list))))
+    (agent-shell-markdown-math--refresh-buffer buf)))
 
 (defun agent-shell-markdown-math--maybe-refresh (&rest _)
   "Re-render equations if the appearance changed since they were rendered.
@@ -966,15 +975,19 @@ updates the recorded appearance)."
     (run-at-time 0 nil #'agent-shell-markdown-math--refresh-if-changed)))
 
 (defun agent-shell-markdown-math--refresh-if-changed ()
-  "Run `agent-shell-markdown-math-refresh' iff the appearance changed.
-The appearance signature folds in both colors and the buffer font
-height (see `agent-shell-markdown-math--current-appearance'), so a
-font-size change is picked up the next time a hook fires (e.g. on
-switching to the buffer), just like a color change."
+  "Re-render the current buffer's equations if its appearance changed.
+Acts only on the current buffer — the one the firing hook just made
+relevant (displayed, themed, or zoomed) — so making one chat visible
+never re-renders the others; each refreshes lazily when it is itself
+displayed.  The appearance signature folds in both colors and the
+buffer font height (see
+`agent-shell-markdown-math--current-appearance'), so a font-size
+change is picked up just like a color change."
   (when (and agent-shell-markdown-render-math
+             agent-shell-markdown-math--present
              (not (equal (agent-shell-markdown-math--current-appearance)
                          agent-shell-markdown-math--rendered-appearance)))
-    (agent-shell-markdown-math-refresh)))
+    (agent-shell-markdown-math-refresh (current-buffer))))
 
 ;; Re-render lazily, when an equation buffer is next displayed, rather than
 ;; eagerly on every event that might recolor the default face.

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -75,7 +75,7 @@ on a non-graphical display."
 `dollar' is `$$...$$'; `bracket' is `\\[...\\]'.  The keys of this
 map are the values accepted in `agent-shell-markdown-math-delimiters'.")
 
-(defvar agent-shell-markdown-math-delimiters '(bracket)
+(defvar agent-shell-markdown-math-delimiters '(bracket dollar)
   "Display-math delimiter styles recognized when rendering markdown.
 
 A list whose members are keys of
@@ -85,14 +85,19 @@ A list whose members are keys of
   `dollar'   recognize `$$...$$'
 
 The two are independent — add or drop one to toggle it.  An empty
-list disables math rendering entirely (as does passing
-`:render-math nil' to `agent-shell-markdown-replace-markup').
+list disables the delimiter styles (fenced math via
+`agent-shell-markdown-math-fence-languages' is separate); the
+master switch `agent-shell-markdown-render-math' disables
+everything.
 
-Defaults to `bracket' only: `\\[...\\]' is unambiguous, whereas
-`dollar' can false-positive on prose or currency like \"it cost
-$$$\".  Opt into `$$...$$' with:
-
-  (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
+Both styles are matched only as block-level equations: the opener
+must start its line (after optional indentation) and the closer
+must be flush — either start or end its line.  Genuinely inline
+display math is therefore not recognized (agents don't emit it,
+and truly inline math should use `\\(...\\)' / `$...$', which are
+left untouched).  That anchoring makes `$$' safe enough to enable
+by default; set to \\='(bracket) to drop it if `$$' still
+collides with your prose.")
 
 (defvar agent-shell-markdown-render-math nil
   "Master switch for rendering display math in agent responses.
@@ -170,6 +175,14 @@ ever).")
 (defvar agent-shell-markdown-math--pending (make-hash-table :test 'equal)
   "In-memory map of cache key to regions awaiting an in-flight compile.")
 
+(defun agent-shell-markdown--math-delimiter-flush-p (start end)
+  "Return non-nil if the delimiter spanning START..END is flush on its line.
+Flush means it begins the line (only whitespace before it) or ends
+the line (only whitespace after it) — the shape display-math
+delimiters take in practice."
+  (or (save-excursion (goto-char start) (skip-chars-backward " \t") (bolp))
+      (save-excursion (goto-char end) (skip-chars-forward " \t") (eolp))))
+
 (defun agent-shell-markdown--math-blocks (&optional avoid-ranges)
   "Return display-math blocks in the current buffer.
 
@@ -180,18 +193,25 @@ body is the buffer text in [S+O, E-C).
 
 Only the delimiter styles listed in
 `agent-shell-markdown-math-delimiters' are recognized (`$$...$$'
-and/or `\\[...\\]').
+and/or `\\[...\\]'), and only as BLOCK-LEVEL equations:
+
+  - the opener must start its line (after optional indentation), and
+  - the closer must be flush — start or end its line.
+
+Genuinely inline display math is thus not matched; this keeps
+prose / currency (`$$') from false-positiving.
 
 Scanning resolves each opener immediately: from just after an
-opener we look for the first of its matching closer or a blank
+opener, look for the first of its matching flush closer or a blank
 line (a paragraph break, which LaTeX display math can't contain).
+A closer that is not flush is treated as body and the search
+continues.
 
-  - Closer first: a valid block, recorded; scanning resumes after
-    the closer.
-  - Blank line first: the opener is a false positive, so scanning
-    resumes just after the OPENER (not past the blank line), so
-    real blocks sitting between a stray opener and the blank line
-    are still found.
+  - Flush closer first: a valid block, recorded; scanning resumes
+    after the closer.
+  - Blank line first (or no closer): the opener is a false
+    positive, so scanning resumes just after the OPENER, so a real
+    block on a later line is still found.
   - Neither yet (end of buffer): a still-streaming block extending
     to `point-max' with :close 0, so a genuine equation stays
     protected as the buffer grows — mirrors
@@ -213,11 +233,14 @@ returns ((:start 1 :end 11 :open 2 :close 2))."
     (when specs
       (save-excursion
         (goto-char (point-min))
-        (let ((open-re (regexp-opt (mapcar #'car specs))))
+        ;; Opener anchored at line start (after optional indentation);
+        ;; group 1 is the delimiter token itself.
+        (let ((open-re (concat "^[ \t]*\\(" (regexp-opt (mapcar #'car specs))
+                               "\\)")))
           (while (re-search-forward open-re nil t)
-            (let* ((open-token (match-string-no-properties 0))
-                   (open-start (match-beginning 0))
-                   (open-end (point))
+            (let* ((open-token (match-string-no-properties 1))
+                   (open-start (match-beginning 1))
+                   (open-end (match-end 1))
                    (avoid (agent-shell-markdown--in-avoid-range-p
                            open-start open-end avoid-ranges)))
               (if avoid
@@ -226,9 +249,9 @@ returns ((:start 1 :end 11 :open 2 :close 2))."
                                           (lambda (spec)
                                             (string= open-token (car spec)))
                                           specs)))
-                       ;; First closer or blank line at or after the body.
-                       ;; A closer inside an avoid-range isn't real — skip
-                       ;; past that range and keep looking.
+                       ;; First flush closer or blank line after the body.
+                       ;; A closer in an avoid-range (code) or not flush
+                       ;; on its line is body — skip it and keep looking.
                        (hit (save-excursion
                               (goto-char open-end)
                               (let ((re (concat (regexp-quote close-token)
@@ -236,16 +259,25 @@ returns ((:start 1 :end 11 :open 2 :close 2))."
                                     (result nil))
                                 (while (and (not result)
                                             (re-search-forward re nil t))
-                                  (if-let* ((av (agent-shell-markdown--in-avoid-range-p
-                                                 (match-beginning 0) (point)
-                                                 avoid-ranges)))
-                                      (goto-char (cdr av))
-                                    (setq result
-                                          (cons (match-string-no-properties 0)
-                                                (point)))))
+                                  (let ((mb (match-beginning 0))
+                                        (me (match-end 0))
+                                        (tok (match-string-no-properties 0)))
+                                    (cond
+                                     ((agent-shell-markdown--in-avoid-range-p
+                                       mb me avoid-ranges)
+                                      (goto-char
+                                       (cdr (agent-shell-markdown--in-avoid-range-p
+                                             mb me avoid-ranges))))
+                                     ;; Blank line: paragraph-break terminator.
+                                     ((string-match-p "\n" tok)
+                                      (setq result (cons tok me)))
+                                     ;; Flush closer: a real block end.
+                                     ((agent-shell-markdown--math-delimiter-flush-p
+                                       mb me)
+                                      (setq result (cons tok me))))))
                                 result))))
                   (cond
-                   ;; Matching closer reached with no blank line before it.
+                   ;; Flush closer reached with no blank line before it.
                    ((and hit (string= (car hit) close-token))
                     (push (list :start open-start :end (cdr hit)
                                 :open (length open-token)
@@ -253,7 +285,7 @@ returns ((:start 1 :end 11 :open 2 :close 2))."
                           blocks)
                     (goto-char (cdr hit)))
                    ;; Blank line first: false-positive opener.  Resume
-                   ;; right after the opener so inner real blocks are seen.
+                   ;; right after the opener so a later real block is seen.
                    (hit (goto-char open-end))
                    ;; Neither yet: still-streaming open block.
                    (t (push (list :start open-start :end (point-max)

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -889,6 +889,33 @@ finishes."
     (unless pending
       (agent-shell-markdown--math-compile key latex inline))))
 
+(defun agent-shell-markdown--math-compile-failed (key latex dir)
+  "Handle a failed LaTeX compile for KEY with source LATEX.
+DIR is the scratch directory containing the build log.  The log
+is copied to a persistent file in the math cache directory, and a
+warning is emitted with a clickable link to it."
+  (let* ((log-src (expand-file-name "equation.log" dir))
+         (log-dst (expand-file-name (concat key ".log")
+                                    (agent-shell-markdown--math-cache-dir)))
+         (snippet (truncate-string-to-width latex 60 nil nil t)))
+    (when (file-exists-p log-src)
+      (copy-file log-src log-dst t))
+    (display-warning
+     'agent-shell-markdown-math
+     (format "LaTeX compile failed for: %s\nSee log: %s"
+             snippet
+             (if (file-exists-p log-dst) log-dst "(no log available)"))
+     :warning)
+    (when (file-exists-p log-dst)
+      (with-current-buffer "*Warnings*"
+        (let ((inhibit-read-only t))
+          (goto-char (point-max))
+          (save-excursion
+            (when (search-backward log-dst nil t)
+              (make-text-button (point) (+ (point) (length log-dst))
+                                'action (lambda (_) (find-file log-dst))
+                                'help-echo "Open LaTeX log"))))))))
+
 (defun agent-shell-markdown--math-compile (key latex &optional inline)
   "Asynchronously compile LATEX to the color-independent cache SVG for KEY.
 
@@ -897,9 +924,11 @@ Writes a standalone LaTeX document, runs
 `agent-shell-markdown-math-dvisvgm-program' in a scratch
 directory, and on success caches the SVG and overlays it onto
 every region queued for KEY (see
-`agent-shell-markdown--math-schedule').  On failure the queued
-regions keep their raw faced text.  The scratch directory is
-removed when the process exits.
+`agent-shell-markdown--math-schedule').  On failure the log is
+saved and a warning emitted (see
+`agent-shell-markdown--math-compile-failed'); the queued regions
+keep their raw faced text.  The scratch directory is removed when
+the process exits.
 
 No color is baked in: the equation's default ink is emitted as the
 literal `currentColor' (dvisvgm `--currentcolor'), so the SVG is
@@ -949,21 +978,19 @@ portable; it can slot in here without changing callers."
            (start-process-shell-command "agent-shell-markdown-math" nil command)
            (lambda (process _event)
              (when (memq (process-status process) '(exit signal))
-               (when (and (eq (process-status process) 'exit)
-                          (zerop (process-exit-status process))
-                          (file-exists-p svg))
-                 ;; Overlay each queued region with an image scaled to its
-                 ;; own buffer's font (via `--math-cached-image', which now
-                 ;; keys per display scale and loads the just-written SVG).
-                 (dolist (region (gethash key agent-shell-markdown-math--pending))
-                   (let ((buffer (nth 0 region))
-                         (start (nth 1 region))
-                         (end (nth 2 region)))
-                     (when (buffer-live-p buffer)
-                       (with-current-buffer buffer
-                         (agent-shell-markdown--math-overlay-image
-                          buffer start end
-                          (agent-shell-markdown--math-cached-image key)))))))
+               (if (and (eq (process-status process) 'exit)
+                        (zerop (process-exit-status process))
+                        (file-exists-p svg))
+                   (dolist (region (gethash key agent-shell-markdown-math--pending))
+                     (let ((buffer (nth 0 region))
+                           (start (nth 1 region))
+                           (end (nth 2 region)))
+                       (when (buffer-live-p buffer)
+                         (with-current-buffer buffer
+                           (agent-shell-markdown--math-overlay-image
+                            buffer start end
+                            (agent-shell-markdown--math-cached-image key))))))
+                 (agent-shell-markdown--math-compile-failed key latex dir))
                (remhash key agent-shell-markdown-math--pending)
                (funcall cleanup))))
         (error

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -190,6 +190,23 @@ ever).")
 (defvar agent-shell-markdown-math--pending (make-hash-table :test 'equal)
   "In-memory map of cache key to regions awaiting an in-flight compile.")
 
+(defvar agent-shell-markdown-math--rendered-colors nil
+  "The (FOREGROUND . BACKGROUND) the displayed equations were rendered for.
+Updated whenever an equation renders; compared on theme / frame /
+appearance changes to decide whether equations need re-rendering
+\(see `agent-shell-markdown-math--maybe-refresh').")
+
+(defvar-local agent-shell-markdown-math--present nil
+  "Non-nil in a buffer that has rendered display-math regions.
+Lets `agent-shell-markdown-math-refresh' visit only relevant buffers.")
+
+(defun agent-shell-markdown-math--current-colors ()
+  "Return the (FOREGROUND . BACKGROUND) equations should render for now.
+Both are `#rrggbb' strings resolved from the `default' face of the
+selected frame."
+  (cons (agent-shell-markdown--svg-color 'default :foreground "#000000")
+        (agent-shell-markdown--svg-color 'default :background "#ffffff")))
+
 (defun agent-shell-markdown--math-delimiter-flush-p (start end)
   "Return non-nil if the delimiter spanning START..END is flush on its line.
 Flush means it begins the line (only whitespace before it) or ends
@@ -385,6 +402,7 @@ Shared by the delimiter pass (`--style-math-blocks') and the
 fenced-block path (`agent-shell-markdown--style-source-blocks',
 for ```math / ```latex)."
   (with-current-buffer buffer
+    (setq agent-shell-markdown-math--present t)
     (add-face-text-property start end 'agent-shell-markdown-math)
     (add-text-properties
      start end
@@ -557,22 +575,26 @@ an async compile (see `agent-shell-markdown--math-compile') that
 overlays the result once ready — START / END are captured as
 markers so the overlay lands even after more output streams in."
   (when (agent-shell-markdown--math-renderable-p)
-    (cond
-     ((or agent-shell-markdown-math-use-placeholder
-          (not (agent-shell-markdown--math-tools-available-p)))
-      (agent-shell-markdown--math-overlay-image
-       buffer start end
-       (agent-shell-markdown--latex-placeholder-image latex)))
-     (t
-      (let* ((color (agent-shell-markdown--svg-color 'default :foreground "#000000"))
-             (scale agent-shell-markdown-math-scale)
-             (key (agent-shell-markdown--math-cache-key latex color scale))
-             (image (agent-shell-markdown--math-cached-image key)))
-        (if image
-            (agent-shell-markdown--math-overlay-image buffer start end image)
-          (agent-shell-markdown--math-schedule
-           key latex color scale buffer
-           (copy-marker start) (copy-marker end))))))))
+    ;; Record the colors this render is for, so a later theme / frame /
+    ;; appearance change can detect the difference and re-render.
+    (let ((colors (agent-shell-markdown-math--current-colors)))
+      (setq agent-shell-markdown-math--rendered-colors colors)
+      (cond
+       ((or agent-shell-markdown-math-use-placeholder
+            (not (agent-shell-markdown--math-tools-available-p)))
+        (agent-shell-markdown--math-overlay-image
+         buffer start end
+         (agent-shell-markdown--latex-placeholder-image latex)))
+       (t
+        (let* ((color (car colors))
+               (scale agent-shell-markdown-math-scale)
+               (key (agent-shell-markdown--math-cache-key latex color scale))
+               (image (agent-shell-markdown--math-cached-image key)))
+          (if image
+              (agent-shell-markdown--math-overlay-image buffer start end image)
+            (agent-shell-markdown--math-schedule
+             key latex color scale buffer
+             (copy-marker start) (copy-marker end)))))))))
 
 (defun agent-shell-markdown--math-schedule (key latex color scale
                                                 buffer start end)
@@ -645,6 +667,67 @@ portable; it can slot in here without changing callers."
          (remhash key agent-shell-markdown-math--pending)
          (funcall cleanup)
          (signal (car err) (cdr err)))))))
+
+(defun agent-shell-markdown-math--refresh-buffer (buffer)
+  "Re-render every display-math region in BUFFER for the current colors.
+Each `agent-shell-markdown-math-source' region is handed back to
+`agent-shell-markdown--math-render', which recomputes the cache key
+\(so a foreground change yields a fresh image and an unchanged one
+is reused from cache)."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (save-excursion
+        (let ((pos (point-min)))
+          (while (setq pos (text-property-not-all
+                            pos (point-max)
+                            'agent-shell-markdown-math-source nil))
+            (let ((latex (get-text-property
+                          pos 'agent-shell-markdown-math-source))
+                  (end (or (next-single-property-change
+                            pos 'agent-shell-markdown-math-source nil (point-max))
+                           (point-max))))
+              (agent-shell-markdown--math-render buffer pos end latex)
+              (setq pos end))))))))
+
+(defun agent-shell-markdown-math-refresh ()
+  "Re-render all displayed equations for the current foreground/background.
+Call after a theme or appearance change so equation images pick up
+the new colors.  Unchanged equations are served from cache, so this
+is cheap when nothing actually changed."
+  (interactive)
+  (setq agent-shell-markdown-math--rendered-colors
+        (agent-shell-markdown-math--current-colors))
+  (dolist (buffer (buffer-list))
+    (when (buffer-local-value 'agent-shell-markdown-math--present buffer)
+      (agent-shell-markdown-math--refresh-buffer buffer))))
+
+(defun agent-shell-markdown-math--maybe-refresh (&rest _)
+  "Re-render equations if the appearance changed since they were rendered.
+Hooked to theme / frame-creation / system-appearance changes.  A
+no-op when math rendering is off; otherwise the actual comparison
+and refresh are deferred to the next idle moment, by which point the
+new theme / frame is fully in effect (and rapid repeat triggers
+collapse, since the first refresh updates the recorded colors)."
+  (when agent-shell-markdown-render-math
+    (run-at-time 0 nil #'agent-shell-markdown-math--refresh-if-changed)))
+
+(defun agent-shell-markdown-math--refresh-if-changed ()
+  "Run `agent-shell-markdown-math-refresh' iff the current colors changed."
+  (when (and agent-shell-markdown-render-math
+             (not (equal (agent-shell-markdown-math--current-colors)
+                         agent-shell-markdown-math--rendered-colors)))
+    (agent-shell-markdown-math-refresh)))
+
+;; Re-render on the events that change the default face's colors: a theme
+;; being enabled (Emacs 29+), a new frame opening (e.g. a graphical client
+;; attaching to a daemon after a TTY render), and macOS light/dark
+;; switches.  Each handler is gated by `agent-shell-markdown-render-math'
+;; and a colors-actually-changed check, so they're cheap no-ops otherwise.
+(add-hook 'enable-theme-functions #'agent-shell-markdown-math--maybe-refresh)
+(add-hook 'after-make-frame-functions #'agent-shell-markdown-math--maybe-refresh)
+(when (boundp 'ns-system-appearance-change-functions)
+  (add-hook 'ns-system-appearance-change-functions
+            #'agent-shell-markdown-math--maybe-refresh))
 
 (provide 'agent-shell-markdown-math)
 

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -236,11 +236,14 @@ real session.  The renderer's test harness loads this module
 without `agent-shell.el'; set this variable there (or stub
 `agent-shell--cache-dir') if a code path needs the directory.")
 
-;; key (sha1 of latex + color + scale + preamble) -> image object.  An
-;; equation is compiled at most once per key; subsequent renders (same
-;; session, or any buffer) reuse the cached image.
+;; image-cache key = content key (sha1 of latex + color + scale + preamble +
+;; inline) plus the display scale, via `--math-image-cache-key'.  Folding the
+;; scale in lets images at different font sizes coexist, so a font change just
+;; adds an entry (no cache clear) and sibling buffers' warm images survive.
+;; The underlying SVG is still compiled at most once per content key (the disk
+;; cache is font-independent); only the cheap `create-image' is per scale.
 (defvar agent-shell-markdown-math--image-cache (make-hash-table :test 'equal)
-  "In-memory map of cache key to rendered equation image.")
+  "In-memory map of image-cache key to rendered equation image.")
 
 ;; key -> list of (BUFFER START-MARKER END-MARKER) awaiting one in-flight
 ;; compile.  Dedupes concurrent compiles of the same equation and records
@@ -759,23 +762,41 @@ leaving the image at its natural size."
               (agent-shell-markdown--math-svg-px-per-pt)))
       1.0)))
 
-(defun agent-shell-markdown--math-load-svg-image (file)
+(defun agent-shell-markdown--math-load-svg-image (file &optional scale)
   "Return an SVG image created from FILE, sized to the buffer font.
-The image is scaled (see `agent-shell-markdown--math-display-scale')
+Scaled by SCALE (default `agent-shell-markdown--math-display-scale')
 so the equation's body font matches the surrounding text, and
 centred vertically for inline display."
   (create-image file 'svg nil
-                :scale (agent-shell-markdown--math-display-scale)
+                :scale (or scale (agent-shell-markdown--math-display-scale))
                 :ascent 'center))
 
+(defun agent-shell-markdown--math-image-cache-key (key scale)
+  "Return the in-memory image-cache key for content KEY at display SCALE.
+KEY names the font-independent on-disk SVG; the cached image object
+bakes in a display `:scale', so the in-memory key adds SCALE.  This
+lets images at different font sizes coexist, so a font change just
+creates a new entry — no cache clearing, and a sibling buffer's
+warm images survive."
+  (format "%s@%s" key scale))
+
 (defun agent-shell-markdown--math-cached-image (key)
-  "Return the rendered image for KEY from memory or disk, or nil.
-A disk hit is promoted into the in-memory cache."
-  (or (gethash key agent-shell-markdown-math--image-cache)
-      (let ((file (agent-shell-markdown--math-svg-file key)))
-        (when (file-exists-p file)
-          (puthash key (agent-shell-markdown--math-load-svg-image file)
-                   agent-shell-markdown-math--image-cache)))))
+  "Return the rendered image for content KEY at the current font scale.
+Checks the in-memory cache (keyed by KEY and the display scale via
+`agent-shell-markdown--math-image-cache-key', so each font size has
+its own image), else loads KEY's on-disk SVG and caches a freshly
+scaled image.  Returns nil when the SVG isn't on disk yet (its
+compile hasn't finished).  Computes the scale from the current
+buffer, so call it within the target buffer to honour a buffer-local
+text scale."
+  (let* ((scale (agent-shell-markdown--math-display-scale))
+         (image-key (agent-shell-markdown--math-image-cache-key key scale)))
+    (or (gethash image-key agent-shell-markdown-math--image-cache)
+        (let ((file (agent-shell-markdown--math-svg-file key)))
+          (when (file-exists-p file)
+            (puthash image-key
+                     (agent-shell-markdown--math-load-svg-image file scale)
+                     agent-shell-markdown-math--image-cache))))))
 
 (defun agent-shell-markdown--math-overlay-image (buffer start end image)
   "Lay IMAGE over BUFFER's START..END as a `display' property.
@@ -899,15 +920,21 @@ portable; it can slot in here without changing callers."
            (start-process-shell-command "agent-shell-markdown-math" nil command)
            (lambda (process _event)
              (when (memq (process-status process) '(exit signal))
-               (let ((image (when (and (eq (process-status process) 'exit)
-                                       (zerop (process-exit-status process))
-                                       (file-exists-p svg))
-                              (agent-shell-markdown--math-load-svg-image svg))))
-                 (when image
-                   (puthash key image agent-shell-markdown-math--image-cache)
-                   (dolist (region (gethash key agent-shell-markdown-math--pending))
-                     (agent-shell-markdown--math-overlay-image
-                      (nth 0 region) (nth 1 region) (nth 2 region) image))))
+               (when (and (eq (process-status process) 'exit)
+                          (zerop (process-exit-status process))
+                          (file-exists-p svg))
+                 ;; Overlay each queued region with an image scaled to its
+                 ;; own buffer's font (via `--math-cached-image', which now
+                 ;; keys per display scale and loads the just-written SVG).
+                 (dolist (region (gethash key agent-shell-markdown-math--pending))
+                   (let ((buffer (nth 0 region))
+                         (start (nth 1 region))
+                         (end (nth 2 region)))
+                     (when (buffer-live-p buffer)
+                       (with-current-buffer buffer
+                         (agent-shell-markdown--math-overlay-image
+                          buffer start end
+                          (agent-shell-markdown--math-cached-image key)))))))
                (remhash key agent-shell-markdown-math--pending)
                (funcall cleanup))))
         (error
@@ -946,15 +973,18 @@ default) every buffer that has rendered equations.  Call after a
 theme, appearance, or font-size change so equation images pick up
 the new colors and size.
 
-The in-memory image cache and the pixels-per-point calibration are
-dropped so images are rebuilt at the current font scale from the
-on-disk SVGs (cheap — no LaTeX recompile unless the color also
-changed); each re-rendered buffer records its new appearance via
-`agent-shell-markdown--math-render', so unchanged buffers stay
-fast and untouched buffers refresh lazily when next displayed."
+The pixels-per-point calibration is dropped so it is re-measured
+\(e.g. after a display / scaling change); images are then rebuilt at
+the current font scale from the on-disk SVGs — cheap, no LaTeX
+recompile unless the color also changed.  The in-memory image cache
+is keyed per display scale (see
+`agent-shell-markdown--math-image-cache-key'), so a new size just
+adds entries and a sibling buffer's warm images survive — no clear
+needed.  Each re-rendered buffer records its new appearance via
+`agent-shell-markdown--math-render', so unchanged buffers stay fast
+and untouched buffers refresh lazily when next displayed."
   (interactive)
   (setq agent-shell-markdown-math--svg-px-per-pt nil)
-  (clrhash agent-shell-markdown-math--image-cache)
   (dolist (buf (if buffer
                    (list buffer)
                  (seq-filter

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -40,9 +40,13 @@
 ;; `agent-shell-markdown-replace-markup'; the other functions support
 ;; it and the renderer's avoid-range / watermark bookkeeping.
 ;;
-;; Image rendering is currently a PLACEHOLDER (it boxes the raw LaTeX);
-;; `agent-shell-markdown--latex-to-image' is the seam for real LaTeX
-;; compilation.
+;; Equations are typeset by compiling a standalone LaTeX document to DVI
+;; (`latex') and converting it to SVG (`dvisvgm') — the same toolchain
+;; org-latex-preview uses.  Compilation is asynchronous and the SVG is
+;; cached on disk by content (so each unique equation compiles at most
+;; once); the image is overlaid when ready.  When the toolchain is
+;; absent or `agent-shell-markdown-math-use-placeholder' is set, a
+;; placeholder panel boxing the raw LaTeX is shown instead.
 
 ;;; Code:
 
@@ -89,6 +93,52 @@ Defaults to `bracket' only: `\\[...\\]' is unambiguous, whereas
 $$$\".  Opt into `$$...$$' with:
 
   (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
+
+(defvar agent-shell-markdown-math-use-placeholder nil
+  "When non-nil, draw the placeholder panel instead of typesetting LaTeX.
+Also used as the automatic fallback when the LaTeX toolchain
+\(`agent-shell-markdown-math-latex-program' /
+`agent-shell-markdown-math-dvisvgm-program') is unavailable.")
+
+(defvar agent-shell-markdown-math-latex-program "latex"
+  "Program that compiles a LaTeX document to DVI.")
+
+(defvar agent-shell-markdown-math-dvisvgm-program "dvisvgm"
+  "Program that converts DVI to SVG.")
+
+(defvar agent-shell-markdown-math-scale 1.4
+  "`dvisvgm' output scale for rendered equations.
+Larger values produce bigger images.")
+
+(defvar agent-shell-markdown-math-preamble
+  "\\documentclass[border=2pt]{standalone}
+\\usepackage{amsmath}
+\\usepackage{amssymb}
+\\usepackage{xcolor}"
+  "LaTeX preamble (everything before `\\begin{document}') for equations.
+The `standalone' class crops the page tightly to the equation, so
+no `preview' package is required.  `xcolor' is used to tint the
+equation to match the buffer foreground.  Equations are typeset as
+`\\displaystyle' inline math inside the document body.")
+
+(defvar agent-shell-markdown-math-cache-directory nil
+  "Directory for cached equation SVGs and scratch compiles.
+When nil, a subdirectory of the variable `temporary-file-directory'
+is used.  Point this at a persistent location to keep the cache
+across sessions (each unique equation then compiles at most once
+ever).")
+
+;; key (sha1 of latex + color + scale + preamble) -> image object.  An
+;; equation is compiled at most once per key; subsequent renders (same
+;; session, or any buffer) reuse the cached image.
+(defvar agent-shell-markdown-math--image-cache (make-hash-table :test 'equal)
+  "In-memory map of cache key to rendered equation image.")
+
+;; key -> list of (BUFFER START-MARKER END-MARKER) awaiting one in-flight
+;; compile.  Dedupes concurrent compiles of the same equation and records
+;; every region to overlay once the SVG is ready.
+(defvar agent-shell-markdown-math--pending (make-hash-table :test 'equal)
+  "In-memory map of cache key to regions awaiting an in-flight compile.")
 
 (defun agent-shell-markdown--math-blocks (&optional avoid-ranges)
   "Return display-math blocks in the current buffer.
@@ -202,22 +252,18 @@ Recognizes the delimiter styles in
 `agent-shell-markdown-math-delimiters' (`$$...$$' and/or
 `\\[...\\]').  For each complete block with a non-empty body, the
 raw delimited text is left in the buffer (so copy / save
-round-trips the LaTeX source) and, on a graphical display, an
-image of the equation is layered over it via a `display' text
-property.  The whole region is faced with
+round-trips the LaTeX source) and the region is faced with
 `agent-shell-markdown-math' and tagged
 `agent-shell-markdown-frozen' so later passes and subsequent
-streaming calls leave it alone.  Blocks inside any of AVOID-RANGES
-\(typically fenced code) are left untouched, as is an empty block.
+streaming calls leave it alone.  The equation image is then
+applied by `agent-shell-markdown--math-render' (immediately when
+cached, otherwise once an async compile finishes).  Blocks inside
+any of AVOID-RANGES (typically fenced code) are left untouched, as
+is an empty block.
 
 Adds only text properties (no insert / delete), so the block
 positions returned by `agent-shell-markdown--math-blocks' stay
 valid while iterating.
-
-Image rendering is currently a PLACEHOLDER: it boxes the raw
-LaTeX rather than typesetting it.  Real compilation is meant to
-slot into `agent-shell-markdown--latex-to-image' without touching
-this pass.
 
 For example, with the buffer:
 
@@ -237,23 +283,14 @@ place, faced `agent-shell-markdown-math' and frozen."
                          (+ start (plist-get block :open))
                          (- end close))))
                 ((not (string-empty-p latex))))
-      (let ((image (agent-shell-markdown--latex-to-image latex))
-            (line-prefix (get-text-property start 'line-prefix))
-            (wrap-prefix (get-text-property start 'wrap-prefix)))
-        (add-face-text-property start end 'agent-shell-markdown-math)
-        (when image
-          (put-text-property start end 'display image)
-          (put-text-property start end 'mouse-face 'highlight)
-          (when line-prefix
-            (put-text-property start end 'line-prefix line-prefix))
-          (when wrap-prefix
-            (put-text-property start end 'wrap-prefix wrap-prefix)))
-        (add-text-properties
-         start end
-         `(help-echo ,latex
-           agent-shell-markdown-math-source ,latex
-           agent-shell-markdown-frozen t
-           rear-nonsticky (agent-shell-markdown-frozen)))))))
+      (add-face-text-property start end 'agent-shell-markdown-math)
+      (add-text-properties
+       start end
+       `(help-echo ,latex
+         agent-shell-markdown-math-source ,latex
+         agent-shell-markdown-frozen t
+         rear-nonsticky (agent-shell-markdown-frozen)))
+      (agent-shell-markdown--math-render (current-buffer) start end latex))))
 
 (defun agent-shell-markdown--svg-color (face attribute fallback)
   "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
@@ -275,17 +312,17 @@ For example:
         (apply #'color-rgb-to-hex (append rgb '(2)))
       fallback)))
 
-(defun agent-shell-markdown--latex-to-image (latex)
-  "Return a PLACEHOLDER SVG image for LATEX, or nil.
+(defun agent-shell-markdown--latex-placeholder-image (latex)
+  "Return a placeholder SVG image boxing the raw LATEX, or nil.
 
-This does NOT typeset LATEX.  It draws the raw source inside a
-bordered panel so the interception / overlay pipeline can be
-exercised ahead of real LaTeX compilation (which is meant to
-replace this function's body).  Returns nil when no graphical
+This does NOT typeset LATEX — it draws the source inside a
+bordered panel.  Used when `agent-shell-markdown-math-use-placeholder'
+is set or the LaTeX toolchain is unavailable, so math still has a
+visible (if un-typeset) rendering.  Returns nil when no graphical
 display is available, so callers fall back to the raw text.
 
-LATEX is the equation source with the surrounding `$$'
-delimiters already stripped, e.g. \"E=mc^2\"."
+LATEX is the equation source with the surrounding delimiters
+already stripped, e.g. \"E=mc^2\"."
   (when (display-graphic-p)
     (let* ((lines (split-string latex "\n"))
            ;; `frame-char-width' / `-height' give per-char pixel
@@ -327,6 +364,171 @@ delimiters already stripped, e.g. \"E=mc^2\"."
                    :fill fg))
        lines)
       (svg-image svg :scale 1.0 :ascent 'center))))
+
+(defun agent-shell-markdown--math-tools-available-p ()
+  "Return non-nil when the LaTeX-to-SVG toolchain is on the variable `exec-path'."
+  (and (executable-find agent-shell-markdown-math-latex-program)
+       (executable-find agent-shell-markdown-math-dvisvgm-program)))
+
+(defun agent-shell-markdown--math-cache-dir ()
+  "Return the equation cache directory, creating it if needed.
+Honours `agent-shell-markdown-math-cache-directory', else a
+subdirectory of the variable `temporary-file-directory'."
+  (let ((dir (or agent-shell-markdown-math-cache-directory
+                 (expand-file-name "agent-shell-markdown-math"
+                                   temporary-file-directory))))
+    (unless (file-directory-p dir)
+      (make-directory dir t))
+    dir))
+
+(defun agent-shell-markdown--math-cache-key (latex color scale)
+  "Return a stable cache key for LATEX rendered in COLOR at SCALE.
+The preamble is folded in so changing it invalidates the cache."
+  (secure-hash 'sha1 (format "%s\0%s\0%s\0%s"
+                             latex color scale
+                             agent-shell-markdown-math-preamble)))
+
+(defun agent-shell-markdown--math-svg-file (key)
+  "Return the cache SVG path for KEY."
+  (expand-file-name (concat key ".svg")
+                    (agent-shell-markdown--math-cache-dir)))
+
+(defun agent-shell-markdown--math-load-svg-image (file)
+  "Return an SVG image created from FILE, centred for inline display."
+  (create-image file 'svg nil :scale 1.0 :ascent 'center))
+
+(defun agent-shell-markdown--math-cached-image (key)
+  "Return the rendered image for KEY from memory or disk, or nil.
+A disk hit is promoted into the in-memory cache."
+  (or (gethash key agent-shell-markdown-math--image-cache)
+      (let ((file (agent-shell-markdown--math-svg-file key)))
+        (when (file-exists-p file)
+          (puthash key (agent-shell-markdown--math-load-svg-image file)
+                   agent-shell-markdown-math--image-cache)))))
+
+(defun agent-shell-markdown--math-overlay-image (buffer start end image)
+  "Lay IMAGE over BUFFER's START..END as a `display' property.
+
+START / END may be markers (async case) or integers (sync case).
+No-ops when BUFFER is dead or the region is no longer valid (it
+was edited or killed away).  Runs with `with-silent-modifications'
+so an async overlay doesn't flag the buffer modified, and carries
+the region's existing `line-prefix' / `wrap-prefix' so indentation
+is preserved."
+  (when (and image (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (let ((s (if (markerp start) (marker-position start) start))
+            (e (if (markerp end) (marker-position end) end)))
+        (when (and s e (<= (point-min) s) (< s e) (<= e (point-max)))
+          (with-silent-modifications
+            (let ((line-prefix (get-text-property s 'line-prefix))
+                  (wrap-prefix (get-text-property s 'wrap-prefix)))
+              (put-text-property s e 'display image)
+              (put-text-property s e 'mouse-face 'highlight)
+              (when line-prefix
+                (put-text-property s e 'line-prefix line-prefix))
+              (when wrap-prefix
+                (put-text-property s e 'wrap-prefix wrap-prefix)))))))))
+
+(defun agent-shell-markdown--math-render (buffer start end latex)
+  "Render LATEX over BUFFER's START..END as an equation image.
+
+On a non-graphical display, does nothing (the raw faced text
+stands in).  With `agent-shell-markdown-math-use-placeholder' set
+or no LaTeX toolchain, overlays the placeholder panel.  Otherwise
+overlays the cached SVG immediately when available, else schedules
+an async compile (see `agent-shell-markdown--math-compile') that
+overlays the result once ready — START / END are captured as
+markers so the overlay lands even after more output streams in."
+  (when (display-graphic-p)
+    (cond
+     ((or agent-shell-markdown-math-use-placeholder
+          (not (agent-shell-markdown--math-tools-available-p)))
+      (agent-shell-markdown--math-overlay-image
+       buffer start end
+       (agent-shell-markdown--latex-placeholder-image latex)))
+     (t
+      (let* ((color (agent-shell-markdown--svg-color 'default :foreground "#000000"))
+             (scale agent-shell-markdown-math-scale)
+             (key (agent-shell-markdown--math-cache-key latex color scale))
+             (image (agent-shell-markdown--math-cached-image key)))
+        (if image
+            (agent-shell-markdown--math-overlay-image buffer start end image)
+          (agent-shell-markdown--math-schedule
+           key latex color scale buffer
+           (copy-marker start) (copy-marker end))))))))
+
+(defun agent-shell-markdown--math-schedule (key latex color scale
+                                                buffer start end)
+  "Queue BUFFER's START..END for KEY and start a compile if none is running.
+
+KEY identifies the equation; LATEX, COLOR, and SCALE are forwarded
+to `agent-shell-markdown--math-compile' for the render.  Multiple
+regions sharing KEY (the same equation rendered more than once)
+are coalesced onto a single in-flight compile; all are overlaid
+when it finishes."
+  (let ((pending (gethash key agent-shell-markdown-math--pending)))
+    (puthash key (cons (list buffer start end) pending)
+             agent-shell-markdown-math--pending)
+    (unless pending
+      (agent-shell-markdown--math-compile key latex color scale))))
+
+(defun agent-shell-markdown--math-compile (key latex color scale)
+  "Asynchronously compile LATEX (in COLOR, at SCALE) to the cache SVG for KEY.
+
+Writes a standalone LaTeX document, runs
+`agent-shell-markdown-math-latex-program' then
+`agent-shell-markdown-math-dvisvgm-program' in a scratch
+directory, and on success caches the SVG and overlays it onto
+every region queued for KEY (see
+`agent-shell-markdown--math-schedule').  On failure the queued
+regions keep their raw faced text.  The scratch directory is
+removed when the process exits.
+
+Future optimization: a precompiled-preamble `.fmt' (mylatexformat)
+would cut per-equation latency, but plain compilation keeps this
+portable; it can slot in here without changing callers."
+  (let* ((dir (make-temp-file "agent-shell-markdown-math" t))
+         (tex (expand-file-name "equation.tex" dir))
+         (dvi (expand-file-name "equation.dvi" dir))
+         (svg (agent-shell-markdown--math-svg-file key))
+         (cleanup (lambda () (ignore-errors (delete-directory dir t)))))
+    (with-temp-file tex
+      (insert agent-shell-markdown-math-preamble "\n"
+              "\\begin{document}\n"
+              (format "{\\color[HTML]{%s}$\\displaystyle %s$}\n"
+                      (upcase (substring color 1)) latex)
+              "\\end{document}\n"))
+    (let ((command
+           (format "cd %s && %s -interaction=nonstopmode -halt-on-error %s && %s --no-fonts --exact-bbox --scale=%s -o %s %s"
+                   (shell-quote-argument dir)
+                   (shell-quote-argument agent-shell-markdown-math-latex-program)
+                   (shell-quote-argument tex)
+                   (shell-quote-argument agent-shell-markdown-math-dvisvgm-program)
+                   scale
+                   (shell-quote-argument svg)
+                   (shell-quote-argument dvi))))
+      (condition-case err
+          (set-process-sentinel
+           (start-process-shell-command "agent-shell-markdown-math" nil command)
+           (lambda (process _event)
+             (when (memq (process-status process) '(exit signal))
+               (let ((image (when (and (eq (process-status process) 'exit)
+                                       (zerop (process-exit-status process))
+                                       (file-exists-p svg))
+                              (agent-shell-markdown--math-load-svg-image svg))))
+                 (when image
+                   (puthash key image agent-shell-markdown-math--image-cache)
+                   (dolist (region (gethash key agent-shell-markdown-math--pending))
+                     (agent-shell-markdown--math-overlay-image
+                      (nth 0 region) (nth 1 region) (nth 2 region) image))))
+               (remhash key agent-shell-markdown-math--pending)
+               (funcall cleanup))))
+        (error
+         ;; Couldn't even spawn the process — drop the queue and clean up.
+         (remhash key agent-shell-markdown-math--pending)
+         (funcall cleanup)
+         (signal (car err) (cdr err)))))))
 
 (provide 'agent-shell-markdown-math)
 

--- a/agent-shell-markdown-math.el
+++ b/agent-shell-markdown-math.el
@@ -1,0 +1,333 @@
+;;; agent-shell-markdown-math.el --- Display-math rendering for agent-shell -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Alvaro Ramirez
+
+;; Author: Alvaro Ramirez https://xenodium.com
+;; URL: https://github.com/xenodium/agent-shell
+
+;; This package is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This package is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Display-math support for `agent-shell-markdown': intercept LaTeX
+;; display equations in agent output and overlay them with an image.
+;;
+;; Two delimiter styles are recognized, toggled independently via
+;; `agent-shell-markdown-math-delimiters':
+;;
+;;   bracket  `\[X\]'    (default; unambiguous)
+;;   dollar   `$$X$$'    (opt-in; can clash with prose / currency)
+;;
+;; The raw LaTeX is kept in the buffer (so copy / save round-trips the
+;; source) and, on a graphical display, an equation image is layered on
+;; top with a `display' text property.  A blank line can't appear inside
+;; LaTeX display math, so a candidate block whose body would span one is
+;; rejected — this bounds detection and stops a stray delimiter from
+;; swallowing the rest of a streaming response.
+;;
+;; `agent-shell-markdown--style-math-blocks' is run as a pass by
+;; `agent-shell-markdown-replace-markup'; the other functions support
+;; it and the renderer's avoid-range / watermark bookkeeping.
+;;
+;; Image rendering is currently a PLACEHOLDER (it boxes the raw LaTeX);
+;; `agent-shell-markdown--latex-to-image' is the seam for real LaTeX
+;; compilation.
+
+;;; Code:
+
+(eval-when-compile
+  (require 'cl-lib))
+(require 'color)
+(require 'map)
+(require 'org-faces)
+(require 'seq)
+(require 'svg)
+
+(declare-function agent-shell-markdown--in-avoid-range-p "agent-shell-markdown")
+
+(defface agent-shell-markdown-math
+  '((t :inherit font-lock-constant-face))
+  "Face applied to rendered display-math source.
+On a graphical display the source is hidden behind an equation
+image; this face is the fallback styling for the raw LaTeX shown
+on a non-graphical display."
+  :group 'agent-shell-markdown)
+
+(defconst agent-shell-markdown--math-delimiters
+  '((dollar . ("$$" . "$$"))
+    (bracket . ("\\[" . "\\]")))
+  "Map of display-math delimiter styles to their (OPEN . CLOSE) tokens.
+`dollar' is `$$...$$'; `bracket' is `\\[...\\]'.  The keys of this
+map are the values accepted in `agent-shell-markdown-math-delimiters'.")
+
+(defvar agent-shell-markdown-math-delimiters '(bracket)
+  "Display-math delimiter styles recognized when rendering markdown.
+
+A list whose members are keys of
+`agent-shell-markdown--math-delimiters':
+
+  `bracket'  recognize `\\[...\\]'
+  `dollar'   recognize `$$...$$'
+
+The two are independent — add or drop one to toggle it.  An empty
+list disables math rendering entirely (as does passing
+`:render-math nil' to `agent-shell-markdown-replace-markup').
+
+Defaults to `bracket' only: `\\[...\\]' is unambiguous, whereas
+`dollar' can false-positive on prose or currency like \"it cost
+$$$\".  Opt into `$$...$$' with:
+
+  (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
+
+(defun agent-shell-markdown--math-blocks (&optional avoid-ranges)
+  "Return display-math blocks in the current buffer.
+
+Each element is a plist (:start S :end E :open O :close C): S..E
+spans the whole delimited block (delimiters included), and O / C
+are the opening / closing delimiter token lengths, so the LaTeX
+body is the buffer text in [S+O, E-C).
+
+Only the delimiter styles listed in
+`agent-shell-markdown-math-delimiters' are recognized (`$$...$$'
+and/or `\\[...\\]').
+
+Scanning resolves each opener immediately: from just after an
+opener we look for the first of its matching closer or a blank
+line (a paragraph break, which LaTeX display math can't contain).
+
+  - Closer first: a valid block, recorded; scanning resumes after
+    the closer.
+  - Blank line first: the opener is a false positive, so scanning
+    resumes just after the OPENER (not past the blank line), so
+    real blocks sitting between a stray opener and the blank line
+    are still found.
+  - Neither yet (end of buffer): a still-streaming block extending
+    to `point-max' with :close 0, so a genuine equation stays
+    protected as the buffer grows — mirrors
+    `agent-shell-markdown--source-block-ranges'.
+
+A delimiter inside any of AVOID-RANGES (a sorted vector, typically
+fenced code) is ignored — both openers and closers — so blocks
+never overlap AVOID-RANGES.  Because openers are resolved one at a
+time and bodies never cross a blank line, returned blocks never
+overlap each other.
+
+For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
+returns ((:start 1 :end 11 :open 2 :close 2))."
+  (let* ((specs (seq-keep (lambda (style)
+                            (map-elt agent-shell-markdown--math-delimiters style))
+                          agent-shell-markdown-math-delimiters))
+         (blocks '())
+         (case-fold-search nil))
+    (when specs
+      (save-excursion
+        (goto-char (point-min))
+        (let ((open-re (regexp-opt (mapcar #'car specs))))
+          (while (re-search-forward open-re nil t)
+            (let* ((open-token (match-string-no-properties 0))
+                   (open-start (match-beginning 0))
+                   (open-end (point))
+                   (avoid (agent-shell-markdown--in-avoid-range-p
+                           open-start open-end avoid-ranges)))
+              (if avoid
+                  (goto-char (cdr avoid))
+                (let* ((close-token (cdr (seq-find
+                                          (lambda (spec)
+                                            (string= open-token (car spec)))
+                                          specs)))
+                       ;; First closer or blank line at or after the body.
+                       ;; A closer inside an avoid-range isn't real — skip
+                       ;; past that range and keep looking.
+                       (hit (save-excursion
+                              (goto-char open-end)
+                              (let ((re (concat (regexp-quote close-token)
+                                                "\\|\n[ \t]*\n"))
+                                    (result nil))
+                                (while (and (not result)
+                                            (re-search-forward re nil t))
+                                  (if-let* ((av (agent-shell-markdown--in-avoid-range-p
+                                                 (match-beginning 0) (point)
+                                                 avoid-ranges)))
+                                      (goto-char (cdr av))
+                                    (setq result
+                                          (cons (match-string-no-properties 0)
+                                                (point)))))
+                                result))))
+                  (cond
+                   ;; Matching closer reached with no blank line before it.
+                   ((and hit (string= (car hit) close-token))
+                    (push (list :start open-start :end (cdr hit)
+                                :open (length open-token)
+                                :close (length close-token))
+                          blocks)
+                    (goto-char (cdr hit)))
+                   ;; Blank line first: false-positive opener.  Resume
+                   ;; right after the opener so inner real blocks are seen.
+                   (hit (goto-char open-end))
+                   ;; Neither yet: still-streaming open block.
+                   (t (push (list :start open-start :end (point-max)
+                                  :open (length open-token) :close 0)
+                            blocks)
+                      (goto-char (point-max)))))))))))
+    (nreverse blocks)))
+
+(defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
+  "Return list of (start . end) ranges covering display-math blocks.
+
+Thin adapter over `agent-shell-markdown--math-blocks' for callers
+that only need the protected spans (avoid-ranges, watermark
+back-off).  AVOID-RANGES is forwarded.
+
+For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
+returns ((1 . 11))."
+  (mapcar (lambda (block)
+            (cons (plist-get block :start) (plist-get block :end)))
+          (agent-shell-markdown--math-blocks avoid-ranges)))
+
+(cl-defun agent-shell-markdown--style-math-blocks (&key avoid-ranges)
+  "Overlay display-math blocks with an equation image.
+
+Recognizes the delimiter styles in
+`agent-shell-markdown-math-delimiters' (`$$...$$' and/or
+`\\[...\\]').  For each complete block with a non-empty body, the
+raw delimited text is left in the buffer (so copy / save
+round-trips the LaTeX source) and, on a graphical display, an
+image of the equation is layered over it via a `display' text
+property.  The whole region is faced with
+`agent-shell-markdown-math' and tagged
+`agent-shell-markdown-frozen' so later passes and subsequent
+streaming calls leave it alone.  Blocks inside any of AVOID-RANGES
+\(typically fenced code) are left untouched, as is an empty block.
+
+Adds only text properties (no insert / delete), so the block
+positions returned by `agent-shell-markdown--math-blocks' stay
+valid while iterating.
+
+Image rendering is currently a PLACEHOLDER: it boxes the raw
+LaTeX rather than typesetting it.  Real compilation is meant to
+slot into `agent-shell-markdown--latex-to-image' without touching
+this pass.
+
+For example, with the buffer:
+
+  \\[E=mc^2\\]
+
+the `\\[E=mc^2\\]' text is kept but shows an equation image in its
+place, faced `agent-shell-markdown-math' and frozen."
+  (dolist (block (agent-shell-markdown--math-blocks avoid-ranges))
+    ;; A still-open block (no closing delimiter yet) reports :close 0
+    ;; and runs to `point-max'; leave it raw until the closer streams in.
+    (when-let* ((close (plist-get block :close))
+                ((> close 0))
+                (start (plist-get block :start))
+                (end (plist-get block :end))
+                (latex (string-trim
+                        (buffer-substring-no-properties
+                         (+ start (plist-get block :open))
+                         (- end close))))
+                ((not (string-empty-p latex))))
+      (let ((image (agent-shell-markdown--latex-to-image latex))
+            (line-prefix (get-text-property start 'line-prefix))
+            (wrap-prefix (get-text-property start 'wrap-prefix)))
+        (add-face-text-property start end 'agent-shell-markdown-math)
+        (when image
+          (put-text-property start end 'display image)
+          (put-text-property start end 'mouse-face 'highlight)
+          (when line-prefix
+            (put-text-property start end 'line-prefix line-prefix))
+          (when wrap-prefix
+            (put-text-property start end 'wrap-prefix wrap-prefix)))
+        (add-text-properties
+         start end
+         `(help-echo ,latex
+           agent-shell-markdown-math-source ,latex
+           agent-shell-markdown-frozen t
+           rear-nonsticky (agent-shell-markdown-frozen)))))))
+
+(defun agent-shell-markdown--svg-color (face attribute fallback)
+  "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
+
+ATTRIBUTE is `:foreground' or `:background'.  FALLBACK is returned
+when the attribute is unspecified or can't be resolved to RGB
+\(e.g. on a terminal that reports symbolic colors).
+
+For example:
+
+  (agent-shell-markdown--svg-color \\='default :foreground \"#000000\")
+  => \"#ffffff\"  ; on a dark theme"
+  (let ((color (face-attribute face attribute nil 'default)))
+    ;; `color-name-to-rgb' both returns nil for unknown names and
+    ;; signals (e.g. on the "unspecified-fg" sentinel, or off a window
+    ;; system) — guard both so we always fall back cleanly.
+    (if-let* (((stringp color))
+              (rgb (ignore-errors (color-name-to-rgb color))))
+        (apply #'color-rgb-to-hex (append rgb '(2)))
+      fallback)))
+
+(defun agent-shell-markdown--latex-to-image (latex)
+  "Return a PLACEHOLDER SVG image for LATEX, or nil.
+
+This does NOT typeset LATEX.  It draws the raw source inside a
+bordered panel so the interception / overlay pipeline can be
+exercised ahead of real LaTeX compilation (which is meant to
+replace this function's body).  Returns nil when no graphical
+display is available, so callers fall back to the raw text.
+
+LATEX is the equation source with the surrounding `$$'
+delimiters already stripped, e.g. \"E=mc^2\"."
+  (when (display-graphic-p)
+    (let* ((lines (split-string latex "\n"))
+           ;; `frame-char-width' / `-height' give per-char pixel
+           ;; dimensions on a graphical frame and stay robust off it
+           ;; (unlike `default-font-width', which calls `font-info' and
+           ;; errors with no live font).  Good enough for placeholder
+           ;; sizing; real typesetting will set its own dimensions.
+           (char-w (frame-char-width))
+           (char-h (frame-char-height))
+           (pad char-h)
+           (badge-h char-h)
+           (text-w (* char-w (apply #'max 1 (mapcar #'length lines))))
+           (width (+ text-w (* 2 pad)))
+           (height (+ badge-h (* char-h (length lines)) (* 2 pad)))
+           (fg (agent-shell-markdown--svg-color 'default :foreground "#000000"))
+           (border (agent-shell-markdown--svg-color
+                    'font-lock-comment-face :foreground "#888888"))
+           (panel (agent-shell-markdown--svg-color
+                   'org-block :background "#f4f4f4"))
+           (svg (svg-create width height)))
+      (svg-rectangle svg 0 0 width height
+                     :rx (/ char-h 2)
+                     :fill panel
+                     :stroke border
+                     :stroke-width 1)
+      (svg-text svg "tex"
+                :x pad
+                :y (* badge-h 0.85)
+                :font-size (* badge-h 0.7)
+                :font-style "italic"
+                :fill border)
+      (seq-do-indexed
+       (lambda (line i)
+         (svg-text svg (if (string-empty-p line) " " line)
+                   :x pad
+                   :y (+ badge-h pad (* char-h (1+ i)) (- (/ char-h 4)))
+                   :font-family "monospace"
+                   :font-size char-h
+                   :fill fg))
+       lines)
+      (svg-image svg :scale 1.0 :ascent 'center))))
+
+(provide 'agent-shell-markdown-math)
+
+;;; agent-shell-markdown-math.el ends here

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -218,7 +218,7 @@ For example:
 
 (cl-defun agent-shell-markdown-replace-markup (&key force
                                                     (render-images t)
-                                                    (render-math t)
+                                                    (render-math agent-shell-markdown-render-math)
                                                     (highlight-blocks t)
                                                     image-cache-directory)
   "Replace Markdown markup in current buffer with propertized text.
@@ -254,12 +254,17 @@ markup with displayed images where the URL resolves to an image
 file; nil leaves the markup as-is.  IMAGE-CACHE-DIRECTORY is where
 remote (http) image URLs are downloaded and cached; when nil
 \(the default), remote images are not fetched and their markup is
-left as text.  RENDER-MATH, when non-nil (the
-default), overlays display-math blocks (`$$...$$' and / or
-`\\[...\\]', per `agent-shell-markdown-math-delimiters') with an
-equation image (compiled via latex / dvisvgm; see
-`agent-shell-markdown--style-math-blocks'); nil leaves the LaTeX
-source raw.  HIGHLIGHT-BLOCKS, when non-nil
+left as text.  RENDER-MATH (default
+`agent-shell-markdown-render-math', itself nil), when non-nil,
+overlays display math with an equation image compiled via latex /
+dvisvgm: the `\\[...\\]' / `$$...$$' delimiter styles in
+`agent-shell-markdown-math-delimiters' (see
+`agent-shell-markdown--style-math-blocks') and the
+`agent-shell-markdown-math-fence-languages' fenced blocks
+\(```math / ```latex, handled in
+`agent-shell-markdown--style-source-blocks').  Nil leaves the
+LaTeX source raw and such fences as ordinary code blocks.
+HIGHLIGHT-BLOCKS, when non-nil
 (the default), runs the fenced-block body through the language's
 major-mode font-lock to colour keywords / strings / etc.; nil
 strips the fences and inserts the action label but leaves the
@@ -313,8 +318,13 @@ body un-fontified."
              :avoid-ranges avoid-ranges))
           (agent-shell-markdown--style-dividers :avoid-ranges avoid-ranges)
           (agent-shell-markdown--style-blockquotes :avoid-ranges avoid-ranges)
+          ;; RENDER-MATH lets the source-block pass divert a
+          ;; `math'/`latex'/`tex' fence to the equation renderer instead
+          ;; of styling it as code (those fences are how several agents
+          ;; emit display math).
           (agent-shell-markdown--style-source-blocks
-           :highlight-blocks highlight-blocks)
+           :highlight-blocks highlight-blocks
+           :render-math render-math)
           ;; Math runs after source blocks (so a `$$' inside fenced code
           ;; stays literal) and before tables (so a frozen equation
           ;; isn't mis-parsed as table rows).  SOURCE-RANGES protects
@@ -814,8 +824,15 @@ characters when no usable window is available (e.g. batch)."
   (or (ignore-errors (window-body-width))
       80))
 
-(cl-defun agent-shell-markdown--style-source-blocks (&key (highlight-blocks t))
+(cl-defun agent-shell-markdown--style-source-blocks (&key (highlight-blocks t)
+                                                          render-math)
   "Strip fenced code block markup and syntax-highlight the body.
+
+When RENDER-MATH is non-nil, a fence whose language is a member of
+`agent-shell-markdown-math-fence-languages' (e.g. ```math) is not
+styled as code: its fences are stripped and the body is handed to
+`agent-shell-markdown--apply-math-region', so it renders as a
+display equation instead.
 
 For each complete `\\`\\`\\`LANG' / `\\`\\`\\`' fenced block,
 the opening and closing fence lines are deleted from the buffer.
@@ -873,7 +890,9 @@ with `emacs-lisp-mode' face properties on the body and a
              (body-end (copy-marker (match-end 4)))
              (close-start (match-beginning 5))
              (close-end (match-end 5))
-             (highlighted (when highlight-blocks
+             (math (and render-math
+                        (agent-shell-markdown--math-fence-language-p lang)))
+             (highlighted (when (and highlight-blocks (not math))
                             (agent-shell-markdown--highlight-code
                              (buffer-substring-no-properties body-start body-end)
                              lang))))
@@ -881,7 +900,23 @@ with `emacs-lisp-mode' face properties on the body and a
         ;; valid; body markers adjust automatically.
         (delete-region close-start close-end)
         (delete-region open-start open-end)
-        ;; Seed the bg panel on body chars first, then layer language
+        (if math
+            ;; A `math' / `latex' / `tex' fence: render the body as a
+            ;; display equation instead of a code panel.  Fences are
+            ;; stripped (like code blocks) so the block isn't re-detected
+            ;; as a fence on later streaming calls; the LaTeX body stays
+            ;; in place as the underlying text.
+            (let ((latex (string-trim
+                          (buffer-substring-no-properties
+                           (marker-position body-start)
+                           (marker-position body-end)))))
+              (unless (string-empty-p latex)
+                (agent-shell-markdown--apply-math-region
+                 (current-buffer)
+                 (marker-position body-start) (marker-position body-end)
+                 latex))
+              (goto-char (marker-position body-end)))
+          ;; Seed the bg panel on body chars first, then layer language
         ;; font-lock faces on top — the foreground colors take priority
         ;; per glyph while the `:extend t' background fills the gaps
         ;; and reaches the right edge of the window.  Include the
@@ -1009,7 +1044,7 @@ with `emacs-lisp-mode' face properties on the body and a
             ;; Move point past the body so the outer `re-search-forward'
             ;; loop doesn't backtrack into body content (e.g. shorter
             ;; inner fences inside a wider outer fence).
-            (goto-char (marker-position body-end))))))))
+            (goto-char (marker-position body-end)))))))))
 
 (defconst agent-shell-markdown--table-line-regexp
   (rx line-start

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -256,10 +256,12 @@ remote (http) image URLs are downloaded and cached; when nil
 \(the default), remote images are not fetched and their markup is
 left as text.  RENDER-MATH (default
 `agent-shell-markdown-render-math', itself nil), when non-nil,
-overlays display math with an equation image compiled via latex /
-dvisvgm: the `\\[...\\]' / `$$...$$' delimiter styles in
-`agent-shell-markdown-math-delimiters' (see
-`agent-shell-markdown--style-math-blocks') and the
+overlays math with an equation image compiled via latex /
+dvisvgm: the block-level `\\[...\\]' / `$$...$$' delimiter styles
+in `agent-shell-markdown-math-delimiters' (see
+`agent-shell-markdown--style-math-blocks'), inline `\\(...\\)'
+spans (when `agent-shell-markdown-math-render-inline' is on, see
+`agent-shell-markdown--style-inline-math'), and the
 `agent-shell-markdown-math-fence-languages' fenced blocks
 \(```math / ```latex, handled in
 `agent-shell-markdown--style-source-blocks').  Nil leaves the
@@ -290,14 +292,27 @@ body un-fontified."
                               (agent-shell-markdown--make-markers
                                (agent-shell-markdown--math-block-ranges
                                 source-ranges))))
-               (protect-ranges (agent-shell-markdown--sort-ranges
-                                source-ranges math-ranges))
                (rendered-ranges (agent-shell-markdown--make-markers
                                  (agent-shell-markdown--frozen-ranges)))
                (inline-ranges (agent-shell-markdown--make-markers
                                (agent-shell-markdown--inline-code-ranges
                                 :avoid-ranges (agent-shell-markdown--sort-ranges
-                                               protect-ranges rendered-ranges))))
+                                               source-ranges math-ranges
+                                               rendered-ranges))))
+               ;; Inline math (`\\(...\\)'), detected after inline code so
+               ;; it avoids (and never nests inside) a code span — a
+               ;; backticked `\\(x\\)' stays literal.  Protected like
+               ;; display math so the inline emphasis passes don't mangle
+               ;; the LaTeX interior.  Skipped unless RENDER-MATH and
+               ;; `agent-shell-markdown-math-render-inline' are both on.
+               (inline-math-ranges
+                (when (and render-math agent-shell-markdown-math-render-inline)
+                  (agent-shell-markdown--make-markers
+                   (agent-shell-markdown--math-inline-ranges
+                    (agent-shell-markdown--sort-ranges
+                     source-ranges math-ranges inline-ranges rendered-ranges)))))
+               (protect-ranges (agent-shell-markdown--sort-ranges
+                                source-ranges math-ranges inline-math-ranges))
                (avoid-ranges (agent-shell-markdown--sort-ranges
                               protect-ranges rendered-ranges inline-ranges)))
           (while (let ((italic-changed (agent-shell-markdown--replace-italics
@@ -331,7 +346,15 @@ body un-fontified."
           ;; the still-open-fence case the same way the other passes do.
           (when render-math
             (agent-shell-markdown--style-math-blocks
-             :avoid-ranges source-ranges))
+             :avoid-ranges source-ranges)
+            ;; Inline `\\(...\\)' spans, faced and overlaid in text style.
+            ;; Avoids code (source / inline) and display math so a `\\('
+            ;; inside any of them stays literal and ranges stay disjoint.
+            (when agent-shell-markdown-math-render-inline
+              (agent-shell-markdown--style-inline-math
+               :avoid-ranges (agent-shell-markdown--sort-ranges
+                              source-ranges math-ranges inline-ranges
+                              rendered-ranges))))
           ;; Tables run last so cell content has already been processed by
           ;; every other pass (bold, italic, links, inline code, etc.).
           ;; The cell parser respects face and `agent-shell-markdown-frozen'

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -41,6 +41,8 @@
 ;;   image path  bare image path on a line  same as `![alt](url)' (no markup)
 ;;   divider     `---' / `***' / `___'    rendered as an underlined rule line
 ;;   fenced code ```LANG\nX\n```          body syntax-highlighted via LANG mode
+;;   display math `$$X$$'                  overlaid with an equation image
+;;                                         (placeholder; LaTeX source kept beneath)
 ;;   tables      `| A | B |' grid rows    rendered with aligned columns,
 ;;                                         unicode borders, header/zebra rows
 ;;                                         and wrap-to-window-width support
@@ -58,9 +60,11 @@
 
 (eval-when-compile
   (require 'cl-lib))
+(require 'color)
 (require 'map)
 (require 'seq)
 (require 'org-faces)
+(require 'svg)
 (require 'url)
 (require 'url-parse)
 (require 'url-util)
@@ -157,6 +161,14 @@ window edge."
   "Face for the language label shown above a fenced source block."
   :group 'agent-shell-markdown)
 
+(defface agent-shell-markdown-math
+  '((t :inherit font-lock-constant-face))
+  "Face applied to rendered `$$...$$' display-math source.
+On a graphical display the source is hidden behind an equation
+image; this face is the fallback styling for the raw LaTeX shown
+on a non-graphical display."
+  :group 'agent-shell-markdown)
+
 (defvar agent-shell-markdown-image-max-width 0.4
   "Maximum width for inline images rendered from `![alt](url)'.
 An integer is taken as pixels.  A float between 0 and 1 is a
@@ -209,6 +221,7 @@ For example:
 
 (cl-defun agent-shell-markdown-replace-markup (&key force
                                                     (render-images t)
+                                                    (render-math t)
                                                     (highlight-blocks t)
                                                     image-cache-directory)
   "Replace Markdown markup in current buffer with propertized text.
@@ -244,7 +257,11 @@ markup with displayed images where the URL resolves to an image
 file; nil leaves the markup as-is.  IMAGE-CACHE-DIRECTORY is where
 remote (http) image URLs are downloaded and cached; when nil
 \(the default), remote images are not fetched and their markup is
-left as text.  HIGHLIGHT-BLOCKS, when non-nil
+left as text.  RENDER-MATH, when non-nil (the
+default), overlays `$$...$$' display-math blocks with an equation
+image (currently a placeholder; see
+`agent-shell-markdown--style-math-blocks'); nil leaves the LaTeX
+source raw.  HIGHLIGHT-BLOCKS, when non-nil
 (the default), runs the fenced-block body through the language's
 major-mode font-lock to colour keywords / strings / etc.; nil
 strips the fences and inserts the action label but leaves the
@@ -260,14 +277,23 @@ body un-fontified."
         (let* ((source-ranges (agent-shell-markdown--sort-ranges
                                (agent-shell-markdown--make-markers
                                 (agent-shell-markdown--source-block-ranges))))
+               ;; `$$...$$' display-math regions, excluding any `$$' that
+               ;; lives inside a fenced code block.  Protected like
+               ;; source blocks so inline passes don't mangle the LaTeX
+               ;; interior (e.g. `a_b' subscripts, `**' superscripts).
+               (math-ranges (agent-shell-markdown--make-markers
+                             (agent-shell-markdown--math-block-ranges
+                              source-ranges)))
+               (protect-ranges (agent-shell-markdown--sort-ranges
+                                source-ranges math-ranges))
                (rendered-ranges (agent-shell-markdown--make-markers
                                  (agent-shell-markdown--frozen-ranges)))
                (inline-ranges (agent-shell-markdown--make-markers
                                (agent-shell-markdown--inline-code-ranges
                                 :avoid-ranges (agent-shell-markdown--sort-ranges
-                                               source-ranges rendered-ranges))))
+                                               protect-ranges rendered-ranges))))
                (avoid-ranges (agent-shell-markdown--sort-ranges
-                              source-ranges rendered-ranges inline-ranges)))
+                              protect-ranges rendered-ranges inline-ranges)))
           (while (let ((italic-changed (agent-shell-markdown--replace-italics
                                         :avoid-ranges avoid-ranges))
                        (bold-changed (agent-shell-markdown--replace-bolds
@@ -276,7 +302,7 @@ body un-fontified."
                                         :avoid-ranges avoid-ranges)))
                    (or italic-changed bold-changed strike-changed)))
           (agent-shell-markdown--replace-headers :avoid-ranges avoid-ranges)
-          (agent-shell-markdown--style-inline-code :avoid-ranges source-ranges)
+          (agent-shell-markdown--style-inline-code :avoid-ranges protect-ranges)
           (agent-shell-markdown--replace-links :avoid-ranges avoid-ranges)
           (when render-images
             (agent-shell-markdown--replace-images
@@ -288,6 +314,13 @@ body un-fontified."
           (agent-shell-markdown--style-blockquotes :avoid-ranges avoid-ranges)
           (agent-shell-markdown--style-source-blocks
            :highlight-blocks highlight-blocks)
+          ;; Math runs after source blocks (so a `$$' inside fenced code
+          ;; stays literal) and before tables (so a frozen equation
+          ;; isn't mis-parsed as table rows).  SOURCE-RANGES protects
+          ;; the still-open-fence case the same way the other passes do.
+          (when render-math
+            (agent-shell-markdown--style-math-blocks
+             :avoid-ranges source-ranges))
           ;; Tables run last so cell content has already been processed by
           ;; every other pass (bold, italic, links, inline code, etc.).
           ;; The cell parser respects face and `agent-shell-markdown-frozen'
@@ -301,7 +334,7 @@ body un-fontified."
           ;; `--set-watermark'), so `--find-tables' under the narrow
           ;; always sees the existing `agent-shell-markdown-table-source'
           ;; needed to fold new rows in.
-          (agent-shell-markdown--style-tables :avoid-ranges source-ranges)
+          (agent-shell-markdown--style-tables :avoid-ranges protect-ranges)
           ;; Mirror every `face' we composed onto `font-lock-face' so our
           ;; styling survives `font-lock-mode' re-fontification — comint
           ;; / shell-maker / agent-shell buffers fontify on every output
@@ -976,6 +1009,143 @@ with `emacs-lisp-mode' face properties on the body and a
             ;; loop doesn't backtrack into body content (e.g. shorter
             ;; inner fences inside a wider outer fence).
             (goto-char (marker-position body-end))))))))
+
+(cl-defun agent-shell-markdown--style-math-blocks (&key avoid-ranges)
+  "Overlay `$$...$$' display-math blocks with an equation image.
+
+For each complete `$$...$$' block with a non-empty body, the raw
+`$$...$$' text is left in the buffer (so copy / save round-trips
+the LaTeX source) and, on a graphical display, an image of the
+equation is layered over it via a `display' text property.  The
+whole region is faced with `agent-shell-markdown-math' and tagged
+`agent-shell-markdown-frozen' so later passes and subsequent
+streaming calls leave it alone.  Blocks inside any of AVOID-RANGES
+\(typically fenced code) are left untouched, as is an
+empty (`$$$$') block.
+
+Image rendering is currently a PLACEHOLDER: it boxes the raw
+LaTeX rather than typesetting it.  Real compilation is meant to
+slot into `agent-shell-markdown--latex-to-image' without touching
+this pass.
+
+For example, the buffer:
+
+  $$
+  E=mc^2
+  $$
+
+keeps the `$$\\nE=mc^2\\n$$' text but shows an equation image in
+its place, faced `agent-shell-markdown-math' and frozen."
+  (let ((case-fold-search nil))
+    (goto-char (point-min))
+    (while (re-search-forward
+            (rx "$$" (group (*? anychar)) "$$")
+            nil t)
+      (let* ((block-start (match-beginning 0))
+             (block-end (match-end 0))
+             (latex (string-trim
+                     (buffer-substring-no-properties
+                      (match-beginning 1) (match-end 1))))
+             (avoid (agent-shell-markdown--in-avoid-range-p
+                     block-start block-end avoid-ranges)))
+        (cond
+         (avoid (goto-char (cdr avoid)))
+         ((string-empty-p latex))
+         (t
+          (let ((image (agent-shell-markdown--latex-to-image latex))
+                (line-prefix (get-text-property block-start 'line-prefix))
+                (wrap-prefix (get-text-property block-start 'wrap-prefix)))
+            (add-face-text-property block-start block-end
+                                    'agent-shell-markdown-math)
+            (when image
+              (put-text-property block-start block-end 'display image)
+              (put-text-property block-start block-end 'mouse-face 'highlight)
+              (when line-prefix
+                (put-text-property block-start block-end
+                                   'line-prefix line-prefix))
+              (when wrap-prefix
+                (put-text-property block-start block-end
+                                   'wrap-prefix wrap-prefix)))
+            (add-text-properties
+             block-start block-end
+             `(help-echo ,latex
+               agent-shell-markdown-math-source ,latex
+               agent-shell-markdown-frozen t
+               rear-nonsticky (agent-shell-markdown-frozen)))
+            (goto-char block-end))))))))
+
+(defun agent-shell-markdown--svg-color (face attribute fallback)
+  "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
+
+ATTRIBUTE is `:foreground' or `:background'.  FALLBACK is returned
+when the attribute is unspecified or can't be resolved to RGB
+\(e.g. on a terminal that reports symbolic colors).
+
+For example:
+
+  (agent-shell-markdown--svg-color \\='default :foreground \"#000000\")
+  => \"#ffffff\"  ; on a dark theme"
+  (let ((color (face-attribute face attribute nil 'default)))
+    ;; `color-name-to-rgb' both returns nil for unknown names and
+    ;; signals (e.g. on the "unspecified-fg" sentinel, or off a window
+    ;; system) — guard both so we always fall back cleanly.
+    (if-let* (((stringp color))
+              (rgb (ignore-errors (color-name-to-rgb color))))
+        (apply #'color-rgb-to-hex (append rgb '(2)))
+      fallback)))
+
+(defun agent-shell-markdown--latex-to-image (latex)
+  "Return a PLACEHOLDER SVG image for LATEX, or nil.
+
+This does NOT typeset LATEX.  It draws the raw source inside a
+bordered panel so the interception / overlay pipeline can be
+exercised ahead of real LaTeX compilation (which is meant to
+replace this function's body).  Returns nil when no graphical
+display is available, so callers fall back to the raw text.
+
+LATEX is the equation source with the surrounding `$$'
+delimiters already stripped, e.g. \"E=mc^2\"."
+  (when (display-graphic-p)
+    (let* ((lines (split-string latex "\n"))
+           ;; `frame-char-width' / `-height' give per-char pixel
+           ;; dimensions on a graphical frame and stay robust off it
+           ;; (unlike `default-font-width', which calls `font-info' and
+           ;; errors with no live font).  Good enough for placeholder
+           ;; sizing; real typesetting will set its own dimensions.
+           (char-w (frame-char-width))
+           (char-h (frame-char-height))
+           (pad char-h)
+           (badge-h char-h)
+           (text-w (* char-w (apply #'max 1 (mapcar #'length lines))))
+           (width (+ text-w (* 2 pad)))
+           (height (+ badge-h (* char-h (length lines)) (* 2 pad)))
+           (fg (agent-shell-markdown--svg-color 'default :foreground "#000000"))
+           (border (agent-shell-markdown--svg-color
+                    'font-lock-comment-face :foreground "#888888"))
+           (panel (agent-shell-markdown--svg-color
+                   'org-block :background "#f4f4f4"))
+           (svg (svg-create width height)))
+      (svg-rectangle svg 0 0 width height
+                     :rx (/ char-h 2)
+                     :fill panel
+                     :stroke border
+                     :stroke-width 1)
+      (svg-text svg "tex"
+                :x pad
+                :y (* badge-h 0.85)
+                :font-size (* badge-h 0.7)
+                :font-style "italic"
+                :fill border)
+      (seq-do-indexed
+       (lambda (line i)
+         (svg-text svg (if (string-empty-p line) " " line)
+                   :x pad
+                   :y (+ badge-h pad (* char-h (1+ i)) (- (/ char-h 4)))
+                   :font-family "monospace"
+                   :font-size char-h
+                   :fill fg))
+       lines)
+      (svg-image svg :scale 1.0 :ascent 'center))))
 
 (defconst agent-shell-markdown--table-line-regexp
   (rx line-start
@@ -2351,6 +2521,16 @@ only to end-of-line, so they're naturally within that zone."
             (let ((last (car (last source-ranges))))
               (when (and last (= (cdr last) (point-max)))
                 (car last))))
+           ;; An open (not yet closed) `$$' must hold the frontier back
+           ;; so the closing `$$' on a future chunk gets paired —
+           ;; otherwise the watermark slips past the equation body line
+           ;; by line and it never renders.  Mirrors OPEN-FENCE-START.
+           (open-math-start
+            (let ((last (car (last (agent-shell-markdown--math-block-ranges
+                                    (agent-shell-markdown--sort-ranges
+                                     source-ranges))))))
+              (when (and last (= (cdr last) (point-max)))
+                (car last))))
            (extending-table-start
             (agent-shell-markdown--extending-table-start))
            (last-line-start
@@ -2359,6 +2539,7 @@ only to end-of-line, so they're naturally within that zone."
            (frontier (apply #'min
                             (delq nil (list last-line-start
                                             open-fence-start
+                                            open-math-start
                                             extending-table-start)))))
       (with-silent-modifications
         (put-text-property (point-min) (1+ (point-min))
@@ -2445,6 +2626,44 @@ returns a list with one range covering the whole block."
             (setq open-start (match-beginning 0)
                   open-count count)))))
       (when open-count
+        (push (cons open-start (point-max)) ranges)))
+    (nreverse ranges)))
+
+(defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
+  "Return list of (start . end) ranges covering `$$...$$' display math.
+
+Each range spans from the opening `$$' to the end of its matching
+closing `$$'.  An opening `$$' with no closing `$$' yet
+\(mid-stream) extends to `point-max', so its contents are
+protected as the buffer grows — mirrors
+`agent-shell-markdown--source-block-ranges'.
+
+A `$$' delimiter that falls inside any of AVOID-RANGES (a sorted
+vector, typically fenced code blocks) is ignored, so the returned
+ranges never overlap AVOID-RANGES.
+
+For example, given the buffer:
+
+  $$
+  E=mc^2
+  $$
+
+returns a list with one range covering the whole block."
+  (let ((ranges '())
+        (open-start nil)
+        (case-fold-search nil))
+    (save-excursion
+      (goto-char (point-min))
+      (while (search-forward "$$" nil t)
+        (let ((avoid (agent-shell-markdown--in-avoid-range-p
+                      (match-beginning 0) (point) avoid-ranges)))
+          (cond
+           (avoid (goto-char (cdr avoid)))
+           (open-start
+            (push (cons open-start (point)) ranges)
+            (setq open-start nil))
+           (t (setq open-start (match-beginning 0))))))
+      (when open-start
         (push (cons open-start (point-max)) ranges)))
     (nreverse ranges)))
 

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -42,7 +42,7 @@
 ;;   divider     `---' / `***' / `___'    rendered as an underlined rule line
 ;;   fenced code ```LANG\nX\n```          body syntax-highlighted via LANG mode
 ;;   display math `$$X$$' / `\[X\]'        overlaid with an equation image
-;;                                         (placeholder; LaTeX source kept beneath)
+;;                                         (latex+dvisvgm; LaTeX source kept beneath)
 ;;   tables      `| A | B |' grid rows    rendered with aligned columns,
 ;;                                         unicode borders, header/zebra rows
 ;;                                         and wrap-to-window-width support
@@ -257,7 +257,7 @@ remote (http) image URLs are downloaded and cached; when nil
 left as text.  RENDER-MATH, when non-nil (the
 default), overlays display-math blocks (`$$...$$' and / or
 `\\[...\\]', per `agent-shell-markdown-math-delimiters') with an
-equation image (currently a placeholder; see
+equation image (compiled via latex / dvisvgm; see
 `agent-shell-markdown--style-math-blocks'); nil leaves the LaTeX
 source raw.  HIGHLIGHT-BLOCKS, when non-nil
 (the default), runs the fenced-block body through the language's

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -2665,58 +2665,86 @@ body is the buffer text in [S+O, E-C).
 
 Only the delimiter styles listed in
 `agent-shell-markdown-math-delimiters' are recognized (`$$...$$'
-and/or `\\[...\\]').  Scanning is a single left-to-right pass with
-one open delimiter at a time: while a block is open only its own
-closer ends it, so a `$$' inside a `\\[...\\]' block (or vice
-versa) is body, and the returned blocks never overlap each other.
+and/or `\\[...\\]').
+
+Scanning resolves each opener immediately: from just after an
+opener we look for the first of its matching closer or a blank
+line (a paragraph break, which LaTeX display math can't contain).
+
+  - Closer first: a valid block, recorded; scanning resumes after
+    the closer.
+  - Blank line first: the opener is a false positive, so scanning
+    resumes just after the OPENER (not past the blank line), so
+    real blocks sitting between a stray opener and the blank line
+    are still found.
+  - Neither yet (end of buffer): a still-streaming block extending
+    to `point-max' with :close 0, so a genuine equation stays
+    protected as the buffer grows — mirrors
+    `agent-shell-markdown--source-block-ranges'.
+
 A delimiter inside any of AVOID-RANGES (a sorted vector, typically
-fenced code) is ignored, so blocks never overlap AVOID-RANGES
-either.  A block whose closing delimiter has not streamed in yet
-extends to `point-max' with :close 0, so its contents stay
-protected as the buffer grows — mirrors
-`agent-shell-markdown--source-block-ranges'.
+fenced code) is ignored — both openers and closers — so blocks
+never overlap AVOID-RANGES.  Because openers are resolved one at a
+time and bodies never cross a blank line, returned blocks never
+overlap each other.
 
 For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
-returns ((:start 1 :end 10 :open 2 :close 2))."
+returns ((:start 1 :end 11 :open 2 :close 2))."
   (let* ((specs (seq-keep (lambda (style)
                             (map-elt agent-shell-markdown--math-delimiters style))
                           agent-shell-markdown-math-delimiters))
-         (tokens (seq-uniq (append (mapcar #'car specs) (mapcar #'cdr specs))))
          (blocks '())
-         (open-start nil)
-         (open-len nil)
-         (open-close nil)
          (case-fold-search nil))
-    (when tokens
+    (when specs
       (save-excursion
         (goto-char (point-min))
-        (while (re-search-forward (regexp-opt tokens) nil t)
-          (let* ((token (match-string-no-properties 0))
-                 (token-start (match-beginning 0))
-                 (avoid (agent-shell-markdown--in-avoid-range-p
-                         token-start (point) avoid-ranges)))
-            (cond
-             (avoid (goto-char (cdr avoid)))
-             ;; Inside a block: only its own closer ends it.
-             (open-close
-              (when (string= token open-close)
-                (push (list :start open-start :end (point)
-                            :open open-len :close (length token))
-                      blocks)
-                (setq open-start nil open-len nil open-close nil)))
-             ;; Not in a block: an opener of some style starts one.  A
-             ;; stray closer (e.g. a lone `\\]') matches no opener and
-             ;; is skipped.
-             ((seq-find (lambda (spec) (string= token (car spec))) specs)
-              (setq open-start token-start
-                    open-len (length token)
-                    open-close (cdr (seq-find (lambda (spec)
-                                                (string= token (car spec)))
-                                              specs)))))))
-        (when open-start
-          (push (list :start open-start :end (point-max)
-                      :open open-len :close 0)
-                blocks))))
+        (let ((open-re (regexp-opt (mapcar #'car specs))))
+          (while (re-search-forward open-re nil t)
+            (let* ((open-token (match-string-no-properties 0))
+                   (open-start (match-beginning 0))
+                   (open-end (point))
+                   (avoid (agent-shell-markdown--in-avoid-range-p
+                           open-start open-end avoid-ranges)))
+              (if avoid
+                  (goto-char (cdr avoid))
+                (let* ((close-token (cdr (seq-find
+                                          (lambda (spec)
+                                            (string= open-token (car spec)))
+                                          specs)))
+                       ;; First closer or blank line at or after the body.
+                       ;; A closer inside an avoid-range isn't real — skip
+                       ;; past that range and keep looking.
+                       (hit (save-excursion
+                              (goto-char open-end)
+                              (let ((re (concat (regexp-quote close-token)
+                                                "\\|\n[ \t]*\n"))
+                                    (result nil))
+                                (while (and (not result)
+                                            (re-search-forward re nil t))
+                                  (if-let* ((av (agent-shell-markdown--in-avoid-range-p
+                                                 (match-beginning 0) (point)
+                                                 avoid-ranges)))
+                                      (goto-char (cdr av))
+                                    (setq result
+                                          (cons (match-string-no-properties 0)
+                                                (point)))))
+                                result))))
+                  (cond
+                   ;; Matching closer reached with no blank line before it.
+                   ((and hit (string= (car hit) close-token))
+                    (push (list :start open-start :end (cdr hit)
+                                :open (length open-token)
+                                :close (length close-token))
+                          blocks)
+                    (goto-char (cdr hit)))
+                   ;; Blank line first: false-positive opener.  Resume
+                   ;; right after the opener so inner real blocks are seen.
+                   (hit (goto-char open-end))
+                   ;; Neither yet: still-streaming open block.
+                   (t (push (list :start open-start :end (point-max)
+                                  :open (length open-token) :close 0)
+                            blocks)
+                      (goto-char (point-max)))))))))))
     (nreverse blocks)))
 
 (defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
@@ -2727,7 +2755,7 @@ that only need the protected spans (avoid-ranges, watermark
 back-off).  AVOID-RANGES is forwarded.
 
 For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
-returns ((1 . 10))."
+returns ((1 . 11))."
   (mapcar (lambda (block)
             (cons (plist-get block :start) (plist-get block :end)))
           (agent-shell-markdown--math-blocks avoid-ranges)))

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -41,7 +41,7 @@
 ;;   image path  bare image path on a line  same as `![alt](url)' (no markup)
 ;;   divider     `---' / `***' / `___'    rendered as an underlined rule line
 ;;   fenced code ```LANG\nX\n```          body syntax-highlighted via LANG mode
-;;   display math `$$X$$'                  overlaid with an equation image
+;;   display math `$$X$$' / `\[X\]'        overlaid with an equation image
 ;;                                         (placeholder; LaTeX source kept beneath)
 ;;   tables      `| A | B |' grid rows    rendered with aligned columns,
 ;;                                         unicode borders, header/zebra rows
@@ -163,11 +163,37 @@ window edge."
 
 (defface agent-shell-markdown-math
   '((t :inherit font-lock-constant-face))
-  "Face applied to rendered `$$...$$' display-math source.
+  "Face applied to rendered display-math source.
 On a graphical display the source is hidden behind an equation
 image; this face is the fallback styling for the raw LaTeX shown
 on a non-graphical display."
   :group 'agent-shell-markdown)
+
+(defconst agent-shell-markdown--math-delimiters
+  '((dollar . ("$$" . "$$"))
+    (bracket . ("\\[" . "\\]")))
+  "Map of display-math delimiter styles to their (OPEN . CLOSE) tokens.
+`dollar' is `$$...$$'; `bracket' is `\\[...\\]'.  The keys of this
+map are the values accepted in `agent-shell-markdown-math-delimiters'.")
+
+(defvar agent-shell-markdown-math-delimiters '(bracket)
+  "Display-math delimiter styles recognized when rendering markdown.
+
+A list whose members are keys of
+`agent-shell-markdown--math-delimiters':
+
+  `bracket'  recognize `\\[...\\]'
+  `dollar'   recognize `$$...$$'
+
+The two are independent — add or drop one to toggle it.  An empty
+list disables math rendering entirely (as does passing
+`:render-math nil' to `agent-shell-markdown-replace-markup').
+
+Defaults to `bracket' only: `\\[...\\]' is unambiguous, whereas
+`dollar' can false-positive on prose or currency like \"it cost
+$$$\".  Opt into `$$...$$' with:
+
+  (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
 
 (defvar agent-shell-markdown-image-max-width 0.4
   "Maximum width for inline images rendered from `![alt](url)'.
@@ -258,8 +284,9 @@ file; nil leaves the markup as-is.  IMAGE-CACHE-DIRECTORY is where
 remote (http) image URLs are downloaded and cached; when nil
 \(the default), remote images are not fetched and their markup is
 left as text.  RENDER-MATH, when non-nil (the
-default), overlays `$$...$$' display-math blocks with an equation
-image (currently a placeholder; see
+default), overlays display-math blocks (`$$...$$' and / or
+`\\[...\\]', per `agent-shell-markdown-math-delimiters') with an
+equation image (currently a placeholder; see
 `agent-shell-markdown--style-math-blocks'); nil leaves the LaTeX
 source raw.  HIGHLIGHT-BLOCKS, when non-nil
 (the default), runs the fenced-block body through the language's
@@ -277,13 +304,16 @@ body un-fontified."
         (let* ((source-ranges (agent-shell-markdown--sort-ranges
                                (agent-shell-markdown--make-markers
                                 (agent-shell-markdown--source-block-ranges))))
-               ;; `$$...$$' display-math regions, excluding any `$$' that
-               ;; lives inside a fenced code block.  Protected like
-               ;; source blocks so inline passes don't mangle the LaTeX
-               ;; interior (e.g. `a_b' subscripts, `**' superscripts).
-               (math-ranges (agent-shell-markdown--make-markers
-                             (agent-shell-markdown--math-block-ranges
-                              source-ranges)))
+               ;; Display-math regions (`$$...$$' / `\\[...\\]'),
+               ;; excluding any delimiter inside a fenced code block.
+               ;; Protected like source blocks so inline passes don't
+               ;; mangle the LaTeX interior (e.g. `a_b' subscripts,
+               ;; `**' superscripts).  Skipped when RENDER-MATH is nil
+               ;; so the delimiters stay plain text.
+               (math-ranges (when render-math
+                              (agent-shell-markdown--make-markers
+                               (agent-shell-markdown--math-block-ranges
+                                source-ranges))))
                (protect-ranges (agent-shell-markdown--sort-ranges
                                 source-ranges math-ranges))
                (rendered-ranges (agent-shell-markdown--make-markers
@@ -1011,68 +1041,64 @@ with `emacs-lisp-mode' face properties on the body and a
             (goto-char (marker-position body-end))))))))
 
 (cl-defun agent-shell-markdown--style-math-blocks (&key avoid-ranges)
-  "Overlay `$$...$$' display-math blocks with an equation image.
+  "Overlay display-math blocks with an equation image.
 
-For each complete `$$...$$' block with a non-empty body, the raw
-`$$...$$' text is left in the buffer (so copy / save round-trips
-the LaTeX source) and, on a graphical display, an image of the
-equation is layered over it via a `display' text property.  The
-whole region is faced with `agent-shell-markdown-math' and tagged
+Recognizes the delimiter styles in
+`agent-shell-markdown-math-delimiters' (`$$...$$' and/or
+`\\[...\\]').  For each complete block with a non-empty body, the
+raw delimited text is left in the buffer (so copy / save
+round-trips the LaTeX source) and, on a graphical display, an
+image of the equation is layered over it via a `display' text
+property.  The whole region is faced with
+`agent-shell-markdown-math' and tagged
 `agent-shell-markdown-frozen' so later passes and subsequent
 streaming calls leave it alone.  Blocks inside any of AVOID-RANGES
-\(typically fenced code) are left untouched, as is an
-empty (`$$$$') block.
+\(typically fenced code) are left untouched, as is an empty block.
+
+Adds only text properties (no insert / delete), so the block
+positions returned by `agent-shell-markdown--math-blocks' stay
+valid while iterating.
 
 Image rendering is currently a PLACEHOLDER: it boxes the raw
 LaTeX rather than typesetting it.  Real compilation is meant to
 slot into `agent-shell-markdown--latex-to-image' without touching
 this pass.
 
-For example, the buffer:
+For example, with the buffer:
 
-  $$
-  E=mc^2
-  $$
+  \\[E=mc^2\\]
 
-keeps the `$$\\nE=mc^2\\n$$' text but shows an equation image in
-its place, faced `agent-shell-markdown-math' and frozen."
-  (let ((case-fold-search nil))
-    (goto-char (point-min))
-    (while (re-search-forward
-            (rx "$$" (group (*? anychar)) "$$")
-            nil t)
-      (let* ((block-start (match-beginning 0))
-             (block-end (match-end 0))
-             (latex (string-trim
-                     (buffer-substring-no-properties
-                      (match-beginning 1) (match-end 1))))
-             (avoid (agent-shell-markdown--in-avoid-range-p
-                     block-start block-end avoid-ranges)))
-        (cond
-         (avoid (goto-char (cdr avoid)))
-         ((string-empty-p latex))
-         (t
-          (let ((image (agent-shell-markdown--latex-to-image latex))
-                (line-prefix (get-text-property block-start 'line-prefix))
-                (wrap-prefix (get-text-property block-start 'wrap-prefix)))
-            (add-face-text-property block-start block-end
-                                    'agent-shell-markdown-math)
-            (when image
-              (put-text-property block-start block-end 'display image)
-              (put-text-property block-start block-end 'mouse-face 'highlight)
-              (when line-prefix
-                (put-text-property block-start block-end
-                                   'line-prefix line-prefix))
-              (when wrap-prefix
-                (put-text-property block-start block-end
-                                   'wrap-prefix wrap-prefix)))
-            (add-text-properties
-             block-start block-end
-             `(help-echo ,latex
-               agent-shell-markdown-math-source ,latex
-               agent-shell-markdown-frozen t
-               rear-nonsticky (agent-shell-markdown-frozen)))
-            (goto-char block-end))))))))
+the `\\[E=mc^2\\]' text is kept but shows an equation image in its
+place, faced `agent-shell-markdown-math' and frozen."
+  (dolist (block (agent-shell-markdown--math-blocks avoid-ranges))
+    ;; A still-open block (no closing delimiter yet) reports :close 0
+    ;; and runs to `point-max'; leave it raw until the closer streams in.
+    (when-let* ((close (plist-get block :close))
+                ((> close 0))
+                (start (plist-get block :start))
+                (end (plist-get block :end))
+                (latex (string-trim
+                        (buffer-substring-no-properties
+                         (+ start (plist-get block :open))
+                         (- end close))))
+                ((not (string-empty-p latex))))
+      (let ((image (agent-shell-markdown--latex-to-image latex))
+            (line-prefix (get-text-property start 'line-prefix))
+            (wrap-prefix (get-text-property start 'wrap-prefix)))
+        (add-face-text-property start end 'agent-shell-markdown-math)
+        (when image
+          (put-text-property start end 'display image)
+          (put-text-property start end 'mouse-face 'highlight)
+          (when line-prefix
+            (put-text-property start end 'line-prefix line-prefix))
+          (when wrap-prefix
+            (put-text-property start end 'wrap-prefix wrap-prefix)))
+        (add-text-properties
+         start end
+         `(help-echo ,latex
+           agent-shell-markdown-math-source ,latex
+           agent-shell-markdown-frozen t
+           rear-nonsticky (agent-shell-markdown-frozen)))))))
 
 (defun agent-shell-markdown--svg-color (face attribute fallback)
   "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
@@ -2629,43 +2655,82 @@ returns a list with one range covering the whole block."
         (push (cons open-start (point-max)) ranges)))
     (nreverse ranges)))
 
-(defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
-  "Return list of (start . end) ranges covering `$$...$$' display math.
+(defun agent-shell-markdown--math-blocks (&optional avoid-ranges)
+  "Return display-math blocks in the current buffer.
 
-Each range spans from the opening `$$' to the end of its matching
-closing `$$'.  An opening `$$' with no closing `$$' yet
-\(mid-stream) extends to `point-max', so its contents are
+Each element is a plist (:start S :end E :open O :close C): S..E
+spans the whole delimited block (delimiters included), and O / C
+are the opening / closing delimiter token lengths, so the LaTeX
+body is the buffer text in [S+O, E-C).
+
+Only the delimiter styles listed in
+`agent-shell-markdown-math-delimiters' are recognized (`$$...$$'
+and/or `\\[...\\]').  Scanning is a single left-to-right pass with
+one open delimiter at a time: while a block is open only its own
+closer ends it, so a `$$' inside a `\\[...\\]' block (or vice
+versa) is body, and the returned blocks never overlap each other.
+A delimiter inside any of AVOID-RANGES (a sorted vector, typically
+fenced code) is ignored, so blocks never overlap AVOID-RANGES
+either.  A block whose closing delimiter has not streamed in yet
+extends to `point-max' with :close 0, so its contents stay
 protected as the buffer grows — mirrors
 `agent-shell-markdown--source-block-ranges'.
 
-A `$$' delimiter that falls inside any of AVOID-RANGES (a sorted
-vector, typically fenced code blocks) is ignored, so the returned
-ranges never overlap AVOID-RANGES.
+For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
+returns ((:start 1 :end 10 :open 2 :close 2))."
+  (let* ((specs (seq-keep (lambda (style)
+                            (map-elt agent-shell-markdown--math-delimiters style))
+                          agent-shell-markdown-math-delimiters))
+         (tokens (seq-uniq (append (mapcar #'car specs) (mapcar #'cdr specs))))
+         (blocks '())
+         (open-start nil)
+         (open-len nil)
+         (open-close nil)
+         (case-fold-search nil))
+    (when tokens
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward (regexp-opt tokens) nil t)
+          (let* ((token (match-string-no-properties 0))
+                 (token-start (match-beginning 0))
+                 (avoid (agent-shell-markdown--in-avoid-range-p
+                         token-start (point) avoid-ranges)))
+            (cond
+             (avoid (goto-char (cdr avoid)))
+             ;; Inside a block: only its own closer ends it.
+             (open-close
+              (when (string= token open-close)
+                (push (list :start open-start :end (point)
+                            :open open-len :close (length token))
+                      blocks)
+                (setq open-start nil open-len nil open-close nil)))
+             ;; Not in a block: an opener of some style starts one.  A
+             ;; stray closer (e.g. a lone `\\]') matches no opener and
+             ;; is skipped.
+             ((seq-find (lambda (spec) (string= token (car spec))) specs)
+              (setq open-start token-start
+                    open-len (length token)
+                    open-close (cdr (seq-find (lambda (spec)
+                                                (string= token (car spec)))
+                                              specs)))))))
+        (when open-start
+          (push (list :start open-start :end (point-max)
+                      :open open-len :close 0)
+                blocks))))
+    (nreverse blocks)))
 
-For example, given the buffer:
+(defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
+  "Return list of (start . end) ranges covering display-math blocks.
 
-  $$
-  E=mc^2
-  $$
+Thin adapter over `agent-shell-markdown--math-blocks' for callers
+that only need the protected spans (avoid-ranges, watermark
+back-off).  AVOID-RANGES is forwarded.
 
-returns a list with one range covering the whole block."
-  (let ((ranges '())
-        (open-start nil)
-        (case-fold-search nil))
-    (save-excursion
-      (goto-char (point-min))
-      (while (search-forward "$$" nil t)
-        (let ((avoid (agent-shell-markdown--in-avoid-range-p
-                      (match-beginning 0) (point) avoid-ranges)))
-          (cond
-           (avoid (goto-char (cdr avoid)))
-           (open-start
-            (push (cons open-start (point)) ranges)
-            (setq open-start nil))
-           (t (setq open-start (match-beginning 0))))))
-      (when open-start
-        (push (cons open-start (point-max)) ranges)))
-    (nreverse ranges)))
+For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
+returns ((1 . 10))."
+  (mapcar (lambda (block)
+            (cons (plist-get block :start) (plist-get block :end)))
+          (agent-shell-markdown--math-blocks avoid-ranges)))
 
 (defun agent-shell-markdown--frozen-ranges ()
   "Return ranges of buffer chars tagged `agent-shell-markdown-frozen'.

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -60,11 +60,9 @@
 
 (eval-when-compile
   (require 'cl-lib))
-(require 'color)
 (require 'map)
 (require 'seq)
 (require 'org-faces)
-(require 'svg)
 (require 'url)
 (require 'url-parse)
 (require 'url-util)
@@ -72,6 +70,13 @@
 (defgroup agent-shell-markdown nil
   "Render Markdown text into propertized form."
   :group 'text)
+
+;; Display-math passes (`$$...$$' / `\[...\]') live in their own module
+;; and are invoked from `agent-shell-markdown-replace-markup' /
+;; `--set-watermark'.  Loaded here (after the defgroup so its faces /
+;; vars attach to the group); the module declares back into this file
+;; for `--in-avoid-range-p' rather than requiring it (avoids a cycle).
+(require 'agent-shell-markdown-math)
 
 (defface agent-shell-markdown-bold
   '((t :inherit bold))
@@ -160,40 +165,6 @@ window edge."
   '((t :inherit (italic font-lock-type-face agent-shell-markdown-source-block)))
   "Face for the language label shown above a fenced source block."
   :group 'agent-shell-markdown)
-
-(defface agent-shell-markdown-math
-  '((t :inherit font-lock-constant-face))
-  "Face applied to rendered display-math source.
-On a graphical display the source is hidden behind an equation
-image; this face is the fallback styling for the raw LaTeX shown
-on a non-graphical display."
-  :group 'agent-shell-markdown)
-
-(defconst agent-shell-markdown--math-delimiters
-  '((dollar . ("$$" . "$$"))
-    (bracket . ("\\[" . "\\]")))
-  "Map of display-math delimiter styles to their (OPEN . CLOSE) tokens.
-`dollar' is `$$...$$'; `bracket' is `\\[...\\]'.  The keys of this
-map are the values accepted in `agent-shell-markdown-math-delimiters'.")
-
-(defvar agent-shell-markdown-math-delimiters '(bracket)
-  "Display-math delimiter styles recognized when rendering markdown.
-
-A list whose members are keys of
-`agent-shell-markdown--math-delimiters':
-
-  `bracket'  recognize `\\[...\\]'
-  `dollar'   recognize `$$...$$'
-
-The two are independent — add or drop one to toggle it.  An empty
-list disables math rendering entirely (as does passing
-`:render-math nil' to `agent-shell-markdown-replace-markup').
-
-Defaults to `bracket' only: `\\[...\\]' is unambiguous, whereas
-`dollar' can false-positive on prose or currency like \"it cost
-$$$\".  Opt into `$$...$$' with:
-
-  (setq agent-shell-markdown-math-delimiters \\='(bracket dollar))")
 
 (defvar agent-shell-markdown-image-max-width 0.4
   "Maximum width for inline images rendered from `![alt](url)'.
@@ -1039,139 +1010,6 @@ with `emacs-lisp-mode' face properties on the body and a
             ;; loop doesn't backtrack into body content (e.g. shorter
             ;; inner fences inside a wider outer fence).
             (goto-char (marker-position body-end))))))))
-
-(cl-defun agent-shell-markdown--style-math-blocks (&key avoid-ranges)
-  "Overlay display-math blocks with an equation image.
-
-Recognizes the delimiter styles in
-`agent-shell-markdown-math-delimiters' (`$$...$$' and/or
-`\\[...\\]').  For each complete block with a non-empty body, the
-raw delimited text is left in the buffer (so copy / save
-round-trips the LaTeX source) and, on a graphical display, an
-image of the equation is layered over it via a `display' text
-property.  The whole region is faced with
-`agent-shell-markdown-math' and tagged
-`agent-shell-markdown-frozen' so later passes and subsequent
-streaming calls leave it alone.  Blocks inside any of AVOID-RANGES
-\(typically fenced code) are left untouched, as is an empty block.
-
-Adds only text properties (no insert / delete), so the block
-positions returned by `agent-shell-markdown--math-blocks' stay
-valid while iterating.
-
-Image rendering is currently a PLACEHOLDER: it boxes the raw
-LaTeX rather than typesetting it.  Real compilation is meant to
-slot into `agent-shell-markdown--latex-to-image' without touching
-this pass.
-
-For example, with the buffer:
-
-  \\[E=mc^2\\]
-
-the `\\[E=mc^2\\]' text is kept but shows an equation image in its
-place, faced `agent-shell-markdown-math' and frozen."
-  (dolist (block (agent-shell-markdown--math-blocks avoid-ranges))
-    ;; A still-open block (no closing delimiter yet) reports :close 0
-    ;; and runs to `point-max'; leave it raw until the closer streams in.
-    (when-let* ((close (plist-get block :close))
-                ((> close 0))
-                (start (plist-get block :start))
-                (end (plist-get block :end))
-                (latex (string-trim
-                        (buffer-substring-no-properties
-                         (+ start (plist-get block :open))
-                         (- end close))))
-                ((not (string-empty-p latex))))
-      (let ((image (agent-shell-markdown--latex-to-image latex))
-            (line-prefix (get-text-property start 'line-prefix))
-            (wrap-prefix (get-text-property start 'wrap-prefix)))
-        (add-face-text-property start end 'agent-shell-markdown-math)
-        (when image
-          (put-text-property start end 'display image)
-          (put-text-property start end 'mouse-face 'highlight)
-          (when line-prefix
-            (put-text-property start end 'line-prefix line-prefix))
-          (when wrap-prefix
-            (put-text-property start end 'wrap-prefix wrap-prefix)))
-        (add-text-properties
-         start end
-         `(help-echo ,latex
-           agent-shell-markdown-math-source ,latex
-           agent-shell-markdown-frozen t
-           rear-nonsticky (agent-shell-markdown-frozen)))))))
-
-(defun agent-shell-markdown--svg-color (face attribute fallback)
-  "Return FACE's ATTRIBUTE color as a `#rrggbb' string, or FALLBACK.
-
-ATTRIBUTE is `:foreground' or `:background'.  FALLBACK is returned
-when the attribute is unspecified or can't be resolved to RGB
-\(e.g. on a terminal that reports symbolic colors).
-
-For example:
-
-  (agent-shell-markdown--svg-color \\='default :foreground \"#000000\")
-  => \"#ffffff\"  ; on a dark theme"
-  (let ((color (face-attribute face attribute nil 'default)))
-    ;; `color-name-to-rgb' both returns nil for unknown names and
-    ;; signals (e.g. on the "unspecified-fg" sentinel, or off a window
-    ;; system) — guard both so we always fall back cleanly.
-    (if-let* (((stringp color))
-              (rgb (ignore-errors (color-name-to-rgb color))))
-        (apply #'color-rgb-to-hex (append rgb '(2)))
-      fallback)))
-
-(defun agent-shell-markdown--latex-to-image (latex)
-  "Return a PLACEHOLDER SVG image for LATEX, or nil.
-
-This does NOT typeset LATEX.  It draws the raw source inside a
-bordered panel so the interception / overlay pipeline can be
-exercised ahead of real LaTeX compilation (which is meant to
-replace this function's body).  Returns nil when no graphical
-display is available, so callers fall back to the raw text.
-
-LATEX is the equation source with the surrounding `$$'
-delimiters already stripped, e.g. \"E=mc^2\"."
-  (when (display-graphic-p)
-    (let* ((lines (split-string latex "\n"))
-           ;; `frame-char-width' / `-height' give per-char pixel
-           ;; dimensions on a graphical frame and stay robust off it
-           ;; (unlike `default-font-width', which calls `font-info' and
-           ;; errors with no live font).  Good enough for placeholder
-           ;; sizing; real typesetting will set its own dimensions.
-           (char-w (frame-char-width))
-           (char-h (frame-char-height))
-           (pad char-h)
-           (badge-h char-h)
-           (text-w (* char-w (apply #'max 1 (mapcar #'length lines))))
-           (width (+ text-w (* 2 pad)))
-           (height (+ badge-h (* char-h (length lines)) (* 2 pad)))
-           (fg (agent-shell-markdown--svg-color 'default :foreground "#000000"))
-           (border (agent-shell-markdown--svg-color
-                    'font-lock-comment-face :foreground "#888888"))
-           (panel (agent-shell-markdown--svg-color
-                   'org-block :background "#f4f4f4"))
-           (svg (svg-create width height)))
-      (svg-rectangle svg 0 0 width height
-                     :rx (/ char-h 2)
-                     :fill panel
-                     :stroke border
-                     :stroke-width 1)
-      (svg-text svg "tex"
-                :x pad
-                :y (* badge-h 0.85)
-                :font-size (* badge-h 0.7)
-                :font-style "italic"
-                :fill border)
-      (seq-do-indexed
-       (lambda (line i)
-         (svg-text svg (if (string-empty-p line) " " line)
-                   :x pad
-                   :y (+ badge-h pad (* char-h (1+ i)) (- (/ char-h 4)))
-                   :font-family "monospace"
-                   :font-size char-h
-                   :fill fg))
-       lines)
-      (svg-image svg :scale 1.0 :ascent 'center))))
 
 (defconst agent-shell-markdown--table-line-regexp
   (rx line-start
@@ -2654,111 +2492,6 @@ returns a list with one range covering the whole block."
       (when open-count
         (push (cons open-start (point-max)) ranges)))
     (nreverse ranges)))
-
-(defun agent-shell-markdown--math-blocks (&optional avoid-ranges)
-  "Return display-math blocks in the current buffer.
-
-Each element is a plist (:start S :end E :open O :close C): S..E
-spans the whole delimited block (delimiters included), and O / C
-are the opening / closing delimiter token lengths, so the LaTeX
-body is the buffer text in [S+O, E-C).
-
-Only the delimiter styles listed in
-`agent-shell-markdown-math-delimiters' are recognized (`$$...$$'
-and/or `\\[...\\]').
-
-Scanning resolves each opener immediately: from just after an
-opener we look for the first of its matching closer or a blank
-line (a paragraph break, which LaTeX display math can't contain).
-
-  - Closer first: a valid block, recorded; scanning resumes after
-    the closer.
-  - Blank line first: the opener is a false positive, so scanning
-    resumes just after the OPENER (not past the blank line), so
-    real blocks sitting between a stray opener and the blank line
-    are still found.
-  - Neither yet (end of buffer): a still-streaming block extending
-    to `point-max' with :close 0, so a genuine equation stays
-    protected as the buffer grows — mirrors
-    `agent-shell-markdown--source-block-ranges'.
-
-A delimiter inside any of AVOID-RANGES (a sorted vector, typically
-fenced code) is ignored — both openers and closers — so blocks
-never overlap AVOID-RANGES.  Because openers are resolved one at a
-time and bodies never cross a blank line, returned blocks never
-overlap each other.
-
-For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
-returns ((:start 1 :end 11 :open 2 :close 2))."
-  (let* ((specs (seq-keep (lambda (style)
-                            (map-elt agent-shell-markdown--math-delimiters style))
-                          agent-shell-markdown-math-delimiters))
-         (blocks '())
-         (case-fold-search nil))
-    (when specs
-      (save-excursion
-        (goto-char (point-min))
-        (let ((open-re (regexp-opt (mapcar #'car specs))))
-          (while (re-search-forward open-re nil t)
-            (let* ((open-token (match-string-no-properties 0))
-                   (open-start (match-beginning 0))
-                   (open-end (point))
-                   (avoid (agent-shell-markdown--in-avoid-range-p
-                           open-start open-end avoid-ranges)))
-              (if avoid
-                  (goto-char (cdr avoid))
-                (let* ((close-token (cdr (seq-find
-                                          (lambda (spec)
-                                            (string= open-token (car spec)))
-                                          specs)))
-                       ;; First closer or blank line at or after the body.
-                       ;; A closer inside an avoid-range isn't real — skip
-                       ;; past that range and keep looking.
-                       (hit (save-excursion
-                              (goto-char open-end)
-                              (let ((re (concat (regexp-quote close-token)
-                                                "\\|\n[ \t]*\n"))
-                                    (result nil))
-                                (while (and (not result)
-                                            (re-search-forward re nil t))
-                                  (if-let* ((av (agent-shell-markdown--in-avoid-range-p
-                                                 (match-beginning 0) (point)
-                                                 avoid-ranges)))
-                                      (goto-char (cdr av))
-                                    (setq result
-                                          (cons (match-string-no-properties 0)
-                                                (point)))))
-                                result))))
-                  (cond
-                   ;; Matching closer reached with no blank line before it.
-                   ((and hit (string= (car hit) close-token))
-                    (push (list :start open-start :end (cdr hit)
-                                :open (length open-token)
-                                :close (length close-token))
-                          blocks)
-                    (goto-char (cdr hit)))
-                   ;; Blank line first: false-positive opener.  Resume
-                   ;; right after the opener so inner real blocks are seen.
-                   (hit (goto-char open-end))
-                   ;; Neither yet: still-streaming open block.
-                   (t (push (list :start open-start :end (point-max)
-                                  :open (length open-token) :close 0)
-                            blocks)
-                      (goto-char (point-max)))))))))))
-    (nreverse blocks)))
-
-(defun agent-shell-markdown--math-block-ranges (&optional avoid-ranges)
-  "Return list of (start . end) ranges covering display-math blocks.
-
-Thin adapter over `agent-shell-markdown--math-blocks' for callers
-that only need the protected spans (avoid-ranges, watermark
-back-off).  AVOID-RANGES is forwarded.
-
-For example, with `bracket' enabled and buffer \"\\=\\[E=mc^2\\]\",
-returns ((1 . 11))."
-  (mapcar (lambda (block)
-            (cons (plist-get block :start) (plist-get block :end)))
-          (agent-shell-markdown--math-blocks avoid-ranges)))
 
 (defun agent-shell-markdown--frozen-ranges ()
   "Return ranges of buffer chars tagged `agent-shell-markdown-frozen'.

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -328,7 +328,7 @@ E=mc^2
   ;; re-tints all equations.  Stub --math-render to record the visits.
   (let ((calls '()))
     (cl-letf (((symbol-function 'agent-shell-markdown--math-render)
-               (lambda (_buffer start end latex)
+               (lambda (_buffer start end latex &optional _inline)
                  (push (list start end latex) calls))))
       (with-temp-buffer
         (insert "first eq then second eq")
@@ -355,6 +355,116 @@ E=mc^2
     (let ((agent-shell-markdown-math-preamble "\\documentclass{minimal}"))
       (should-not (equal base (agent-shell-markdown--math-cache-key
                                "E=mc^2" "#000000" 1.4))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-protects-markup ()
+  ;; Inline `\\(...\\)' is matched anywhere on a line (not just block
+  ;; level) and faced `agent-shell-markdown-math', keeping its interior
+  ;; literal (here `**x**' is not turned bold).
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "a \\( **x** \\) b"))
+                   '(("a " nil)
+                     ("\\( **x** \\)" (agent-shell-markdown-math))
+                     (" b" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-multiple-per-line ()
+  ;; Several inline spans on one line each render independently.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "\\(a\\) and \\(b\\)"))
+                   '(("\\(a\\)" (agent-shell-markdown-math))
+                     (" and " nil)
+                     ("\\(b\\)" (agent-shell-markdown-math)))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-in-inline-code-untouched ()
+  ;; A `\\(...\\)' inside an inline-code span is literal code, not math:
+  ;; it keeps the inline-code face and gets no math face.
+  (agent-shell-markdown-math-tests--enabled
+    (let ((runs (agent-shell-markdown--deconstruct
+                 (agent-shell-markdown-convert "`\\(x\\)`"))))
+      (should-not (seq-some (lambda (run)
+                              (memq 'agent-shell-markdown-math (cadr run)))
+                            runs))
+      (should (seq-some (lambda (run)
+                          (memq 'agent-shell-markdown-inline-code (cadr run)))
+                        runs)))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-in-fenced-block-untouched ()
+  ;; A `\\(...\\)' inside a fenced code block is body text, not math.
+  (agent-shell-markdown-math-tests--enabled
+    (let ((runs (agent-shell-markdown--deconstruct
+                 (agent-shell-markdown-convert "```
+\\(x\\)
+```"))))
+      (should-not (seq-some (lambda (run)
+                              (memq 'agent-shell-markdown-math (cadr run)))
+                            runs)))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-closer-must-be-same-line ()
+  ;; The closer must be on the opener's line; a `\\(' whose `\\)' is on a
+  ;; later line is not matched (left as plain text), which bounds the
+  ;; single-line inline form.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "\\(
+x
+\\)"))
+                   '(("\\(
+x
+\\)" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-streaming-tail ()
+  ;; An unclosed `\\(' on the buffer's last line is left raw (the closer
+  ;; may still stream in); the start-of-last-line watermark re-scans it.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "text \\(E=mc^2"))
+                   '(("text \\(E=mc^2" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-can-be-disabled ()
+  ;; `agent-shell-markdown-math-render-inline' nil disables `\\(...\\)'
+  ;; even with the master switch on: delimiters are plain and inner
+  ;; markup (`**x**') is processed normally.
+  (let ((agent-shell-markdown-render-math t)
+        (agent-shell-markdown-math-render-inline nil))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "a \\( **x** \\) b"))
+                   '(("a \\( " nil)
+                     ("x" (agent-shell-markdown-bold))
+                     (" \\) b" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-master-switch-off ()
+  ;; With the master switch off, inline `\\(...\\)' is plain text and
+  ;; inner markup is processed (here `**x**' becomes bold).
+  (let ((agent-shell-markdown-render-math nil))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "a \\( **x** \\) b"))
+                   '(("a \\( " nil)
+                     ("x" (agent-shell-markdown-bold))
+                     (" \\) b" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-inline-math-tags-source-and-inline ()
+  ;; Inline math stashes its source and the inline flag, while display
+  ;; math stashes its source with the flag nil — so a refresh re-renders
+  ;; each in the right style.
+  (agent-shell-markdown-math-tests--enabled
+    (let ((inline (agent-shell-markdown-convert "a \\(x\\) b"))
+          (display (agent-shell-markdown-convert "\\[ x \\]")))
+      (should (equal (get-text-property 2 'agent-shell-markdown-math-source inline)
+                     "x"))
+      (should (get-text-property 2 'agent-shell-markdown-math-inline inline))
+      (should (equal (get-text-property 0 'agent-shell-markdown-math-source display)
+                     "x"))
+      (should-not (get-text-property 0 'agent-shell-markdown-math-inline display)))))
+
+(ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inline ()
+  ;; Inline and display renders of the same source must not collide:
+  ;; the inline flag changes the key, while the default (display) key is
+  ;; unchanged from the no-flag form (so existing caches stay valid).
+  (should (equal (agent-shell-markdown--math-cache-key "x" "#000000" 1.4)
+                 (agent-shell-markdown--math-cache-key "x" "#000000" 1.4 nil)))
+  (should-not (equal (agent-shell-markdown--math-cache-key "x" "#000000" 1.4)
+                     (agent-shell-markdown--math-cache-key "x" "#000000" 1.4 t))))
 
 (provide 'agent-shell-markdown-math-tests)
 

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -604,6 +604,14 @@ x
         (agent-shell-markdown-math--refresh-if-changed))
       (should-not refreshed))))
 
+(ert-deftest agent-shell-markdown-math-text-scale-wired-to-refresh ()
+  ;; A buffer zoom (`text-scale-adjust') fires `text-scale-mode-hook' but
+  ;; neither display nor theme hooks, so the lazy refresh must subscribe to
+  ;; it directly — otherwise equations only re-size on the next buffer
+  ;; switch.  Verify the hook is wired at load time.
+  (should (memq 'agent-shell-markdown-math--maybe-refresh
+                (default-value 'text-scale-mode-hook))))
+
 (ert-deftest agent-shell-markdown-math-image-cache-key-includes-scale ()
   ;; The in-memory image-cache key folds in the display scale, so the same
   ;; equation at two font sizes maps to two distinct entries.

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -52,10 +52,8 @@ so the dollar-delimited tests opt into `dollar' (and the master
   (agent-shell-markdown-math-tests--with-dollar
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
-                     "before $$ **x** $$ after"))
-                   '(("before " nil)
-                     ("$$ **x** $$" (agent-shell-markdown-math))
-                     (" after" nil))))))
+                     "$$ **x** $$"))
+                   '(("$$ **x** $$" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-display-math-block ()
   ;; Multi-line block form: the whole `$$\\n...\\n$$' region is one
@@ -105,42 +103,44 @@ $$ x $$
 " (agent-shell-markdown-source-block)))))))
 
 (ert-deftest agent-shell-markdown-convert-bracket-math-protects-markup ()
-  ;; A complete `\\[...\\]' block is recognized as display math and
-  ;; faced `agent-shell-markdown-math', keeping its interior literal.
+  ;; A complete block-level `\\[...\\]' is recognized as display math
+  ;; and faced `agent-shell-markdown-math', keeping its interior literal.
   (agent-shell-markdown-math-tests--enabled
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
-                     "before \\[ **x** \\] after"))
-                   '(("before " nil)
-                     ("\\[ **x** \\]" (agent-shell-markdown-math))
-                     (" after" nil))))))
+                     "\\[ **x** \\]"))
+                   '(("\\[ **x** \\]" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-open-bracket-math-protects-rest ()
-  ;; An unclosed `\\[' protects the rest of the buffer until the
-  ;; closing `\\]' arrives, mirroring open `$$' / open fences.
+  ;; A line-start `\\[' with no closer yet protects the rest of the
+  ;; buffer until the closing `\\]' arrives, mirroring open `$$' /
+  ;; open fences.
   (agent-shell-markdown-math-tests--enabled
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
-                     "before **b** \\[ streaming **not bold**"))
+                     "before **b**
+\\[ streaming **not bold**"))
                    '(("before " nil)
                      ("b" (agent-shell-markdown-bold))
-                     (" \\[ streaming **not bold**" nil))))))
+                     ("
+\\[ streaming **not bold**" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-math-delimiters-independent ()
   ;; `agent-shell-markdown-math-delimiters' toggles each style
-  ;; independently: with only `bracket' enabled, `\\[...\\]' renders
-  ;; while `$$...$$' is left as plain text (and its `**' inside is
-  ;; processed as ordinary markup).
+  ;; independently: with only `bracket' enabled, a block-level
+  ;; `\\[...\\]' renders while `$$...$$' is left as plain text (and its
+  ;; `**' inside is processed as ordinary markup).
   (let ((agent-shell-markdown-render-math t)
         (agent-shell-markdown-math-delimiters '(bracket)))
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
-                     "a $$ **b** $$ c \\[ **d** \\] e"))
-                   '(("a $$ " nil)
+                     "$$ **b** $$
+\\[ **d** \\]"))
+                   '(("$$ " nil)
                      ("b" (agent-shell-markdown-bold))
-                     (" $$ c " nil)
-                     ("\\[ **d** \\]" (agent-shell-markdown-math))
-                     (" e" nil))))))
+                     (" $$
+" nil)
+                     ("\\[ **d** \\]" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-math-delimiters-disabled ()
   ;; An empty `agent-shell-markdown-math-delimiters' disables the
@@ -196,21 +196,48 @@ extra
 \\]" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-math-stray-opener-recovers-real-blocks ()
-  ;; A stray opener that never closes before a blank line is a false
-  ;; positive, but scanning resumes just after it — so a real block
-  ;; sitting between the stray opener and the blank line is still
-  ;; rendered (rather than swallowed and lost).
-  (agent-shell-markdown-math-tests--with-dollar
+  ;; A stray line-start opener that never closes before a blank line is
+  ;; a false positive; scanning resumes just after it, so a real
+  ;; block-level equation on a later line is still rendered (rather than
+  ;; the stray opener swallowing it).
+  (agent-shell-markdown-math-tests--enabled
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
-                     "\\[ oops and $$E=mc^2$$ here
+                     "\\[ stray opener
 
-next"))
-                   '(("\\[ oops and " nil)
-                     ("$$E=mc^2$$" (agent-shell-markdown-math))
-                     (" here
+\\[ E=mc^2 \\]"))
+                   '(("\\[ stray opener
 
-next" nil))))))
+" nil)
+                     ("\\[ E=mc^2 \\]" (agent-shell-markdown-math)))))))
+
+(ert-deftest agent-shell-markdown-convert-math-inline-opener-ignored ()
+  ;; An opener not at line start is inline, not block-level display
+  ;; math: it is left as plain text and inner markup is processed.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "see \\[ **x** \\] here"))
+                   '(("see \\[ " nil)
+                     ("x" (agent-shell-markdown-bold))
+                     (" \\] here" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-non-flush-closer-rejected ()
+  ;; A line-start opener whose closer sits mid-line (text follows on the
+  ;; same line) is not a flush block; it is rejected and left as plain
+  ;; text rather than rendered.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "\\[ E=mc^2 \\] and text"))
+                   '(("\\[ E=mc^2 \\] and text" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-dollar-on-by-default ()
+  ;; `dollar' is part of the default `agent-shell-markdown-math-delimiters'
+  ;; now that block-level anchoring makes it safe, so `$$...$$' renders
+  ;; without opting in (only the master switch need be on here).
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "$$ E=mc^2 $$"))
+                   '(("$$ E=mc^2 $$" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-fenced-math-renders ()
   ;; A ```math fence renders as display math: the fences are stripped

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -378,6 +378,12 @@ E=mc^2
     (let ((agent-shell-markdown-math-preamble "\\documentclass{minimal}"))
       (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2"))))))
 
+(ert-deftest agent-shell-markdown-math-cache-key-folds-in-appended-preamble ()
+  ;; Changing the appended preamble must also invalidate the cache.
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2")))
+    (let ((agent-shell-markdown-math-appended-preamble "\\usepackage{braket}"))
+      (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2"))))))
+
 (ert-deftest agent-shell-markdown-convert-inline-math-protects-markup ()
   ;; Inline `\\(...\\)' is matched anywhere on a line (not just block
   ;; level) and faced `agent-shell-markdown-math', keeping its interior

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -494,6 +494,48 @@ x
           (should (file-directory-p dir)))
       (delete-directory parent t))))
 
+(ert-deftest agent-shell-markdown-math-display-scale-is-1-when-non-graphical ()
+  ;; Off a graphical frame (batch, the daemon-prerender path) the font
+  ;; height is unknown, so the image is left at natural size — this is
+  ;; why the batch render paths and the rest of the suite are unaffected.
+  (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) nil)))
+    (should (equal (agent-shell-markdown--math-display-scale) 1.0))))
+
+(ert-deftest agent-shell-markdown-math-svg-px-per-pt-falls-back-uncached ()
+  ;; Without a graphical frame the calibration returns the 96/72 fallback
+  ;; and must NOT cache it, so a later graphical frame can still measure.
+  (let ((agent-shell-markdown-math--svg-px-per-pt nil))
+    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) nil)))
+      (should (equal (agent-shell-markdown--math-svg-px-per-pt) (/ 96.0 72.0)))
+      (should-not agent-shell-markdown-math--svg-px-per-pt))))
+
+(ert-deftest agent-shell-markdown-math-display-scale-matches-font ()
+  ;; The display scale maps LaTeX's 10pt body font onto the buffer font
+  ;; height: scale = target * font-scale / (10 * math-scale * px-per-pt).
+  ;; Stub the graphical inputs so the arithmetic is checked deterministically.
+  (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
+            ((symbol-function 'default-font-height) (lambda (&rest _) 28))
+            ((symbol-function 'agent-shell-markdown--math-svg-px-per-pt)
+             (lambda () 2.0)))
+    (let ((agent-shell-markdown-math-scale 1.4)
+          (agent-shell-markdown-math-font-scale 1.0))
+      (should (equal (agent-shell-markdown--math-display-scale)
+                     (/ 28.0 (* 10.0 1.4 2.0)))))
+    ;; Doubling font-scale doubles the displayed size.
+    (let* ((agent-shell-markdown-math-scale 1.4)
+           (agent-shell-markdown-math-font-scale 1.0)
+           (base (agent-shell-markdown--math-display-scale))
+           (agent-shell-markdown-math-font-scale 2.0))
+      (should (equal (agent-shell-markdown--math-display-scale) (* 2 base))))
+    ;; The compile scale cancels: changing it leaves on-screen size unchanged.
+    (let ((agent-shell-markdown-math-font-scale 1.0))
+      (should (equal (let ((agent-shell-markdown-math-scale 1.4))
+                       (* agent-shell-markdown-math-scale
+                          (agent-shell-markdown--math-display-scale)))
+                     (let ((agent-shell-markdown-math-scale 3.0))
+                       (* agent-shell-markdown-math-scale
+                          (agent-shell-markdown--math-display-scale))))))))
+
 (provide 'agent-shell-markdown-math-tests)
 
 ;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -536,6 +536,39 @@ x
                        (* agent-shell-markdown-math-scale
                           (agent-shell-markdown--math-display-scale))))))))
 
+(ert-deftest agent-shell-markdown-math-appearance-tracks-color-and-font ()
+  ;; The appearance signature folds in both the colors and the buffer font
+  ;; height, so the lazy refresh detects a font-size change as well as a
+  ;; color change.  Stub the graphical inputs.
+  (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
+            ((symbol-function 'agent-shell-markdown--svg-color)
+             (lambda (_face attr _fallback)
+               (if (eq attr :foreground) "#111111" "#eeeeee"))))
+    (cl-letf (((symbol-function 'default-font-height) (lambda (&rest _) 20)))
+      (let ((a (agent-shell-markdown-math--current-appearance)))
+        (should (equal a '("#111111" "#eeeeee" 20)))
+        ;; Same colors, larger font => different signature => would refresh.
+        (cl-letf (((symbol-function 'default-font-height) (lambda (&rest _) 28)))
+          (should-not (equal a (agent-shell-markdown-math--current-appearance))))))))
+
+(ert-deftest agent-shell-markdown-math-refresh-if-changed-detects-font ()
+  ;; `--refresh-if-changed' triggers a refresh when only the font height
+  ;; moved (colors unchanged) — the new behavior over a colors-only check.
+  (let ((agent-shell-markdown-render-math t)
+        (refreshed nil))
+    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
+              ((symbol-function 'agent-shell-markdown--svg-color)
+               (lambda (_face attr _fallback)
+                 (if (eq attr :foreground) "#000000" "#ffffff")))
+              ((symbol-function 'agent-shell-markdown-math-refresh)
+               (lambda () (setq refreshed t))))
+      ;; Rendered at font height 20; current font is now 30, same colors.
+      (let ((agent-shell-markdown-math--rendered-appearance
+             '("#000000" "#ffffff" 20)))
+        (cl-letf (((symbol-function 'default-font-height) (lambda (&rest _) 30)))
+          (agent-shell-markdown-math--refresh-if-changed)))
+      (should refreshed))))
+
 (provide 'agent-shell-markdown-math-tests)
 
 ;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -195,6 +195,23 @@ next"))
 
 next" nil))))))
 
+(ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
+  ;; The cache key must be stable for identical inputs and differ when the
+  ;; equation, colour, or scale changes — otherwise cached SVGs collide or
+  ;; never hit.  (Pure function; no TeX or graphical display needed.)
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
+    (should (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^3" "#000000" 1.4)))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#ffffff" 1.4)))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 2.0)))))
+
+(ert-deftest agent-shell-markdown-math-cache-key-folds-in-preamble ()
+  ;; Changing the preamble must invalidate the cache (different output).
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
+    (let ((agent-shell-markdown-math-preamble "\\documentclass{minimal}"))
+      (should-not (equal base (agent-shell-markdown--math-cache-key
+                               "E=mc^2" "#000000" 1.4))))))
+
 (provide 'agent-shell-markdown-math-tests)
 
 ;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -553,21 +553,43 @@ x
 
 (ert-deftest agent-shell-markdown-math-refresh-if-changed-detects-font ()
   ;; `--refresh-if-changed' triggers a refresh when only the font height
-  ;; moved (colors unchanged) — the new behavior over a colors-only check.
+  ;; moved (colors unchanged), and targets just the current buffer (the
+  ;; one the hook made relevant) rather than every buffer.
   (let ((agent-shell-markdown-render-math t)
         (refreshed nil))
-    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
-              ((symbol-function 'agent-shell-markdown--svg-color)
-               (lambda (_face attr _fallback)
-                 (if (eq attr :foreground) "#000000" "#ffffff")))
-              ((symbol-function 'agent-shell-markdown-math-refresh)
-               (lambda () (setq refreshed t))))
-      ;; Rendered at font height 20; current font is now 30, same colors.
-      (let ((agent-shell-markdown-math--rendered-appearance
-             '("#000000" "#ffffff" 20)))
-        (cl-letf (((symbol-function 'default-font-height) (lambda (&rest _) 30)))
-          (agent-shell-markdown-math--refresh-if-changed)))
-      (should refreshed))))
+    (with-temp-buffer
+      (setq agent-shell-markdown-math--present t)
+      ;; Buffer was last rendered at font height 20; same colors.
+      (setq agent-shell-markdown-math--rendered-appearance
+            '("#000000" "#ffffff" 20))
+      (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
+                ((symbol-function 'agent-shell-markdown--svg-color)
+                 (lambda (_face attr _fallback)
+                   (if (eq attr :foreground) "#000000" "#ffffff")))
+                ((symbol-function 'default-font-height) (lambda (&rest _) 30))
+                ((symbol-function 'agent-shell-markdown-math-refresh)
+                 (lambda (&optional buffer) (setq refreshed (or buffer t)))))
+        (agent-shell-markdown-math--refresh-if-changed))
+      ;; Refreshed, and scoped to this buffer.
+      (should (eq refreshed (current-buffer))))))
+
+(ert-deftest agent-shell-markdown-math-refresh-if-changed-skips-non-present ()
+  ;; In a buffer with no equations (`--present' nil), a hook firing is a
+  ;; no-op even if the appearance differs — nothing to re-render.
+  (let ((agent-shell-markdown-render-math t)
+        (refreshed nil))
+    (with-temp-buffer
+      (setq agent-shell-markdown-math--present nil)
+      (setq agent-shell-markdown-math--rendered-appearance nil)
+      (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
+                ((symbol-function 'agent-shell-markdown--svg-color)
+                 (lambda (_face attr _fallback)
+                   (if (eq attr :foreground) "#000000" "#ffffff")))
+                ((symbol-function 'default-font-height) (lambda (&rest _) 30))
+                ((symbol-function 'agent-shell-markdown-math-refresh)
+                 (lambda (&optional _buffer) (setq refreshed t))))
+        (agent-shell-markdown-math--refresh-if-changed))
+      (should-not refreshed))))
 
 (provide 'agent-shell-markdown-math-tests)
 

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -341,20 +341,20 @@ E=mc^2
 
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
   ;; The cache key must be stable for identical inputs and differ when the
-  ;; equation, colour, or scale changes — otherwise cached SVGs collide or
-  ;; never hit.  (Pure function; no TeX or graphical display needed.)
-  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
-    (should (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
-    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^3" "#000000" 1.4)))
-    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#ffffff" 1.4)))
-    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 2.0)))))
+  ;; equation or colour changes — otherwise cached SVGs collide or never
+  ;; hit.  (Pure function; no TeX or graphical display needed.)  Display
+  ;; size is NOT part of this key (the on-disk SVG is font-independent).
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
+    (should (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^3" "#000000")))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#ffffff")))))
 
 (ert-deftest agent-shell-markdown-math-cache-key-folds-in-preamble ()
   ;; Changing the preamble must invalidate the cache (different output).
-  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000" 1.4)))
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
     (let ((agent-shell-markdown-math-preamble "\\documentclass{minimal}"))
       (should-not (equal base (agent-shell-markdown--math-cache-key
-                               "E=mc^2" "#000000" 1.4))))))
+                               "E=mc^2" "#000000"))))))
 
 (ert-deftest agent-shell-markdown-convert-inline-math-protects-markup ()
   ;; Inline `\\(...\\)' is matched anywhere on a line (not just block
@@ -460,11 +460,11 @@ x
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inline ()
   ;; Inline and display renders of the same source must not collide:
   ;; the inline flag changes the key, while the default (display) key is
-  ;; unchanged from the no-flag form (so existing caches stay valid).
-  (should (equal (agent-shell-markdown--math-cache-key "x" "#000000" 1.4)
-                 (agent-shell-markdown--math-cache-key "x" "#000000" 1.4 nil)))
-  (should-not (equal (agent-shell-markdown--math-cache-key "x" "#000000" 1.4)
-                     (agent-shell-markdown--math-cache-key "x" "#000000" 1.4 t))))
+  ;; unchanged from the no-flag form.
+  (should (equal (agent-shell-markdown--math-cache-key "x" "#000000")
+                 (agent-shell-markdown--math-cache-key "x" "#000000" nil)))
+  (should-not (equal (agent-shell-markdown--math-cache-key "x" "#000000")
+                     (agent-shell-markdown--math-cache-key "x" "#000000" t))))
 
 (ert-deftest agent-shell-markdown-math-cache-dir-uses-agent-shell-cache ()
   ;; By default the equation cache lives under agent-shell's shared cache
@@ -510,31 +510,21 @@ x
       (should-not agent-shell-markdown-math--svg-px-per-pt))))
 
 (ert-deftest agent-shell-markdown-math-display-scale-matches-font ()
-  ;; The display scale maps LaTeX's 10pt body font onto the buffer font
-  ;; height: scale = target * font-scale / (10 * math-scale * px-per-pt).
-  ;; Stub the graphical inputs so the arithmetic is checked deterministically.
+  ;; The display scale maps the LaTeX 10pt body font onto the buffer font
+  ;; height: scale = target * font-scale / (10 * px-per-pt).  Stub the
+  ;; graphical inputs so the arithmetic is checked deterministically.
   (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t))
             ((symbol-function 'default-font-height) (lambda (&rest _) 28))
             ((symbol-function 'agent-shell-markdown--math-svg-px-per-pt)
              (lambda () 2.0)))
-    (let ((agent-shell-markdown-math-scale 1.4)
-          (agent-shell-markdown-math-font-scale 1.0))
+    (let ((agent-shell-markdown-math-font-scale 1.0))
       (should (equal (agent-shell-markdown--math-display-scale)
-                     (/ 28.0 (* 10.0 1.4 2.0)))))
+                     (/ 28.0 (* 10.0 2.0)))))
     ;; Doubling font-scale doubles the displayed size.
-    (let* ((agent-shell-markdown-math-scale 1.4)
-           (agent-shell-markdown-math-font-scale 1.0)
+    (let* ((agent-shell-markdown-math-font-scale 1.0)
            (base (agent-shell-markdown--math-display-scale))
            (agent-shell-markdown-math-font-scale 2.0))
-      (should (equal (agent-shell-markdown--math-display-scale) (* 2 base))))
-    ;; The compile scale cancels: changing it leaves on-screen size unchanged.
-    (let ((agent-shell-markdown-math-font-scale 1.0))
-      (should (equal (let ((agent-shell-markdown-math-scale 1.4))
-                       (* agent-shell-markdown-math-scale
-                          (agent-shell-markdown--math-display-scale)))
-                     (let ((agent-shell-markdown-math-scale 3.0))
-                       (* agent-shell-markdown-math-scale
-                          (agent-shell-markdown--math-display-scale))))))))
+      (should (equal (agent-shell-markdown--math-display-scale) (* 2 base))))))
 
 (ert-deftest agent-shell-markdown-math-appearance-tracks-color-and-font ()
   ;; The appearance signature folds in both the colors and the buffer font

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -1,0 +1,200 @@
+;;; agent-shell-markdown-math-tests.el --- Tests for agent-shell-markdown-math -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; Run via:
+;;
+;;   emacs -batch -l ert -l tests/agent-shell-markdown-math-tests.el \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ert)
+
+(add-to-list 'load-path
+             (expand-file-name ".." (file-name-directory
+                                     (or load-file-name buffer-file-name))))
+
+;; Loads `agent-shell-markdown', which in turn requires
+;; `agent-shell-markdown-math'.  The math passes run through the public
+;; `agent-shell-markdown-convert', so the tests exercise the renderer
+;; integration rather than the module in isolation.
+(load-file (expand-file-name "../agent-shell-markdown.el"
+                             (file-name-directory
+                              (or load-file-name buffer-file-name))))
+
+(defmacro agent-shell-markdown-math-tests--with-dollar (&rest body)
+  "Evaluate BODY with `$$...$$' display math enabled.
+`agent-shell-markdown-math-delimiters' defaults to `bracket' only,
+so the dollar-delimited tests opt into `dollar' through this one
+binding rather than repeating it in each test."
+  (declare (indent 0) (debug t))
+  `(let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
+     ,@body))
+
+(ert-deftest agent-shell-markdown-convert-display-math-protects-markup ()
+  ;; A complete `$$...$$' block is faced `agent-shell-markdown-math'
+  ;; as a single run; the LaTeX source is kept literal (no bold /
+  ;; italic / subscript processing of its interior).  On the
+  ;; non-graphical batch display no equation image is overlaid, so
+  ;; `--deconstruct' sees only the math face.
+  (agent-shell-markdown-math-tests--with-dollar
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before $$ **x** $$ after"))
+                   '(("before " nil)
+                     ("$$ **x** $$" (agent-shell-markdown-math))
+                     (" after" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-display-math-block ()
+  ;; Multi-line block form: the whole `$$\\n...\\n$$' region is one
+  ;; math-faced run.
+  (agent-shell-markdown-math-tests--with-dollar
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "$$
+E=mc^2
+$$"))
+                   '(("$$
+E=mc^2
+$$" (agent-shell-markdown-math)))))))
+
+(ert-deftest agent-shell-markdown-convert-open-math-protects-rest ()
+  ;; An unclosed `$$' protects the rest of the buffer as still
+  ;; streaming, just like an open fence: markup after it is left raw
+  ;; until the closing `$$' arrives.
+  (agent-shell-markdown-math-tests--with-dollar
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before **b**
+$$
+streaming **not bold**"))
+                   '(("before " nil)
+                     ("b" (agent-shell-markdown-bold))
+                     ("
+$$
+streaming **not bold**" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-display-math-in-fenced-block-untouched ()
+  ;; A `$$' inside a fenced code block is body text, not display
+  ;; math: it must not get the math face (even with `dollar' enabled).
+  (agent-shell-markdown-math-tests--with-dollar
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "```
+$$ x $$
+```"))
+                   '(("
+" (agent-shell-markdown-source-block))
+                     ("snippet ⧉" (agent-shell-markdown-source-block-language))
+                     ("
+
+$$ x $$
+
+" (agent-shell-markdown-source-block)))))))
+
+(ert-deftest agent-shell-markdown-convert-bracket-math-protects-markup ()
+  ;; A complete `\\[...\\]' block is recognized as display math and
+  ;; faced `agent-shell-markdown-math', keeping its interior literal.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before \\[ **x** \\] after"))
+                 '(("before " nil)
+                   ("\\[ **x** \\]" (agent-shell-markdown-math))
+                   (" after" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-open-bracket-math-protects-rest ()
+  ;; An unclosed `\\[' protects the rest of the buffer until the
+  ;; closing `\\]' arrives, mirroring open `$$' / open fences.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before **b** \\[ streaming **not bold**"))
+                 '(("before " nil)
+                   ("b" (agent-shell-markdown-bold))
+                   (" \\[ streaming **not bold**" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-math-delimiters-independent ()
+  ;; `agent-shell-markdown-math-delimiters' toggles each style
+  ;; independently: with only `bracket' enabled, `\\[...\\]' renders
+  ;; while `$$...$$' is left as plain text (and its `**' inside is
+  ;; processed as ordinary markup).
+  (let ((agent-shell-markdown-math-delimiters '(bracket)))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "a $$ **b** $$ c \\[ **d** \\] e"))
+                   '(("a $$ " nil)
+                     ("b" (agent-shell-markdown-bold))
+                     (" $$ c " nil)
+                     ("\\[ **d** \\]" (agent-shell-markdown-math))
+                     (" e" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-delimiters-disabled ()
+  ;; An empty `agent-shell-markdown-math-delimiters' disables math
+  ;; rendering entirely: delimiters are plain text and inner markup
+  ;; is processed normally.
+  (let ((agent-shell-markdown-math-delimiters '()))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "x \\[ **y** \\] z"))
+                   '(("x \\[ " nil)
+                     ("y" (agent-shell-markdown-bold))
+                     (" \\] z" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-no-cross-delimiter-nesting ()
+  ;; A `$$' inside a `\\[...\\]' block is body, not a delimiter: the
+  ;; block runs to the matching `\\]' and is one math-faced run.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[ a $$ b \\]"))
+                 '(("\\[ a $$ b \\]" (agent-shell-markdown-math))))))
+
+(ert-deftest agent-shell-markdown-convert-math-multiline-body ()
+  ;; LaTeX allows newlines (but not blank lines) inside display math,
+  ;; so `\\[\\nE=mc^2\\n\\]' renders as one block.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[
+E=mc^2
+\\]"))
+                 '(("\\[
+E=mc^2
+\\]" (agent-shell-markdown-math))))))
+
+(ert-deftest agent-shell-markdown-convert-math-blank-line-rejected ()
+  ;; A blank line can't appear inside LaTeX display math, so a block
+  ;; whose body would span one is rejected (left as plain text rather
+  ;; than mis-rendered as a single equation).
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[
+E=mc^2
+
+extra
+\\]"))
+                 '(("\\[
+E=mc^2
+
+extra
+\\]" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-math-stray-opener-recovers-real-blocks ()
+  ;; A stray opener that never closes before a blank line is a false
+  ;; positive, but scanning resumes just after it — so a real block
+  ;; sitting between the stray opener and the blank line is still
+  ;; rendered (rather than swallowed and lost).
+  (agent-shell-markdown-math-tests--with-dollar
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "\\[ oops and $$E=mc^2$$ here
+
+next"))
+                   '(("\\[ oops and " nil)
+                     ("$$E=mc^2$$" (agent-shell-markdown-math))
+                     (" here
+
+next" nil))))))
+
+(provide 'agent-shell-markdown-math-tests)
+
+;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -322,6 +322,23 @@ E=mc^2
     (let ((agent-shell-markdown-math-render-on-non-graphic t))
       (should-not (agent-shell-markdown--math-renderable-p)))))
 
+(ert-deftest agent-shell-markdown-math-refresh-buffer-revisits-each-region ()
+  ;; A refresh hands every `agent-shell-markdown-math-source' region
+  ;; back to --math-render (with its own latex), so a theme change
+  ;; re-tints all equations.  Stub --math-render to record the visits.
+  (let ((calls '()))
+    (cl-letf (((symbol-function 'agent-shell-markdown--math-render)
+               (lambda (_buffer start end latex)
+                 (push (list start end latex) calls))))
+      (with-temp-buffer
+        (insert "first eq then second eq")
+        ;; Two separate math-source regions with distinct latex.
+        (put-text-property 1 6 'agent-shell-markdown-math-source "A")
+        (put-text-property 15 21 'agent-shell-markdown-math-source "B")
+        (agent-shell-markdown-math--refresh-buffer (current-buffer))))
+    (should (equal (nreverse calls)
+                   '((1 6 "A") (15 21 "B"))))))
+
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
   ;; The cache key must be stable for identical inputs and differ when the
   ;; equation, colour, or scale changes — otherwise cached SVGs collide or

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -591,6 +591,49 @@ x
         (agent-shell-markdown-math--refresh-if-changed))
       (should-not refreshed))))
 
+(ert-deftest agent-shell-markdown-math-image-cache-key-includes-scale ()
+  ;; The in-memory image-cache key folds in the display scale, so the same
+  ;; equation at two font sizes maps to two distinct entries.
+  (should (equal (agent-shell-markdown--math-image-cache-key "K" 0.8)
+                 (agent-shell-markdown--math-image-cache-key "K" 0.8)))
+  (should-not (equal (agent-shell-markdown--math-image-cache-key "K" 0.8)
+                     (agent-shell-markdown--math-image-cache-key "K" 1.5))))
+
+(ert-deftest agent-shell-markdown-math-image-cache-coexists-per-scale ()
+  ;; The same on-disk SVG cached at two display scales yields two distinct
+  ;; image objects that coexist: the first stays warm after the second is
+  ;; created (so a sibling buffer's images survive a font change — no clear).
+  (let ((tmp (make-temp-file "asm-svg" nil ".svg")))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (insert "<svg xmlns='http://www.w3.org/2000/svg' "
+                    "width='10pt' height='10pt'>"
+                    "<rect width='10' height='10'/></svg>"))
+          (clrhash agent-shell-markdown-math--image-cache)
+          (cl-letf (((symbol-function 'agent-shell-markdown--math-svg-file)
+                     (lambda (_key) tmp)))
+            (let (img1 img2)
+              (cl-letf (((symbol-function 'agent-shell-markdown--math-display-scale)
+                         (lambda () 0.8)))
+                (setq img1 (agent-shell-markdown--math-cached-image "K")))
+              (cl-letf (((symbol-function 'agent-shell-markdown--math-display-scale)
+                         (lambda () 1.5)))
+                (setq img2 (agent-shell-markdown--math-cached-image "K")))
+              (should img1)
+              (should img2)
+              ;; Two coexisting entries, one per scale.
+              (should (= 2 (hash-table-count
+                            agent-shell-markdown-math--image-cache)))
+              ;; The first is still served from cache (warm, not evicted).
+              (cl-letf (((symbol-function 'agent-shell-markdown--math-display-scale)
+                         (lambda () 0.8)))
+                (should (eq img1 (agent-shell-markdown--math-cached-image "K"))))
+              ;; Each image carries its own scale.
+              (should (equal (image-property img1 :scale) 0.8))
+              (should (equal (image-property img2 :scale) 1.5)))))
+      (delete-file tmp))))
+
 (provide 'agent-shell-markdown-math-tests)
 
 ;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -24,13 +24,23 @@
                              (file-name-directory
                               (or load-file-name buffer-file-name))))
 
-(defmacro agent-shell-markdown-math-tests--with-dollar (&rest body)
-  "Evaluate BODY with `$$...$$' display math enabled.
-`agent-shell-markdown-math-delimiters' defaults to `bracket' only,
-so the dollar-delimited tests opt into `dollar' through this one
-binding rather than repeating it in each test."
+(defmacro agent-shell-markdown-math-tests--enabled (&rest body)
+  "Evaluate BODY with math rendering enabled.
+`agent-shell-markdown-render-math' (the master switch) defaults to
+nil, so every test that expects equations to render must opt in;
+this binds it for the default delimiter set (`bracket')."
   (declare (indent 0) (debug t))
-  `(let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
+  `(let ((agent-shell-markdown-render-math t))
+     ,@body))
+
+(defmacro agent-shell-markdown-math-tests--with-dollar (&rest body)
+  "Evaluate BODY with math rendering on and `$$...$$' enabled.
+`agent-shell-markdown-math-delimiters' defaults to `bracket' only,
+so the dollar-delimited tests opt into `dollar' (and the master
+`agent-shell-markdown-render-math' switch) through this one binding."
+  (declare (indent 0) (debug t))
+  `(let ((agent-shell-markdown-render-math t)
+         (agent-shell-markdown-math-delimiters '(dollar bracket)))
      ,@body))
 
 (ert-deftest agent-shell-markdown-convert-display-math-protects-markup ()
@@ -97,29 +107,32 @@ $$ x $$
 (ert-deftest agent-shell-markdown-convert-bracket-math-protects-markup ()
   ;; A complete `\\[...\\]' block is recognized as display math and
   ;; faced `agent-shell-markdown-math', keeping its interior literal.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before \\[ **x** \\] after"))
-                 '(("before " nil)
-                   ("\\[ **x** \\]" (agent-shell-markdown-math))
-                   (" after" nil)))))
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before \\[ **x** \\] after"))
+                   '(("before " nil)
+                     ("\\[ **x** \\]" (agent-shell-markdown-math))
+                     (" after" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-open-bracket-math-protects-rest ()
   ;; An unclosed `\\[' protects the rest of the buffer until the
   ;; closing `\\]' arrives, mirroring open `$$' / open fences.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before **b** \\[ streaming **not bold**"))
-                 '(("before " nil)
-                   ("b" (agent-shell-markdown-bold))
-                   (" \\[ streaming **not bold**" nil)))))
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before **b** \\[ streaming **not bold**"))
+                   '(("before " nil)
+                     ("b" (agent-shell-markdown-bold))
+                     (" \\[ streaming **not bold**" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-math-delimiters-independent ()
   ;; `agent-shell-markdown-math-delimiters' toggles each style
   ;; independently: with only `bracket' enabled, `\\[...\\]' renders
   ;; while `$$...$$' is left as plain text (and its `**' inside is
   ;; processed as ordinary markup).
-  (let ((agent-shell-markdown-math-delimiters '(bracket)))
+  (let ((agent-shell-markdown-render-math t)
+        (agent-shell-markdown-math-delimiters '(bracket)))
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
                      "a $$ **b** $$ c \\[ **d** \\] e"))
@@ -130,10 +143,11 @@ $$ x $$
                      (" e" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-math-delimiters-disabled ()
-  ;; An empty `agent-shell-markdown-math-delimiters' disables math
-  ;; rendering entirely: delimiters are plain text and inner markup
-  ;; is processed normally.
-  (let ((agent-shell-markdown-math-delimiters '()))
+  ;; An empty `agent-shell-markdown-math-delimiters' disables the
+  ;; delimiter styles even with the master switch on: delimiters are
+  ;; plain text and inner markup is processed normally.
+  (let ((agent-shell-markdown-render-math t)
+        (agent-shell-markdown-math-delimiters '()))
     (should (equal (agent-shell-markdown--deconstruct
                     (agent-shell-markdown-convert
                      "x \\[ **y** \\] z"))
@@ -144,39 +158,42 @@ $$ x $$
 (ert-deftest agent-shell-markdown-convert-math-no-cross-delimiter-nesting ()
   ;; A `$$' inside a `\\[...\\]' block is body, not a delimiter: the
   ;; block runs to the matching `\\]' and is one math-faced run.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[ a $$ b \\]"))
-                 '(("\\[ a $$ b \\]" (agent-shell-markdown-math))))))
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "\\[ a $$ b \\]"))
+                   '(("\\[ a $$ b \\]" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-math-multiline-body ()
   ;; LaTeX allows newlines (but not blank lines) inside display math,
   ;; so `\\[\\nE=mc^2\\n\\]' renders as one block.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "\\[
 E=mc^2
 \\]"))
-                 '(("\\[
+                   '(("\\[
 E=mc^2
-\\]" (agent-shell-markdown-math))))))
+\\]" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-math-blank-line-rejected ()
   ;; A blank line can't appear inside LaTeX display math, so a block
   ;; whose body would span one is rejected (left as plain text rather
   ;; than mis-rendered as a single equation).
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "\\[
 E=mc^2
 
 extra
 \\]"))
-                 '(("\\[
+                   '(("\\[
 E=mc^2
 
 extra
-\\]" nil)))))
+\\]" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-math-stray-opener-recovers-real-blocks ()
   ;; A stray opener that never closes before a blank line is a false
@@ -194,6 +211,71 @@ next"))
                      (" here
 
 next" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-fenced-math-renders ()
+  ;; A ```math fence renders as display math: the fences are stripped
+  ;; and the body is math-faced (the trailing newline stays plain).
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "```math
+E=mc^2
+```"))
+                   '(("E=mc^2" (agent-shell-markdown-math))
+                     ("
+" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-fenced-latex-renders ()
+  ;; A ```latex fence is also treated as display math.
+  (agent-shell-markdown-math-tests--enabled
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "```latex
+E=mc^2
+```"))
+                   '(("E=mc^2" (agent-shell-markdown-math))
+                     ("
+" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-fenced-non-math-stays-code ()
+  ;; A non-math language fence is unaffected by math rendering — it
+  ;; still renders as a code block (no math face), even with the
+  ;; master switch on.
+  (agent-shell-markdown-math-tests--enabled
+    (let ((runs (agent-shell-markdown--deconstruct
+                 (agent-shell-markdown-convert "```python
+x = 1
+```"))))
+      (should-not (seq-some (lambda (run)
+                              (memq 'agent-shell-markdown-math (cadr run)))
+                            runs))
+      (should (seq-some (lambda (run)
+                          (memq 'agent-shell-markdown-source-block (cadr run)))
+                        runs)))))
+
+(ert-deftest agent-shell-markdown-convert-math-master-switch-off ()
+  ;; With the master switch off (the default), `\\[...\\]' is plain
+  ;; text and its inner markup is processed normally (here `**x**'
+  ;; becomes bold) — math rendering is fully gated.
+  (let ((agent-shell-markdown-render-math nil))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert "before \\[ **x** \\] after"))
+                   '(("before \\[ " nil)
+                     ("x" (agent-shell-markdown-bold))
+                     (" \\] after" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-fenced-math-as-code-when-off ()
+  ;; With the master switch off, a ```math fence is left as an ordinary
+  ;; code block (source-block face), not a math equation.
+  (let* ((agent-shell-markdown-render-math nil)
+         (runs (agent-shell-markdown--deconstruct
+                (agent-shell-markdown-convert "```math
+E=mc^2
+```"))))
+    (should-not (seq-some (lambda (run)
+                            (memq 'agent-shell-markdown-math (cadr run)))
+                          runs))
+    (should (seq-some (lambda (run)
+                        (memq 'agent-shell-markdown-source-block (cadr run)))
+                      runs))))
 
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
   ;; The cache key must be stable for identical inputs and differ when the

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -363,21 +363,20 @@ E=mc^2
                    '((1 6 "A") (15 21 "B"))))))
 
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
-  ;; The cache key must be stable for identical inputs and differ when the
-  ;; equation or colour changes — otherwise cached SVGs collide or never
-  ;; hit.  (Pure function; no TeX or graphical display needed.)  Display
-  ;; size is NOT part of this key (the on-disk SVG is font-independent).
-  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
-    (should (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
-    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^3" "#000000")))
-    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2" "#ffffff")))))
+  ;; The content key must be stable for identical inputs and differ when the
+  ;; equation changes — otherwise cached SVGs collide or never hit.  (Pure
+  ;; function; no TeX or graphical display needed.)  Neither display size
+  ;; NOR color is part of this key: the on-disk SVG is font-independent and
+  ;; color-independent (compiled with --currentcolor, tinted at display).
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2")))
+    (should (equal base (agent-shell-markdown--math-cache-key "E=mc^2")))
+    (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^3")))))
 
 (ert-deftest agent-shell-markdown-math-cache-key-folds-in-preamble ()
   ;; Changing the preamble must invalidate the cache (different output).
-  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2" "#000000")))
+  (let ((base (agent-shell-markdown--math-cache-key "E=mc^2")))
     (let ((agent-shell-markdown-math-preamble "\\documentclass{minimal}"))
-      (should-not (equal base (agent-shell-markdown--math-cache-key
-                               "E=mc^2" "#000000"))))))
+      (should-not (equal base (agent-shell-markdown--math-cache-key "E=mc^2"))))))
 
 (ert-deftest agent-shell-markdown-convert-inline-math-protects-markup ()
   ;; Inline `\\(...\\)' is matched anywhere on a line (not just block
@@ -484,10 +483,10 @@ x
   ;; Inline and display renders of the same source must not collide:
   ;; the inline flag changes the key, while the default (display) key is
   ;; unchanged from the no-flag form.
-  (should (equal (agent-shell-markdown--math-cache-key "x" "#000000")
-                 (agent-shell-markdown--math-cache-key "x" "#000000" nil)))
-  (should-not (equal (agent-shell-markdown--math-cache-key "x" "#000000")
-                     (agent-shell-markdown--math-cache-key "x" "#000000" t))))
+  (should (equal (agent-shell-markdown--math-cache-key "x")
+                 (agent-shell-markdown--math-cache-key "x" nil)))
+  (should-not (equal (agent-shell-markdown--math-cache-key "x")
+                     (agent-shell-markdown--math-cache-key "x" t))))
 
 (ert-deftest agent-shell-markdown-math-cache-dir-uses-agent-shell-cache ()
   ;; By default the equation cache lives under agent-shell's shared cache
@@ -612,13 +611,32 @@ x
   (should (memq 'agent-shell-markdown-math--maybe-refresh
                 (default-value 'text-scale-mode-hook))))
 
-(ert-deftest agent-shell-markdown-math-image-cache-key-includes-scale ()
-  ;; The in-memory image-cache key folds in the display scale, so the same
-  ;; equation at two font sizes maps to two distinct entries.
-  (should (equal (agent-shell-markdown--math-image-cache-key "K" 0.8)
-                 (agent-shell-markdown--math-image-cache-key "K" 0.8)))
-  (should-not (equal (agent-shell-markdown--math-image-cache-key "K" 0.8)
-                     (agent-shell-markdown--math-image-cache-key "K" 1.5))))
+(ert-deftest agent-shell-markdown-math-image-cache-key-includes-scale-and-color ()
+  ;; The in-memory image-cache key folds in BOTH the display scale and the
+  ;; tint color, so the same equation at two font sizes or two themes maps
+  ;; to distinct entries (the on-disk SVG is shared).
+  (should (equal (agent-shell-markdown--math-image-cache-key "K" 0.8 "#fff")
+                 (agent-shell-markdown--math-image-cache-key "K" 0.8 "#fff")))
+  (should-not (equal (agent-shell-markdown--math-image-cache-key "K" 0.8 "#fff")
+                     (agent-shell-markdown--math-image-cache-key "K" 1.5 "#fff")))
+  (should-not (equal (agent-shell-markdown--math-image-cache-key "K" 0.8 "#fff")
+                     (agent-shell-markdown--math-image-cache-key "K" 0.8 "#000"))))
+
+(ert-deftest agent-shell-markdown-math-load-svg-recolors-currentcolor ()
+  ;; The on-disk SVG carries `currentColor'; loading substitutes the given
+  ;; foreground in, so the image is tinted without recompiling.
+  (let ((tmp (make-temp-file "asm-cc" nil ".svg")))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (insert "<svg xmlns='http://www.w3.org/2000/svg'>"
+                    "<path fill='currentColor' d='M0 0h1v1z'/></svg>"))
+          (let ((data (image-property
+                       (agent-shell-markdown--math-load-svg-image tmp 1.0 "#abcdef")
+                       :data)))
+            (should (string-match-p "#abcdef" data))
+            (should-not (string-match-p "currentColor" data))))
+      (delete-file tmp))))
 
 (ert-deftest agent-shell-markdown-math-image-cache-coexists-per-scale ()
   ;; The same on-disk SVG cached at two display scales yields two distinct

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -322,6 +322,29 @@ E=mc^2
     (let ((agent-shell-markdown-math-render-on-non-graphic t))
       (should-not (agent-shell-markdown--math-renderable-p)))))
 
+(ert-deftest agent-shell-markdown-convert-math-degrades-without-svg ()
+  ;; On a build without SVG support, math rendering degrades gracefully:
+  ;; even on a graphical frame and with the feature on, equations are still
+  ;; recognized and faced (markup protected), but no image is overlaid and
+  ;; conversion never errors — the raw LaTeX simply shows as faced text.
+  ;; (A user who doesn't want even that sets `agent-shell-markdown-render-math'
+  ;; to nil; there is deliberately no PNG fallback.)
+  (agent-shell-markdown-math-tests--enabled
+    (cl-letf (((symbol-function 'image-type-available-p) (lambda (_) nil))
+              ((symbol-function 'display-graphic-p) (lambda (&rest _) t)))
+      ;; Block-level display math: faced, no image.
+      (should (equal (agent-shell-markdown--deconstruct
+                      (agent-shell-markdown-convert "\\[ E=mc^2 \\]"))
+                     '(("\\[ E=mc^2 \\]" (agent-shell-markdown-math)))))
+      ;; Inline math: faced, and crucially no `display' image property
+      ;; anywhere (nothing was overlaid).
+      (let ((out (agent-shell-markdown-convert "a \\(x^2\\) b")))
+        (should (equal (agent-shell-markdown--deconstruct out)
+                       '(("a " nil)
+                         ("\\(x^2\\)" (agent-shell-markdown-math))
+                         (" b" nil))))
+        (should-not (text-property-not-all 0 (length out) 'display nil out))))))
+
 (ert-deftest agent-shell-markdown-math-refresh-buffer-revisits-each-region ()
   ;; A refresh hands every `agent-shell-markdown-math-source' region
   ;; back to --math-render (with its own latex), so a theme change

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -304,6 +304,24 @@ E=mc^2
                         (memq 'agent-shell-markdown-source-block (cadr run)))
                       runs))))
 
+(ert-deftest agent-shell-markdown-math-renderable-p-honors-non-graphic-opt-in ()
+  ;; Renderability requires SVG build support, and then either a
+  ;; graphical frame or the non-graphic opt-in (for daemon use).
+  (cl-letf (((symbol-function 'image-type-available-p) (lambda (_) t)))
+    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) nil)))
+      (let ((agent-shell-markdown-math-render-on-non-graphic nil))
+        (should-not (agent-shell-markdown--math-renderable-p)))
+      (let ((agent-shell-markdown-math-render-on-non-graphic t))
+        (should (agent-shell-markdown--math-renderable-p))))
+    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t)))
+      (let ((agent-shell-markdown-math-render-on-non-graphic nil))
+        (should (agent-shell-markdown--math-renderable-p)))))
+  ;; No SVG support in the build => never renderable, even with the opt-in.
+  (cl-letf (((symbol-function 'image-type-available-p) (lambda (_) nil))
+            ((symbol-function 'display-graphic-p) (lambda (&rest _) t)))
+    (let ((agent-shell-markdown-math-render-on-non-graphic t))
+      (should-not (agent-shell-markdown--math-renderable-p)))))
+
 (ert-deftest agent-shell-markdown-math-cache-key-distinguishes-inputs ()
   ;; The cache key must be stable for identical inputs and differ when the
   ;; equation, colour, or scale changes — otherwise cached SVGs collide or

--- a/tests/agent-shell-markdown-math-tests.el
+++ b/tests/agent-shell-markdown-math-tests.el
@@ -466,6 +466,34 @@ x
   (should-not (equal (agent-shell-markdown--math-cache-key "x" "#000000" 1.4)
                      (agent-shell-markdown--math-cache-key "x" "#000000" 1.4 t))))
 
+(ert-deftest agent-shell-markdown-math-cache-dir-uses-agent-shell-cache ()
+  ;; By default the equation cache lives under agent-shell's shared cache
+  ;; directory (so SVGs persist across sessions next to other cached
+  ;; assets).  `agent-shell.el' isn't loaded by this renderer-only test
+  ;; harness, so stub the helper — exactly the seam the production code
+  ;; relies on agent-shell.el providing in a real session.
+  (let ((agent-shell-markdown-math-cache-directory nil)
+        (tmp (make-temp-file "asm-cache" t)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-shell--cache-dir)
+                   (lambda (&rest components)
+                     (apply #'file-name-concat tmp components))))
+          (should (equal (agent-shell-markdown--math-cache-dir)
+                         (file-name-concat tmp "markdown-math"))))
+      (delete-directory tmp t))))
+
+(ert-deftest agent-shell-markdown-math-cache-dir-honors-explicit-override ()
+  ;; An explicit `agent-shell-markdown-math-cache-directory' wins over the
+  ;; shared default and is created on demand.
+  (let* ((parent (make-temp-file "asm-cache-override" t))
+         (dir (file-name-concat parent "eqs"))
+         (agent-shell-markdown-math-cache-directory dir))
+    (unwind-protect
+        (progn
+          (should (equal (agent-shell-markdown--math-cache-dir) dir))
+          (should (file-directory-p dir)))
+      (delete-directory parent t))))
+
 (provide 'agent-shell-markdown-math-tests)
 
 ;;; agent-shell-markdown-math-tests.el ends here

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -297,6 +297,52 @@ $$ x $$
                    "\\[ a $$ b \\]"))
                  '(("\\[ a $$ b \\]" (agent-shell-markdown-math))))))
 
+(ert-deftest agent-shell-markdown-convert-math-multiline-body ()
+  ;; LaTeX allows newlines (but not blank lines) inside display math,
+  ;; so `\\[\\nE=mc^2\\n\\]' renders as one block.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[
+E=mc^2
+\\]"))
+                 '(("\\[
+E=mc^2
+\\]" (agent-shell-markdown-math))))))
+
+(ert-deftest agent-shell-markdown-convert-math-blank-line-rejected ()
+  ;; A blank line can't appear inside LaTeX display math, so a block
+  ;; whose body would span one is rejected (left as plain text rather
+  ;; than mis-rendered as a single equation).
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[
+E=mc^2
+
+extra
+\\]"))
+                 '(("\\[
+E=mc^2
+
+extra
+\\]" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-math-stray-opener-recovers-real-blocks ()
+  ;; A stray opener that never closes before a blank line is a false
+  ;; positive, but scanning resumes just after it — so a real block
+  ;; sitting between the stray opener and the blank line is still
+  ;; rendered (rather than swallowed and lost).
+  (let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "\\[ oops and $$E=mc^2$$ here
+
+next"))
+                   '(("\\[ oops and " nil)
+                     ("$$E=mc^2$$" (agent-shell-markdown-math))
+                     (" here
+
+next" nil))))))
+
 (ert-deftest agent-shell-markdown-convert-open-inline-code-protects-rest-of-line ()
   (should (equal (agent-shell-markdown--deconstruct
                   (agent-shell-markdown-convert

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -173,6 +173,63 @@ streaming **not bold**"))
 ```
 streaming **not bold**" nil)))))
 
+(ert-deftest agent-shell-markdown-convert-display-math-protects-markup ()
+  ;; A complete `$$...$$' block is faced `agent-shell-markdown-math'
+  ;; as a single run; the LaTeX source is kept literal (no bold /
+  ;; italic / subscript processing of its interior).  On the
+  ;; non-graphical batch display no equation image is overlaid, so
+  ;; `--deconstruct' sees only the math face.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before $$ **x** $$ after"))
+                 '(("before " nil)
+                   ("$$ **x** $$" (agent-shell-markdown-math))
+                   (" after" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-display-math-block ()
+  ;; Multi-line block form: the whole `$$\\n...\\n$$' region is one
+  ;; math-faced run.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "$$
+E=mc^2
+$$"))
+                 '(("$$
+E=mc^2
+$$" (agent-shell-markdown-math))))))
+
+(ert-deftest agent-shell-markdown-convert-open-math-protects-rest ()
+  ;; An unclosed `$$' protects the rest of the buffer as still
+  ;; streaming, just like an open fence: markup after it is left raw
+  ;; until the closing `$$' arrives.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before **b**
+$$
+streaming **not bold**"))
+                 '(("before " nil)
+                   ("b" (agent-shell-markdown-bold))
+                   ("
+$$
+streaming **not bold**" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-display-math-in-fenced-block-untouched ()
+  ;; A `$$' inside a fenced code block is body text, not display
+  ;; math: it must not get the math face.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "```
+$$ x $$
+```"))
+                 '(("
+" (agent-shell-markdown-source-block))
+                   ("snippet ⧉" (agent-shell-markdown-source-block-language))
+                   ("
+
+$$ x $$
+
+" (agent-shell-markdown-source-block))))))
+
 (ert-deftest agent-shell-markdown-convert-open-inline-code-protects-rest-of-line ()
   (should (equal (agent-shell-markdown--deconstruct
                   (agent-shell-markdown-convert

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -12,18 +12,13 @@
 (require 'cl-lib)
 (require 'ert)
 
+(add-to-list 'load-path
+             (expand-file-name ".." (file-name-directory
+                                     (or load-file-name buffer-file-name))))
+
 (load-file (expand-file-name "../agent-shell-markdown.el"
                              (file-name-directory
                               (or load-file-name buffer-file-name))))
-
-(defmacro agent-shell-markdown-tests--with-dollar-math (&rest body)
-  "Evaluate BODY with `$$...$$' display math enabled.
-`agent-shell-markdown-math-delimiters' defaults to `bracket' only,
-so the dollar-delimited tests opt into `dollar' through this one
-binding rather than repeating it in each test."
-  (declare (indent 0) (debug t))
-  `(let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
-     ,@body))
 
 (ert-deftest agent-shell-markdown-convert-bold ()
   (should (equal (agent-shell-markdown--deconstruct
@@ -181,167 +176,6 @@ streaming **not bold**"))
                    ("
 ```
 streaming **not bold**" nil)))))
-
-(ert-deftest agent-shell-markdown-convert-display-math-protects-markup ()
-  ;; A complete `$$...$$' block is faced `agent-shell-markdown-math'
-  ;; as a single run; the LaTeX source is kept literal (no bold /
-  ;; italic / subscript processing of its interior).  On the
-  ;; non-graphical batch display no equation image is overlaid, so
-  ;; `--deconstruct' sees only the math face.
-  (agent-shell-markdown-tests--with-dollar-math
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "before $$ **x** $$ after"))
-                   '(("before " nil)
-                     ("$$ **x** $$" (agent-shell-markdown-math))
-                     (" after" nil))))))
-
-(ert-deftest agent-shell-markdown-convert-display-math-block ()
-  ;; Multi-line block form: the whole `$$\\n...\\n$$' region is one
-  ;; math-faced run.
-  (agent-shell-markdown-tests--with-dollar-math
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "$$
-E=mc^2
-$$"))
-                   '(("$$
-E=mc^2
-$$" (agent-shell-markdown-math)))))))
-
-(ert-deftest agent-shell-markdown-convert-open-math-protects-rest ()
-  ;; An unclosed `$$' protects the rest of the buffer as still
-  ;; streaming, just like an open fence: markup after it is left raw
-  ;; until the closing `$$' arrives.
-  (agent-shell-markdown-tests--with-dollar-math
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "before **b**
-$$
-streaming **not bold**"))
-                   '(("before " nil)
-                     ("b" (agent-shell-markdown-bold))
-                     ("
-$$
-streaming **not bold**" nil))))))
-
-(ert-deftest agent-shell-markdown-convert-display-math-in-fenced-block-untouched ()
-  ;; A `$$' inside a fenced code block is body text, not display
-  ;; math: it must not get the math face.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "```
-$$ x $$
-```"))
-                 '(("
-" (agent-shell-markdown-source-block))
-                   ("snippet ⧉" (agent-shell-markdown-source-block-language))
-                   ("
-
-$$ x $$
-
-" (agent-shell-markdown-source-block))))))
-
-(ert-deftest agent-shell-markdown-convert-bracket-math-protects-markup ()
-  ;; A complete `\\[...\\]' block is recognized as display math and
-  ;; faced `agent-shell-markdown-math', keeping its interior literal.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before \\[ **x** \\] after"))
-                 '(("before " nil)
-                   ("\\[ **x** \\]" (agent-shell-markdown-math))
-                   (" after" nil)))))
-
-(ert-deftest agent-shell-markdown-convert-open-bracket-math-protects-rest ()
-  ;; An unclosed `\\[' protects the rest of the buffer until the
-  ;; closing `\\]' arrives, mirroring open `$$' / open fences.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before **b** \\[ streaming **not bold**"))
-                 '(("before " nil)
-                   ("b" (agent-shell-markdown-bold))
-                   (" \\[ streaming **not bold**" nil)))))
-
-(ert-deftest agent-shell-markdown-convert-math-delimiters-independent ()
-  ;; `agent-shell-markdown-math-delimiters' toggles each style
-  ;; independently: with only `bracket' enabled, `\\[...\\]' renders
-  ;; while `$$...$$' is left as plain text (and its `**' inside is
-  ;; processed as ordinary markup).
-  (let ((agent-shell-markdown-math-delimiters '(bracket)))
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "a $$ **b** $$ c \\[ **d** \\] e"))
-                   '(("a $$ " nil)
-                     ("b" (agent-shell-markdown-bold))
-                     (" $$ c " nil)
-                     ("\\[ **d** \\]" (agent-shell-markdown-math))
-                     (" e" nil))))))
-
-(ert-deftest agent-shell-markdown-convert-math-delimiters-disabled ()
-  ;; An empty `agent-shell-markdown-math-delimiters' disables math
-  ;; rendering entirely: delimiters are plain text and inner markup
-  ;; is processed normally.
-  (let ((agent-shell-markdown-math-delimiters '()))
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "x \\[ **y** \\] z"))
-                   '(("x \\[ " nil)
-                     ("y" (agent-shell-markdown-bold))
-                     (" \\] z" nil))))))
-
-(ert-deftest agent-shell-markdown-convert-math-no-cross-delimiter-nesting ()
-  ;; A `$$' inside a `\\[...\\]' block is body, not a delimiter: the
-  ;; block runs to the matching `\\]' and is one math-faced run.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[ a $$ b \\]"))
-                 '(("\\[ a $$ b \\]" (agent-shell-markdown-math))))))
-
-(ert-deftest agent-shell-markdown-convert-math-multiline-body ()
-  ;; LaTeX allows newlines (but not blank lines) inside display math,
-  ;; so `\\[\\nE=mc^2\\n\\]' renders as one block.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[
-E=mc^2
-\\]"))
-                 '(("\\[
-E=mc^2
-\\]" (agent-shell-markdown-math))))))
-
-(ert-deftest agent-shell-markdown-convert-math-blank-line-rejected ()
-  ;; A blank line can't appear inside LaTeX display math, so a block
-  ;; whose body would span one is rejected (left as plain text rather
-  ;; than mis-rendered as a single equation).
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "\\[
-E=mc^2
-
-extra
-\\]"))
-                 '(("\\[
-E=mc^2
-
-extra
-\\]" nil)))))
-
-(ert-deftest agent-shell-markdown-convert-math-stray-opener-recovers-real-blocks ()
-  ;; A stray opener that never closes before a blank line is a false
-  ;; positive, but scanning resumes just after it — so a real block
-  ;; sitting between the stray opener and the blank line is still
-  ;; rendered (rather than swallowed and lost).
-  (let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
-    (should (equal (agent-shell-markdown--deconstruct
-                    (agent-shell-markdown-convert
-                     "\\[ oops and $$E=mc^2$$ here
-
-next"))
-                   '(("\\[ oops and " nil)
-                     ("$$E=mc^2$$" (agent-shell-markdown-math))
-                     (" here
-
-next" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-open-inline-code-protects-rest-of-line ()
   (should (equal (agent-shell-markdown--deconstruct

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -16,6 +16,15 @@
                              (file-name-directory
                               (or load-file-name buffer-file-name))))
 
+(defmacro agent-shell-markdown-tests--with-dollar-math (&rest body)
+  "Evaluate BODY with `$$...$$' display math enabled.
+`agent-shell-markdown-math-delimiters' defaults to `bracket' only,
+so the dollar-delimited tests opt into `dollar' through this one
+binding rather than repeating it in each test."
+  (declare (indent 0) (debug t))
+  `(let ((agent-shell-markdown-math-delimiters '(dollar bracket)))
+     ,@body))
+
 (ert-deftest agent-shell-markdown-convert-bold ()
   (should (equal (agent-shell-markdown--deconstruct
                   (agent-shell-markdown-convert "hello **world**"))
@@ -179,39 +188,42 @@ streaming **not bold**" nil)))))
   ;; italic / subscript processing of its interior).  On the
   ;; non-graphical batch display no equation image is overlaid, so
   ;; `--deconstruct' sees only the math face.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before $$ **x** $$ after"))
-                 '(("before " nil)
-                   ("$$ **x** $$" (agent-shell-markdown-math))
-                   (" after" nil)))))
+  (agent-shell-markdown-tests--with-dollar-math
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before $$ **x** $$ after"))
+                   '(("before " nil)
+                     ("$$ **x** $$" (agent-shell-markdown-math))
+                     (" after" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-display-math-block ()
   ;; Multi-line block form: the whole `$$\\n...\\n$$' region is one
   ;; math-faced run.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "$$
+  (agent-shell-markdown-tests--with-dollar-math
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "$$
 E=mc^2
 $$"))
-                 '(("$$
+                   '(("$$
 E=mc^2
-$$" (agent-shell-markdown-math))))))
+$$" (agent-shell-markdown-math)))))))
 
 (ert-deftest agent-shell-markdown-convert-open-math-protects-rest ()
   ;; An unclosed `$$' protects the rest of the buffer as still
   ;; streaming, just like an open fence: markup after it is left raw
   ;; until the closing `$$' arrives.
-  (should (equal (agent-shell-markdown--deconstruct
-                  (agent-shell-markdown-convert
-                   "before **b**
+  (agent-shell-markdown-tests--with-dollar-math
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "before **b**
 $$
 streaming **not bold**"))
-                 '(("before " nil)
-                   ("b" (agent-shell-markdown-bold))
-                   ("
+                   '(("before " nil)
+                     ("b" (agent-shell-markdown-bold))
+                     ("
 $$
-streaming **not bold**" nil)))))
+streaming **not bold**" nil))))))
 
 (ert-deftest agent-shell-markdown-convert-display-math-in-fenced-block-untouched ()
   ;; A `$$' inside a fenced code block is body text, not display
@@ -229,6 +241,61 @@ $$ x $$
 $$ x $$
 
 " (agent-shell-markdown-source-block))))))
+
+(ert-deftest agent-shell-markdown-convert-bracket-math-protects-markup ()
+  ;; A complete `\\[...\\]' block is recognized as display math and
+  ;; faced `agent-shell-markdown-math', keeping its interior literal.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before \\[ **x** \\] after"))
+                 '(("before " nil)
+                   ("\\[ **x** \\]" (agent-shell-markdown-math))
+                   (" after" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-open-bracket-math-protects-rest ()
+  ;; An unclosed `\\[' protects the rest of the buffer until the
+  ;; closing `\\]' arrives, mirroring open `$$' / open fences.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "before **b** \\[ streaming **not bold**"))
+                 '(("before " nil)
+                   ("b" (agent-shell-markdown-bold))
+                   (" \\[ streaming **not bold**" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-math-delimiters-independent ()
+  ;; `agent-shell-markdown-math-delimiters' toggles each style
+  ;; independently: with only `bracket' enabled, `\\[...\\]' renders
+  ;; while `$$...$$' is left as plain text (and its `**' inside is
+  ;; processed as ordinary markup).
+  (let ((agent-shell-markdown-math-delimiters '(bracket)))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "a $$ **b** $$ c \\[ **d** \\] e"))
+                   '(("a $$ " nil)
+                     ("b" (agent-shell-markdown-bold))
+                     (" $$ c " nil)
+                     ("\\[ **d** \\]" (agent-shell-markdown-math))
+                     (" e" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-delimiters-disabled ()
+  ;; An empty `agent-shell-markdown-math-delimiters' disables math
+  ;; rendering entirely: delimiters are plain text and inner markup
+  ;; is processed normally.
+  (let ((agent-shell-markdown-math-delimiters '()))
+    (should (equal (agent-shell-markdown--deconstruct
+                    (agent-shell-markdown-convert
+                     "x \\[ **y** \\] z"))
+                   '(("x \\[ " nil)
+                     ("y" (agent-shell-markdown-bold))
+                     (" \\] z" nil))))))
+
+(ert-deftest agent-shell-markdown-convert-math-no-cross-delimiter-nesting ()
+  ;; A `$$' inside a `\\[...\\]' block is body, not a delimiter: the
+  ;; block runs to the matching `\\]' and is one math-faced run.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert
+                   "\\[ a $$ b \\]"))
+                 '(("\\[ a $$ b \\]" (agent-shell-markdown-math))))))
 
 (ert-deftest agent-shell-markdown-convert-open-inline-code-protects-rest-of-line ()
   (should (equal (agent-shell-markdown--deconstruct


### PR DESCRIPTION
This is not a PR in the strict sense -- it's a demo submission of a new feature. I'll call it a PR for brevity.

The code is there to show how the feature can be done, and to share design decisions with a working implementation rather than having a generic abstract discussion. This gives us the opportunity to discuss the design concretely and iterate fast -- trying out how certain choices implement in practice. Once we converge on the desired concept, I'm happy if you take the code, but equally happy if you decide to throw it away and recode from scratch once we've identified how we want the whole thing to work.

## What it does

Have you ever tried to have a conversation about scientific subjects with an agent? It always returns mathematical expressions written in raw LaTeX, which is hard to read. In my academic field, I daily have to read walls of unformatted LaTeX, which makes the experience unnecessarily difficult. The code demoed here renders all equations live as they are streamed by the agent. The community of scientists using Emacs may not be as big as that of coders, but for those in academia or data science, this kind of feature makes a real difference.

Here's a short demo (~1 min, no audio): https://www.youtube.com/watch?v=wGM3xH06Wso

- Block-level `\[…\]`, `$$…$$`, and `` ```math ``/`` ```latex `` fences render as SVG images; inline `\(…\)` too
- SVGs render with perfect resolution — no pixelated effect
- Equation size is matched to the buffer font size
- Foreground and background colors sync automatically with the theme; no need to regenerate the SVGs
- When changing font size, all equations rescale correctly; no need to regenerate the SVGs
- Rendering is async and cached on disk, so it doesn't block streaming and repeats are instant
- No special instructions needed for the agent — the only thing worth telling it is to avoid rendering inline equations as markdown inline code, because there's no unambiguous way to distinguish an equation from actual code

The code lives in a dedicated `agent-shell-markdown-math.el`, with minimal changes to the rest of the codebase — I tried to localize everything into one file to keep the footprint small and make it easier to maintain going forward.

I can also share the `CLAUDE.md` I wrote to document the module architecture — it may help navigate the code faster than a PR description would.

## Screenshot

Here is a screenshot of the new feature. If you click on the YouTube link above, you will get a more precise impression.

<img width="2920" height="2072" alt="Screenshot 2026-06-25 at 15 57 38" src="https://github.com/user-attachments/assets/f194fbee-9b15-4b5e-a26c-679f237e11e0" />

