### PR TITLE
Support angle-bracketed link/image destinations

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -257,9 +257,9 @@ For example:
   (agent-shell-markdown-convert \"_my_ **text**\")
   => #(\"my text\" 0 2 (face italic) 3 7 (face bold))"
   (agent-shell-with-work-buffer
-   (insert markdown)
-   (agent-shell-markdown-replace-markup)
-   (buffer-string)))
+    (insert markdown)
+    (agent-shell-markdown-replace-markup)
+    (buffer-string)))
 
 (cl-defun agent-shell-markdown-replace-markup (&key force
                                                     (render-images t)
@@ -702,8 +702,8 @@ face `agent-shell-markdown-inline-code' on \"code\"."
                 (put-text-property markup-start end
                                    'agent-shell-markdown-source source)))))))))
 
-(defun agent-shell-markdown--link-markup-regexp (imagep)
-  "Return a regexp matching link (or image, when IMAGEP) markup.
+(cl-defun agent-shell-markdown--link-markup-regexp (&key as-image?)
+  "Return a regexp matching link (or image, when AS-IMAGE?) markup.
 
 The destination accepts both the bare `(url)' form and the
 CommonMark angle-bracketed `(<url>)' form, the latter allowing the
@@ -714,9 +714,9 @@ group 2 is the angle-bracketed destination body; group 3 is the
 bare destination body.  Exactly one of groups 2 and 3 participates
 in any match — read the URL from whichever did."
   (rx-to-string
-   `(seq ,@(when imagep '("!"))
+   `(seq ,@(when as-image? '("!"))
          "["
-         (group (,(if imagep 'zero-or-more 'one-or-more) (not (any "]"))))
+         (group (,(if as-image? 'zero-or-more 'one-or-more) (not (any "]"))))
          "]"
          "("
          (or (seq "<" (group (zero-or-more (not (any "<" ">" "\n")))) ">")
@@ -748,7 +748,7 @@ For example, the buffer \"see [docs](https://example.com)\"
 becomes \"see docs\" with face `agent-shell-markdown-link' on \"docs\"
 and a keymap that opens the URL."
   (let ((case-fold-search nil)
-        (regexp (agent-shell-markdown--link-markup-regexp nil)))
+        (regexp (agent-shell-markdown--link-markup-regexp)))
     (goto-char (point-min))
     (while (re-search-forward regexp nil t)
       (let* ((markup-start (match-beginning 0))
@@ -811,7 +811,7 @@ URL (see `agent-shell-markdown--link-markup-regexp').
 For example, the buffer \"see ![logo](logo.png)\" becomes
 \"see logo\" with the image shown in place of \"logo\"."
   (let ((case-fold-search nil)
-        (regexp (agent-shell-markdown--link-markup-regexp t)))
+        (regexp (agent-shell-markdown--link-markup-regexp :as-image? t)))
     (goto-char (point-min))
     (while (re-search-forward regexp nil t)
       (let* ((markup-start (match-beginning 0))
@@ -2173,64 +2173,64 @@ CJK) so right borders align across rows.  Without it,
 measurement falls back to `string-width' — fine for ASCII but
 prone to a few-pixel drift on emoji-heavy tables."
   (agent-shell-with-work-buffer
-   (insert source)
-   ;; SOURCE inherits `field' text properties from the calling buffer
-   ;; (e.g. agent-shell tags chars with `field output'); inter-row
-   ;; `\\n's may carry different field values, which would otherwise
-   ;; cause `forward-line' / `line-end-position' in the parsers below
-   ;; to stop at field boundaries and silently drop rows.
-   (setq-local inhibit-field-text-motion t)
-   (let* ((rows (agent-shell-markdown--collect-table-rows))
-          (separator-row-num (agent-shell-markdown--find-separator-row-num rows))
-          (preprocessed (agent-shell-markdown--preprocess-table
-                         :rows rows :window window))
-          (natural-widths (map-elt preprocessed :natural-widths))
-          (processed-rows (map-elt preprocessed :processed-rows))
-          (target-width (when agent-shell-markdown-table-wrap-columns
-                          (floor (* (agent-shell-markdown--display-width)
-                                    agent-shell-markdown-table-max-width-fraction))))
-          (needs-allocation (and target-width
-                                 (> (agent-shell-markdown--table-total-width
-                                     natural-widths)
-                                    target-width)))
-          ;; `:min-widths' is expensive (longest-word per cell) and only
-          ;; consumed by allocation, which kicks in only when the
-          ;; natural total exceeds the target.  Compute lazily.
-          (col-widths (if needs-allocation
-                          (agent-shell-markdown--table-allocate-widths
-                           natural-widths
-                           (agent-shell-markdown--table-min-widths
-                            :processed-rows processed-rows
-                            :window window)
-                           target-width)
-                        natural-widths))
-          (data-row-num 0)
-          (rendered-rows '()))
-     (dolist (entry processed-rows)
-       (let* ((row (car entry))
-              (processed-cells (cdr entry))
-              (row-num (map-elt row :num))
-              (is-separator (map-elt row :separator))
-              (is-header (and separator-row-num
-                              (< row-num separator-row-num)))
-              (is-zebra (and agent-shell-markdown-table-zebra-stripe
-                             (not is-header)
-                             (not is-separator)
-                             (= (mod data-row-num 2) 1)))
-              (row-face (cond
-                         (is-header 'agent-shell-markdown-table-header)
-                         (is-zebra 'agent-shell-markdown-table-zebra))))
-         (unless (or is-header is-separator)
-           (setq data-row-num (1+ data-row-num)))
-         (push (if is-separator
-                   (agent-shell-markdown--render-table-separator-row col-widths)
-                 (agent-shell-markdown--render-table-data-row
-                  :processed-cells processed-cells
-                  :col-widths col-widths
-                  :row-face row-face
-                  :window window))
-               rendered-rows)))
-     (string-join (nreverse rendered-rows) "\n"))))
+    (insert source)
+    ;; SOURCE inherits `field' text properties from the calling buffer
+    ;; (e.g. agent-shell tags chars with `field output'); inter-row
+    ;; `\\n's may carry different field values, which would otherwise
+    ;; cause `forward-line' / `line-end-position' in the parsers below
+    ;; to stop at field boundaries and silently drop rows.
+    (setq-local inhibit-field-text-motion t)
+    (let* ((rows (agent-shell-markdown--collect-table-rows))
+           (separator-row-num (agent-shell-markdown--find-separator-row-num rows))
+           (preprocessed (agent-shell-markdown--preprocess-table
+                          :rows rows :window window))
+           (natural-widths (map-elt preprocessed :natural-widths))
+           (processed-rows (map-elt preprocessed :processed-rows))
+           (target-width (when agent-shell-markdown-table-wrap-columns
+                           (floor (* (agent-shell-markdown--display-width)
+                                     agent-shell-markdown-table-max-width-fraction))))
+           (needs-allocation (and target-width
+                                  (> (agent-shell-markdown--table-total-width
+                                      natural-widths)
+                                     target-width)))
+           ;; `:min-widths' is expensive (longest-word per cell) and only
+           ;; consumed by allocation, which kicks in only when the
+           ;; natural total exceeds the target.  Compute lazily.
+           (col-widths (if needs-allocation
+                           (agent-shell-markdown--table-allocate-widths
+                            natural-widths
+                            (agent-shell-markdown--table-min-widths
+                             :processed-rows processed-rows
+                             :window window)
+                            target-width)
+                         natural-widths))
+           (data-row-num 0)
+           (rendered-rows '()))
+      (dolist (entry processed-rows)
+        (let* ((row (car entry))
+               (processed-cells (cdr entry))
+               (row-num (map-elt row :num))
+               (is-separator (map-elt row :separator))
+               (is-header (and separator-row-num
+                               (< row-num separator-row-num)))
+               (is-zebra (and agent-shell-markdown-table-zebra-stripe
+                              (not is-header)
+                              (not is-separator)
+                              (= (mod data-row-num 2) 1)))
+               (row-face (cond
+                          (is-header 'agent-shell-markdown-table-header)
+                          (is-zebra 'agent-shell-markdown-table-zebra))))
+          (unless (or is-header is-separator)
+            (setq data-row-num (1+ data-row-num)))
+          (push (if is-separator
+                    (agent-shell-markdown--render-table-separator-row col-widths)
+                  (agent-shell-markdown--render-table-data-row
+                   :processed-cells processed-cells
+                   :col-widths col-widths
+                   :row-face row-face
+                   :window window))
+                rendered-rows)))
+      (string-join (nreverse rendered-rows) "\n"))))
 
 (defun agent-shell-markdown--collect-table-rows ()
   "Collect table rows in current buffer (typically a temp buffer).

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -37,7 +37,9 @@
 ;;   header      `# X' .. `###### X'      face `agent-shell-markdown-header-1' .. `-6'
 ;;   inline code `` `X` ``                face `agent-shell-markdown-inline-code'
 ;;   link        `[title](url)'           face `agent-shell-markdown-link', keymap opens URL
+;;                 (`(<url>)' also OK — angle brackets allow spaces in the url)
 ;;   image       `![alt](url)'            `display' property carries image
+;;                 (`(<url>)' also OK — angle brackets allow spaces in the url)
 ;;   image path  bare image path on a line  same as `![alt](url)' (no markup)
 ;;   divider     `---' / `***' / `___'    rendered as an underlined rule line
 ;;   fenced code ```LANG\nX\n```          body syntax-highlighted via LANG mode
@@ -255,9 +257,9 @@ For example:
   (agent-shell-markdown-convert \"_my_ **text**\")
   => #(\"my text\" 0 2 (face italic) 3 7 (face bold))"
   (agent-shell-with-work-buffer
-    (insert markdown)
-    (agent-shell-markdown-replace-markup)
-    (buffer-string)))
+   (insert markdown)
+   (agent-shell-markdown-replace-markup)
+   (buffer-string)))
 
 (cl-defun agent-shell-markdown-replace-markup (&key force
                                                     (render-images t)
@@ -700,6 +702,35 @@ face `agent-shell-markdown-inline-code' on \"code\"."
                 (put-text-property markup-start end
                                    'agent-shell-markdown-source source)))))))))
 
+(defun agent-shell-markdown--link-markup-regexp (imagep)
+  "Return a regexp matching link (or image, when IMAGEP) markup.
+
+The destination accepts both the bare `(url)' form and the
+CommonMark angle-bracketed `(<url>)' form, the latter allowing the
+URL to contain spaces (e.g. `(</path/with spaces.png>)').
+
+Capture groups: group 1 is the label (link title or image alt);
+group 2 is the angle-bracketed destination body; group 3 is the
+bare destination body.  Exactly one of groups 2 and 3 participates
+in any match — read the URL from whichever did."
+  (rx-to-string
+   `(seq ,@(when imagep '("!"))
+         "["
+         (group (,(if imagep 'zero-or-more 'one-or-more) (not (any "]"))))
+         "]"
+         "("
+         (or (seq "<" (group (zero-or-more (not (any "<" ">" "\n")))) ">")
+             (group (one-or-more (not (any ")")))))
+         ")")
+   t))
+
+(defun agent-shell-markdown--link-markup-url ()
+  "Return the URL from the last `agent-shell-markdown--link-markup-regexp' match.
+Reads capture group 2 (angle-bracketed form) when it participated,
+otherwise group 3 (bare form)."
+  (let ((group (if (match-beginning 2) 2 3)))
+    (buffer-substring-no-properties (match-beginning group) (match-end group))))
+
 (cl-defun agent-shell-markdown--replace-links (&key avoid-ranges)
   "Replace `[title](url)' markup with title faced as link.
 
@@ -709,19 +740,17 @@ opens the URL on RET or mouse-1.  Matches preceded by `!' (the
 image syntax) are skipped, as are links inside any of
 AVOID-RANGES.
 
+A bare `(url)' destination and the CommonMark angle-bracketed
+`(<url>)' form are both accepted; the latter allows spaces in the
+URL (see `agent-shell-markdown--link-markup-regexp').
+
 For example, the buffer \"see [docs](https://example.com)\"
 becomes \"see docs\" with face `agent-shell-markdown-link' on \"docs\"
 and a keymap that opens the URL."
-  (let ((case-fold-search nil))
+  (let ((case-fold-search nil)
+        (regexp (agent-shell-markdown--link-markup-regexp nil)))
     (goto-char (point-min))
-    (while (re-search-forward
-            (rx "["
-                (group (one-or-more (not (any "]"))))
-                "]"
-                "("
-                (group (one-or-more (not (any ")"))))
-                ")")
-            nil t)
+    (while (re-search-forward regexp nil t)
       (let* ((markup-start (match-beginning 0))
              (markup-end (match-end 0))
              (is-image (eq (char-before markup-start) ?!))
@@ -733,8 +762,7 @@ and a keymap that opens the URL."
          (is-image nil)
          (t
           (let ((title (buffer-substring (match-beginning 1) (match-end 1)))
-                (url (buffer-substring-no-properties
-                      (match-beginning 2) (match-end 2)))
+                (url (agent-shell-markdown--link-markup-url))
                 (source (unless (get-text-property markup-start
                                                    'agent-shell-markdown-source)
                           (agent-shell-markdown-reconstruct
@@ -776,19 +804,16 @@ faced as `agent-shell-markdown-link' with a keymap that opens the
 URL on RET or mouse-1.  Any other unresolvable markup is left
 untouched.  Images inside any of AVOID-RANGES are left alone.
 
+A bare `(url)' destination and the CommonMark angle-bracketed
+`(<url>)' form are both accepted; the latter allows spaces in the
+URL (see `agent-shell-markdown--link-markup-regexp').
+
 For example, the buffer \"see ![logo](logo.png)\" becomes
 \"see logo\" with the image shown in place of \"logo\"."
-  (let ((case-fold-search nil))
+  (let ((case-fold-search nil)
+        (regexp (agent-shell-markdown--link-markup-regexp t)))
     (goto-char (point-min))
-    (while (re-search-forward
-            (rx "!"
-                "["
-                (group (zero-or-more (not (any "]"))))
-                "]"
-                "("
-                (group (one-or-more (not (any ")"))))
-                ")")
-            nil t)
+    (while (re-search-forward regexp nil t)
       (let* ((markup-start (match-beginning 0))
              (markup-end (match-end 0))
              (avoid (agent-shell-markdown-in-avoid-range-p
@@ -814,8 +839,7 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                                          (text-properties-at markup-start))
                                 (buffer-substring (match-beginning 1)
                                                   (match-end 1))))
-                 (url (buffer-substring-no-properties
-                       (match-beginning 2) (match-end 2)))
+                 (url (agent-shell-markdown--link-markup-url))
                  ;; Stash the original `![alt](url)' markup so
                  ;; `agent-shell-copy-as-markdown' round-trips the image back to
                  ;; source rather than yielding the bare alt placeholder (mirrors
@@ -915,7 +939,7 @@ renders the image in place of that text."
                 (put-text-property path-start path-end 'mouse-face 'highlight)
                 (add-text-properties path-start path-end
                                      '(agent-shell-markdown-frozen t
-                                       rear-nonsticky (agent-shell-markdown-frozen))))))))))))
+                                                                   rear-nonsticky (agent-shell-markdown-frozen))))))))))))
 
 (cl-defun agent-shell-markdown--style-dividers (&key avoid-ranges)
   "Render `---' / `***' / `___' horizontal-rule lines as styled rules.
@@ -998,7 +1022,7 @@ left untouched."
                                   'agent-shell-markdown-blockquote)
           (add-text-properties line-start line-end
                                '(agent-shell-markdown-frozen t
-                                 rear-nonsticky (agent-shell-markdown-frozen))))))))
+                                                             rear-nonsticky (agent-shell-markdown-frozen))))))))
 
 (defun agent-shell-markdown--display-width ()
   "Return a usable display width for divider rendering.
@@ -2149,64 +2173,64 @@ CJK) so right borders align across rows.  Without it,
 measurement falls back to `string-width' — fine for ASCII but
 prone to a few-pixel drift on emoji-heavy tables."
   (agent-shell-with-work-buffer
-    (insert source)
-    ;; SOURCE inherits `field' text properties from the calling buffer
-    ;; (e.g. agent-shell tags chars with `field output'); inter-row
-    ;; `\\n's may carry different field values, which would otherwise
-    ;; cause `forward-line' / `line-end-position' in the parsers below
-    ;; to stop at field boundaries and silently drop rows.
-    (setq-local inhibit-field-text-motion t)
-    (let* ((rows (agent-shell-markdown--collect-table-rows))
-           (separator-row-num (agent-shell-markdown--find-separator-row-num rows))
-           (preprocessed (agent-shell-markdown--preprocess-table
-                          :rows rows :window window))
-           (natural-widths (map-elt preprocessed :natural-widths))
-           (processed-rows (map-elt preprocessed :processed-rows))
-           (target-width (when agent-shell-markdown-table-wrap-columns
-                           (floor (* (agent-shell-markdown--display-width)
-                                     agent-shell-markdown-table-max-width-fraction))))
-           (needs-allocation (and target-width
-                                  (> (agent-shell-markdown--table-total-width
-                                      natural-widths)
-                                     target-width)))
-           ;; `:min-widths' is expensive (longest-word per cell) and only
-           ;; consumed by allocation, which kicks in only when the
-           ;; natural total exceeds the target.  Compute lazily.
-           (col-widths (if needs-allocation
-                           (agent-shell-markdown--table-allocate-widths
-                            natural-widths
-                            (agent-shell-markdown--table-min-widths
-                             :processed-rows processed-rows
-                             :window window)
-                            target-width)
-                         natural-widths))
-           (data-row-num 0)
-           (rendered-rows '()))
-      (dolist (entry processed-rows)
-        (let* ((row (car entry))
-               (processed-cells (cdr entry))
-               (row-num (map-elt row :num))
-               (is-separator (map-elt row :separator))
-               (is-header (and separator-row-num
-                               (< row-num separator-row-num)))
-               (is-zebra (and agent-shell-markdown-table-zebra-stripe
-                              (not is-header)
-                              (not is-separator)
-                              (= (mod data-row-num 2) 1)))
-               (row-face (cond
-                          (is-header 'agent-shell-markdown-table-header)
-                          (is-zebra 'agent-shell-markdown-table-zebra))))
-          (unless (or is-header is-separator)
-            (setq data-row-num (1+ data-row-num)))
-          (push (if is-separator
-                    (agent-shell-markdown--render-table-separator-row col-widths)
-                  (agent-shell-markdown--render-table-data-row
-                   :processed-cells processed-cells
-                   :col-widths col-widths
-                   :row-face row-face
-                   :window window))
-                rendered-rows)))
-      (string-join (nreverse rendered-rows) "\n"))))
+   (insert source)
+   ;; SOURCE inherits `field' text properties from the calling buffer
+   ;; (e.g. agent-shell tags chars with `field output'); inter-row
+   ;; `\\n's may carry different field values, which would otherwise
+   ;; cause `forward-line' / `line-end-position' in the parsers below
+   ;; to stop at field boundaries and silently drop rows.
+   (setq-local inhibit-field-text-motion t)
+   (let* ((rows (agent-shell-markdown--collect-table-rows))
+          (separator-row-num (agent-shell-markdown--find-separator-row-num rows))
+          (preprocessed (agent-shell-markdown--preprocess-table
+                         :rows rows :window window))
+          (natural-widths (map-elt preprocessed :natural-widths))
+          (processed-rows (map-elt preprocessed :processed-rows))
+          (target-width (when agent-shell-markdown-table-wrap-columns
+                          (floor (* (agent-shell-markdown--display-width)
+                                    agent-shell-markdown-table-max-width-fraction))))
+          (needs-allocation (and target-width
+                                 (> (agent-shell-markdown--table-total-width
+                                     natural-widths)
+                                    target-width)))
+          ;; `:min-widths' is expensive (longest-word per cell) and only
+          ;; consumed by allocation, which kicks in only when the
+          ;; natural total exceeds the target.  Compute lazily.
+          (col-widths (if needs-allocation
+                          (agent-shell-markdown--table-allocate-widths
+                           natural-widths
+                           (agent-shell-markdown--table-min-widths
+                            :processed-rows processed-rows
+                            :window window)
+                           target-width)
+                        natural-widths))
+          (data-row-num 0)
+          (rendered-rows '()))
+     (dolist (entry processed-rows)
+       (let* ((row (car entry))
+              (processed-cells (cdr entry))
+              (row-num (map-elt row :num))
+              (is-separator (map-elt row :separator))
+              (is-header (and separator-row-num
+                              (< row-num separator-row-num)))
+              (is-zebra (and agent-shell-markdown-table-zebra-stripe
+                             (not is-header)
+                             (not is-separator)
+                             (= (mod data-row-num 2) 1)))
+              (row-face (cond
+                         (is-header 'agent-shell-markdown-table-header)
+                         (is-zebra 'agent-shell-markdown-table-zebra))))
+         (unless (or is-header is-separator)
+           (setq data-row-num (1+ data-row-num)))
+         (push (if is-separator
+                   (agent-shell-markdown--render-table-separator-row col-widths)
+                 (agent-shell-markdown--render-table-data-row
+                  :processed-cells processed-cells
+                  :col-widths col-widths
+                  :row-face row-face
+                  :window window))
+               rendered-rows)))
+     (string-join (nreverse rendered-rows) "\n"))))
 
 (defun agent-shell-markdown--collect-table-rows ()
   "Collect table rows in current buffer (typically a temp buffer).

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -323,7 +323,7 @@ streaming **not bold**" nil)))))
   (with-temp-buffer
     (insert "[x](</path/with spaces (1).png>)")
     (goto-char (point-min))
-    (should (re-search-forward (agent-shell-markdown--link-markup-regexp nil) nil t))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp) nil t))
     (should (equal (agent-shell-markdown--link-markup-url)
                    "/path/with spaces (1).png"))))
 
@@ -332,7 +332,7 @@ streaming **not bold**" nil)))))
   (with-temp-buffer
     (insert "[x](https://example.com)")
     (goto-char (point-min))
-    (should (re-search-forward (agent-shell-markdown--link-markup-regexp nil) nil t))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp) nil t))
     (should (equal (agent-shell-markdown--link-markup-url) "https://example.com"))))
 
 (ert-deftest agent-shell-markdown--link-markup-regexp-image-empty-alt ()
@@ -340,7 +340,7 @@ streaming **not bold**" nil)))))
   (with-temp-buffer
     (insert "![](<a b.png>)")
     (goto-char (point-min))
-    (should (re-search-forward (agent-shell-markdown--link-markup-regexp t) nil t))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp :as-image? t) nil t))
     (should (equal (match-string 1) ""))
     (should (equal (agent-shell-markdown--link-markup-url) "a b.png"))))
 

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -301,6 +301,49 @@ streaming **not bold**" nil)))))
     (should (equal (agent-shell-markdown-reconstruct (point-min) (point-max))
                    "x ![](https://example.com/a.png) y"))))
 
+(ert-deftest agent-shell-markdown-convert-link-angle-brackets ()
+  ;; CommonMark angle-bracketed destination `[t](<url>)' renders like the
+  ;; bare form, with both the brackets and the angle brackets stripped.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert "see [docs](<https://example.com>) please"))
+                 '(("see " nil)
+                   ("docs" (agent-shell-markdown-link))
+                   (" please" nil)))))
+
+(ert-deftest agent-shell-markdown-convert-image-angle-brackets-remote-falls-back ()
+  ;; A remote image whose destination is angle-bracketed still resolves to
+  ;; the http url (brackets stripped), so the non-inline fallback is a link.
+  (should (equal (agent-shell-markdown--deconstruct
+                  (agent-shell-markdown-convert "![docs](<https://example.com/a.png>)"))
+                 '(("docs" (agent-shell-markdown-link))))))
+
+(ert-deftest agent-shell-markdown--link-markup-url-angle-allows-spaces ()
+  ;; The whole point of the angle-bracket form: the url may contain spaces
+  ;; (and parentheses), which the bare `(...)' form cannot represent.
+  (with-temp-buffer
+    (insert "[x](</path/with spaces (1).png>)")
+    (goto-char (point-min))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp nil) nil t))
+    (should (equal (agent-shell-markdown--link-markup-url)
+                   "/path/with spaces (1).png"))))
+
+(ert-deftest agent-shell-markdown--link-markup-url-bare-form ()
+  ;; The bare destination is still captured (from group 3) unchanged.
+  (with-temp-buffer
+    (insert "[x](https://example.com)")
+    (goto-char (point-min))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp nil) nil t))
+    (should (equal (agent-shell-markdown--link-markup-url) "https://example.com"))))
+
+(ert-deftest agent-shell-markdown--link-markup-regexp-image-empty-alt ()
+  ;; Image alt may be empty; the angle-bracketed url is still captured.
+  (with-temp-buffer
+    (insert "![](<a b.png>)")
+    (goto-char (point-min))
+    (should (re-search-forward (agent-shell-markdown--link-markup-regexp t) nil t))
+    (should (equal (match-string 1) ""))
+    (should (equal (agent-shell-markdown--link-markup-url) "a b.png"))))
+
 (ert-deftest agent-shell-markdown-convert-link-in-fenced-block-untouched ()
   ;; The `[b](v)' inside fences stays literal — it isn't re-processed
   ;; as a link.  Body chars carry the `agent-shell-markdown-frozen'


### PR DESCRIPTION
## Motivation

**Who emits these links?** The agent does. agent-shell renders the markdown the agent streams into the buffer, and an agent can be instructed — via a skill, system prompt, or tool — to **embed local images inline** by emitting image markup with an absolute path. Concretely, I drive a skill that has the agent embed figures/SVGs from local files directly in the transcript (`![](/abs/path/fig.svg)`), so the rendered conversation shows the graphics next to the discussion.

Those absolute paths routinely contain **spaces** (cache dirs, `~/Google Drive/...`, figure filenames, etc.). Two things have to hold for that to be useful:

1. **It renders in agent-shell.** Today it *happens* to, because the renderer matches a destination as everything up to the first `)` — spaces included. But that leniency is **not** standard markdown: in a conformant CommonMark parser a bare `(url)` destination ends at the first space, so the path is truncated.
2. **It survives leaving agent-shell.** These buffers get **saved and copy-pasted into other markdown viewers** (docs, GitHub, editors, static-site generators). A transcript that relied on agent-shell's lenient bare-space handling silently breaks there — the image won't load, or only part of the path is used.

The standard, portable way to write a destination containing spaces is to wrap it in angle brackets. Per the [Markdown links reference](https://www.codecademy.com/resources/docs/markdown/links) — *"How do you Markdown a URL with spaces?"*:

> Either encode spaces as %20 or enclose the entire URL in angle brackets: `<URL with spaces>`. For file paths with spaces, use proper encoding or quotes.

This is also one of the two link-destination forms defined by the [CommonMark spec](https://spec.commonmark.org/current/#link-destination). This PR makes agent-shell **render** that form, so a skill can emit spec-compliant `![alt](<path with spaces>)` that both displays inline *and* stays valid markdown when the transcript is reused elsewhere.

## What

Match CommonMark's angle-bracketed link/image destinations:

- `[text](<url>)`
- `![alt](<url>)`

## How

- New shared helpers `agent-shell-markdown--link-markup-regexp` / `--link-markup-url` that match **both** the bare `(url)` and angle-bracketed `(<url>)` destination forms and return the URL from whichever matched.
- `--replace-links` and `--replace-images` both use them, replacing their duplicated inline `rx` destination patterns.
- The bare form is byte-for-byte unchanged (regression-covered); the angle form strips the brackets and permits spaces and parentheses in the URL.

## Scope

Bare image-path lines (`--replace-image-file-paths`) are a non-CommonMark extension and are intentionally left as-is.

## Tests

**ERT.** Added coverage (angle-bracket link, remote-image angle fallback, space/paren-containing URLs, empty-alt image, bare-form regression). Full suite: `102/102` passing.

\`\`\`
emacs -batch -l ert -l tests/agent-shell-markdown-tests.el -f ert-run-tests-batch-and-exit
\`\`\`

**End-to-end in a live Emacs session.** Loaded the branch and had an agent emit an angle-bracketed absolute path, `![](</abs/path/figure.svg>)`, in its streamed response. agent-shell rendered it as an inline SVG — the markup collapses to the alt placeholder carrying a `display` image whose `:file` is the correct, un-truncated path. Bare `![](...)` and existing `[text](url)` links continue to render as before.