### PR TITLE
Render agent image content blocks inline

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1911,20 +1911,21 @@ pretty-printed JSON inside a json fence."
            ;; below the transcript's ## section headers.  Applied
            ;; per-chunk: if a header is split across chunks it may
            ;; not be indented (graceful degradation).
-           (agent-shell--append-transcript
-            :text (agent-shell--indent-markdown-headers
-                   (map-nested-elt acp-notification '(params update content text)))
-            :file-path agent-shell--transcript-file)
-           (agent-shell--update-fragment
-            :state state
-            :block-id (format "%s-agent_message_chunk"
-                              (map-elt state :chunked-group-count))
-            :body (map-nested-elt acp-notification '(params update content text))
-            :create-new (not (equal (map-elt state :last-entry-type)
-                                    "agent_message_chunk"))
-            :append t
-            :navigation 'never
-            :render-body-images t)
+           (let ((chunk-md (agent-shell--content-block-to-markdown
+                            (map-nested-elt acp-notification '(params update content)))))
+             (agent-shell--append-transcript
+              :text (agent-shell--indent-markdown-headers chunk-md)
+              :file-path agent-shell--transcript-file)
+             (agent-shell--update-fragment
+              :state state
+              :block-id (format "%s-agent_message_chunk"
+                                (map-elt state :chunked-group-count))
+              :body chunk-md
+              :create-new (not (equal (map-elt state :last-entry-type)
+                                      "agent_message_chunk"))
+              :append t
+              :navigation 'never
+              :render-body-images t))
            (map-put! state :last-entry-type "agent_message_chunk"))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "user_message_chunk")
            ;; Only handle user_message_chunks when there's an active session/load
@@ -5819,6 +5820,33 @@ If FILE-PATH is not an image, returns nil."
               (is-image (string-prefix-p "image/" mime-type))
               (type-supported (image-supported-file-p file-path)))
     (create-image file-path nil nil :max-width max-width)))
+
+(defun agent-shell--content-block-to-markdown (content-block)
+  "Return markdown for a `session/update' CONTENT-BLOCK.
+
+Text blocks return their text.  Image blocks (a content block whose `type'
+is \"image\", e.g. an agent returning a screenshot) return a markdown image
+so the existing image-rendering path (`agent-shell--render-markdown' with
+:render-images t) displays them inline rather than dropping them.  An image
+block with no file uri returns an empty string.
+
+Examples:
+
+  (agent-shell--content-block-to-markdown
+   \\='((type . \"text\") (text . \"hello\")))
+  => \"hello\"
+
+  (agent-shell--content-block-to-markdown
+   \\='((type . \"image\") (uri . \"file:///tmp/shot.png\")))
+  => \"\\n\\n![image](file:///tmp/shot.png)\\n\\n\""
+  (cond
+   ((not (equal (map-elt content-block 'type) "image"))
+    (or (map-elt content-block 'text) ""))
+   ((map-elt content-block 'uri)
+    (format "\n\n![%s](%s)\n\n"
+            (or (map-elt content-block 'name) "image")
+            (map-elt content-block 'uri)))
+   (t "")))
 
 (cl-defun agent-shell--collect-attached-files (content-blocks)
   "Collect attached resource uris from CONTENT-BLOCKS."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -387,6 +387,50 @@
 
       (delete-file temp-file))))
 
+(ert-deftest agent-shell--content-block-to-markdown-test ()
+  "Test `agent-shell--content-block-to-markdown'.
+
+Agent `session/update' content blocks may be text OR image (a content block
+whose `type' is \"image\", e.g. an agent returning a screenshot, with a file
+`uri' and/or base64 `data').  The render path historically extracted only
+`(content text)', silently dropping image blocks.  This helper makes
+extraction image-aware so images flow into the existing markdown
+image-rendering path as `![alt](uri)'."
+  ;; Text block -> its text, unchanged.
+  (should (equal (agent-shell--content-block-to-markdown
+                  '((type . "text") (text . "hello world")))
+                 "hello world"))
+
+  ;; Image block with a file URI -> a markdown image referencing that URI,
+  ;; so `agent-shell--render-markdown :render-images t' renders it inline.
+  (should (equal (agent-shell--content-block-to-markdown
+                  '((type . "image")
+                    (mimeType . "image/png")
+                    (uri . "file:///tmp/shot.png")))
+                 "\n\n![image](file:///tmp/shot.png)\n\n"))
+
+  ;; Image block with an explicit alt/name is honored in the alt text.
+  (should (equal (agent-shell--content-block-to-markdown
+                  '((type . "image")
+                    (mimeType . "image/png")
+                    (name . "chart")
+                    (uri . "file:///tmp/chart.png")))
+                 "\n\n![chart](file:///tmp/chart.png)\n\n"))
+
+  ;; THE BUG: an image block must NOT extract to nil/empty -- that is the
+  ;; silent drop. Any non-empty rendering is acceptable here.
+  (should-not (string-empty-p
+               (or (agent-shell--content-block-to-markdown
+                    '((type . "image")
+                      (mimeType . "image/png")
+                      (uri . "file:///tmp/x.png")))
+                   "")))
+
+  ;; Unknown block type with no text -> empty string (graceful, not error).
+  (should (equal (agent-shell--content-block-to-markdown
+                  '((type . "audio") (mimeType . "audio/wav")))
+                 "")))
+
 (ert-deftest agent-shell--collect-attached-files-test ()
   "Test agent-shell--collect-attached-files function."
   ;; Test with empty list


### PR DESCRIPTION
`agent_message_chunk` handler extracts only `(content text)` from a content block.

When the agent returns an image content block that block has no `text` field and it gets silently dropped and never rendered.

I've added a new helper `agent-shell--content-block-to-markdown` that returns text for text blocks and a markdown image (`![](uri)`) for image blocks that carry a file `uri`

I've added a simple test at `agent-shell--content-block-to-markdown-test`

I did not file a feature request first.
I was hacking on something using agent-shell and noticed nothing was rendering so took a shot at alleviating my problem.
Open to discussing correct solution if this diverges from any inflight agent-shell work or steps on toes.

<img width="1154" height="1123" alt="Screenshot 2026-06-26 at 1 09 59 PM" src="https://github.com/user-attachments/assets/3e8c5621-41b0-4686-8bd9-85a8dad2bb91" />

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
