### PR TITLE
Fixes for cline agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.agent-shell/
+agent-shell-autoloads.el
 
 *.elc
+

--- a/agent-shell-cline.el
+++ b/agent-shell-cline.el
@@ -44,6 +44,26 @@ The first element is the command name, and the rest are command parameters."
   :type '(repeat string)
   :group 'agent-shell)
 
+(defcustom agent-shell-cline-default-model-id
+  nil
+  "Default Cline model ID.
+
+Must be one of the model ID's displayed under \"Available models\"
+when starting a new shell.
+
+Can be set to either a string or a function that returns a string."
+  :type '(choice (const nil) string function)
+  :group 'agent-shell)
+
+(defcustom agent-shell-cline-default-session-mode-id
+  nil
+  "Default Cline session mode ID.
+
+Must be one of the mode ID's displayed under \"Available modes\"
+when starting a new shell."
+  :type '(choice (const nil) string)
+  :group 'agent-shell)
+
 (defcustom agent-shell-cline-environment
   nil
   "Environment variables for the Cline agent client.
@@ -67,6 +87,10 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-cline--welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-cline-make-client :buffer buffer))
+   :default-model-id (lambda () (if (functionp agent-shell-cline-default-model-id)
+                                    (funcall agent-shell-cline-default-model-id)
+                                  agent-shell-cline-default-model-id))
+   :default-session-mode-id (lambda () agent-shell-cline-default-session-mode-id)
    :install-instructions "See https://cline.bot/cli for installation."))
 
 (defun agent-shell-cline-start-agent ()

--- a/agent-shell-config.el
+++ b/agent-shell-config.el
@@ -119,18 +119,29 @@ For example:
             (agent-shell--config-options state)))
 
 (defun agent-shell--config-option-by-category (state category)
-  "Return first config option in STATE matching CATEGORY, or nil.
+  "Return a config option in STATE matching CATEGORY, or nil.
 
 CATEGORY may be nil for uncategorized options.  Uses `equal' for
 nil-safe comparison.
+
+When several options share CATEGORY, prefers the one whose `:id'
+equals CATEGORY, falling back to the first match.  Some agents (e.g.
+Cline) tag multiple options with the same category -- both their
+`provider' and `model' options use category \"model\" -- so matching
+on category alone could otherwise resolve \"model\" to the provider
+option.
 
 For example:
 
   (agent-shell--config-option-by-category state \"model\")
   => \\='((:id . \"model\") (:category . \"model\") ...)"
-  (seq-find (lambda (option)
-              (equal category (map-elt option :category)))
-            (agent-shell--config-options state)))
+  (let ((matches (seq-filter (lambda (option)
+                               (equal category (map-elt option :category)))
+                             (agent-shell--config-options state))))
+    (or (seq-find (lambda (option)
+                    (equal category (map-elt option :id)))
+                  matches)
+        (car matches))))
 
 (defun agent-shell--select-config-options (state)
   "Return selectable (type = \"select\") config options from STATE."

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -6105,8 +6105,12 @@ Does nothing if TITLE is empty or matches the current value."
 Sends a `session/list' ACP request and writes any non-empty `title'
 field on the matching session via `agent-shell--set-session-title'.  Agents
 that don't supply a title (e.g. Claude Code) are no-ops; the seeded
-first-prompt title is left in place."
-  (when-let* ((client (map-elt agent-shell--state :client))
+first-prompt title is left in place.
+
+Does nothing if the agent doesn't advertise the `list' session
+capability, since the `session/list' request would otherwise fail."
+  (when-let* ((_ (map-elt agent-shell--state :supports-session-list))
+              (client (map-elt agent-shell--state :client))
               (session-id (map-nested-elt agent-shell--state '(:session :id))))
     (acp-send-request
      :client client

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -949,6 +949,53 @@ bar
                  (list (cons :config-options options))
                  "model"))))
 
+(ert-deftest agent-shell--config-option-by-category-prefers-id-match-test ()
+  "Test `agent-shell--config-option-by-category' tie-breaks on `:id'.
+
+Cline tags both its `provider' and `model' options with category
+\"model\".  Matching on category alone would resolve \"model\" to the
+first match (provider); the lookup must prefer the option whose `:id'
+equals the category."
+  (let* ((options (agent-shell--normalize-config-options
+                   [((id . "provider")
+                     (name . "Provider")
+                     (category . "model")
+                     (type . "select")
+                     (currentValue . "openai-codex")
+                     (options . [((value . "cline") (name . "Cline"))
+                                 ((value . "openai-codex")
+                                  (name . "OpenAI ChatGPT Subscription"))]))
+                    ((id . "model")
+                     (name . "Model")
+                     (category . "model")
+                     (type . "select")
+                     (currentValue . "gpt-5.5")
+                     (options . [((value . "gpt-5.5") (name . "GPT-5.5"))]))]))
+         (state (list (cons :config-options options))))
+    ;; "model" category must resolve to the model option, not provider.
+    (should (equal (map-elt (agent-shell--config-option-by-category state "model") :id)
+                   "model"))
+    ;; And available models must list models, not providers.
+    (should (equal (mapcar (lambda (m) (map-elt m :model-id))
+                           (agent-shell--get-available-models state))
+                   '("gpt-5.5")))))
+
+(ert-deftest agent-shell--config-option-by-category-falls-back-to-first-match-test ()
+  "Test `agent-shell--config-option-by-category' falls back when no `:id' match.
+
+When a single option carries a category but its `:id' differs from
+the category, the option is still returned."
+  (let* ((options (agent-shell--normalize-config-options
+                   [((id . "model_id")
+                     (name . "Model")
+                     (category . "model")
+                     (type . "select")
+                     (currentValue . "sonnet")
+                     (options . [((value . "sonnet") (name . "Sonnet"))]))]))
+         (state (list (cons :config-options options))))
+    (should (equal (map-elt (agent-shell--config-option-by-category state "model") :id)
+                   "model_id"))))
+
 (ert-deftest agent-shell--session-from-response-config-options-test ()
   "Test `agent-shell--session-from-response' stores config options."
   (let ((session (agent-shell--session-from-response

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -3441,5 +3441,39 @@ interaction (e.g. \"1/2\" after switching to the latest interaction)."
       (kill-buffer viewport-buffer)
       (kill-buffer shell-buffer))))
 
+(ert-deftest agent-shell--refresh-session-title-skips-when-list-unsupported ()
+  "Test `agent-shell--refresh-session-title' sends no request without `list'.
+
+Agents that don't advertise the `list' session capability (e.g. Cline)
+would otherwise get a `session/list' request on every turn, failing
+with \"Method not found\"."
+  (with-temp-buffer
+    (let ((request-sent nil)
+          (state (list (cons :client 'test-client)
+                       (cons :supports-session-list nil)
+                       (cons :session (list (cons :id "session-123"))))))
+      (setq-local agent-shell--state state)
+      (cl-letf (((symbol-function 'acp-send-request)
+                 (lambda (&rest _args)
+                   (setq request-sent t))))
+        (agent-shell--refresh-session-title)
+        (should-not request-sent)))))
+
+(ert-deftest agent-shell--refresh-session-title-fetches-when-list-supported ()
+  "Test `agent-shell--refresh-session-title' sends `session/list' when supported."
+  (with-temp-buffer
+    (let ((sent-method nil)
+          (state (list (cons :client 'test-client)
+                       (cons :supports-session-list t)
+                       (cons :session (list (cons :id "session-123"))))))
+      (setq-local agent-shell--state state)
+      (cl-letf (((symbol-function 'agent-shell--resolve-path)
+                 (lambda (path) path))
+                ((symbol-function 'acp-send-request)
+                 (lambda (&rest args)
+                   (setq sent-method (map-elt (plist-get args :request) :method)))))
+        (agent-shell--refresh-session-title)
+        (should (equal sent-method "session/list"))))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
Some fixes for the `cline` agent:

- Guard `agent-shell--refresh-session-title` by `session-list` capability. 
   Cline does not currently support `session-list`.
- Add default model and session-mode defcustoms for cline.
- Match config category options by `:id`. 
    Cline tags both its `provider` and `model` options with category `model`.  Matching on category alone would resolve `model` to the first match (`provider`); the lookup must prefer the option whose `:id' equals the category. This fixes the switch-model and switch-provider actions.

To test cline in agent-shell:

```
(setq agent-shell-cline-environment
   (agent-shell-make-environment-variables :inherit-env t))
(setq agent-shell-cline-default-model-id "gpt-5.5") ;; your default model here
```

Note: Setting the default model is required, otherwise cline acp will use a hard-coded model which fails silently.
  
## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
