### PR TITLE
Record session ID and model in transcript header

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -8286,13 +8286,14 @@ Returns the file path, or nil if disabled."
           (let ((agent-name (or (map-nested-elt agent-shell--state '(:agent-config :mode-line-name))
                                 (map-nested-elt agent-shell--state '(:agent-config :buffer-name))
                                 "Unknown Agent"))
-                (session-id (map-nested-elt agent-shell--state '(:session :id))))
+                (session-id (map-nested-elt agent-shell--state '(:session :id)))
+                (model-id (map-nested-elt agent-shell--state '(:session :model-id))))
             (write-region
              (format "# Agent Shell Transcript
 
 **Agent:** %s
 **Started:** %s
-**Working Directory:** %s%s
+**Working Directory:** %s%s%s
 
 ---
 
@@ -8302,6 +8303,9 @@ Returns the file path, or nil if disabled."
                      (agent-shell-cwd)
                      (if session-id
                          (format "\n**Session ID:** %s" session-id)
+                       "")
+                     (if model-id
+                         (format "\n**Model:** %s" model-id)
                        ""))
              nil filepath nil 'no-message)
             (message "Created %s"

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -8285,20 +8285,24 @@ Returns the file path, or nil if disabled."
       (condition-case err
           (let ((agent-name (or (map-nested-elt agent-shell--state '(:agent-config :mode-line-name))
                                 (map-nested-elt agent-shell--state '(:agent-config :buffer-name))
-                                "Unknown Agent")))
+                                "Unknown Agent"))
+                (session-id (map-nested-elt agent-shell--state '(:session :id))))
             (write-region
              (format "# Agent Shell Transcript
 
 **Agent:** %s
 **Started:** %s
-**Working Directory:** %s
+**Working Directory:** %s%s
 
 ---
 
 "
                      agent-name
                      (format-time-string "%F %T")
-                     (agent-shell-cwd))
+                     (agent-shell-cwd)
+                     (if session-id
+                         (format "\n**Session ID:** %s" session-id)
+                       ""))
              nil filepath nil 'no-message)
             (message "Created %s"
                      (agent-shell--shorten-paths filepath t)))


### PR DESCRIPTION
## Summary

Adds `**Session ID:**` and `**Model:**` lines to the transcript file header
when those values are known.

Today a transcript's only identity is its timestamped filename; nothing in
the file ties it back to the session that produced it. Recording the session
ID makes transcripts self-identifying — a file can be correlated with a
session returned by `session/list`, which is what external tooling (and
session-aware features built on top of transcripts) needs to locate the right
file. The model is recorded alongside it so the transcript captures which
model produced the conversation.

## Header, before → after

Before:

```
# Agent Shell Transcript

**Agent:** Claude
**Started:** 2026-07-02 14:19:52
**Working Directory:** /path/to/project
```

After:

```
# Agent Shell Transcript

**Agent:** Claude
**Started:** 2026-07-02 14:19:52
**Working Directory:** /path/to/project
**Session ID:** 8f3c1a20-...-abc
**Model:** claude-opus-4-6
```

## Notes

- Both fields are conditional: if the value is `nil` the line is omitted, so the header degrades gracefully.
- Timing is safe: the header is written lazily on the first transcript append, which happens after the ACP handshake; so the session ID and model are already in state by then.
- Backward compatible: only new transcripts gain the lines, and they follow the existing `**Key:** value` header convention, so existing files and any header parser are unaffected.