### PR TITLE
Send selected regions as fenced code blocks

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -357,6 +357,54 @@ Sources are checked in order until one returns non-nil."
                          (function :tag "Custom function")))
   :group 'agent-shell)
 
+(defcustom agent-shell-region-context-format-function nil
+  "Function to format a selected region before it is sent as context.
+
+Affects \\[agent-shell-send-region] and the `region' source of
+\\[agent-shell-send-dwim] (see `agent-shell-context-sources').
+
+When nil (the default), the region is sent as a clickable
+`path:line-range' header followed by a capped, line-numbered preview.
+
+When set to a function, it is called with a single plist argument and
+should return the string to send in place of the default formatting, or
+nil to fall back to it.  The plist has these keys:
+
+ :file        Absolute path of the source file, or nil for a buffer with
+              no file.
+ :language    `major-mode' name with the `-ts-mode'/`-mode' suffix stripped
+              (e.g. \"python\").  This is a raw hint, not a canonical
+              Markdown fence identifier -- for example `c++-mode' yields
+              \"c++\", not \"cpp\"; map it yourself if you need a fence tag.
+ :line-start  Line number of the first selected line (1-based).
+ :line-end    Line number of the last selected line (1-based).
+ :content     The selected text, verbatim.
+ :agent-cwd   The target agent's working directory.  Use it to derive a
+              path relative to the agent (as the default does for :file),
+              or nil if unavailable.
+ :agent       Identifier symbol of the target agent (e.g. `claude-code'),
+              or nil if unavailable.
+ :model       Current model id of the target agent (e.g.
+              \"claude-opus-4-8\"), or nil if unavailable.
+
+The keys above are what the function cannot otherwise reach: the target
+shell (:agent-cwd :agent :model) and the selection, which is already
+deactivated by the time the function runs (:content :line-start
+:line-end).  The source buffer itself is not passed because it is the
+current buffer while the function runs: reach it via `current-buffer'
+(and hence `buffer-name', `default-directory', buffer text, overlays,
+...).
+
+This is an escape hatch for tailoring region context to a particular
+agent, model, or workflow -- for example, sending only the
+`path:line-range' header without the line-numbered body, or wrapping the
+body in a fenced code block with a language tag.  The best shape can
+differ across agents and model versions, which is why :agent and :model
+are provided for the formatter to branch on."
+  :type '(choice (const :tag "Default formatting" nil)
+                 (function :tag "Custom formatter"))
+  :group 'agent-shell)
+
 (cl-defun agent-shell--make-acp-client (&key command
                                              command-params
                                              environment-variables
@@ -7829,6 +7877,7 @@ When PICK-SHELL is non-nil, prompt for which shell buffer to use."
                            (agent-shell--shell-buffer)))
          (text (agent-shell--get-region-context
                 :deactivate t
+                :shell-buffer shell-buffer
                 :agent-cwd (with-current-buffer shell-buffer
                              (agent-shell-cwd)))))
     (if (with-current-buffer shell-buffer (shell-maker-busy))
@@ -7866,73 +7915,91 @@ With \\[universal-argument] \\[universal-argument] prefix ARG, prompt to pick an
              (agent-shell--read-queue-prompt :initial (concat text "\n\n"))))
         (agent-shell-insert :text text :shell-buffer shell-buffer))))))
 
-(cl-defun agent-shell--get-region-context (&key deactivate no-error agent-cwd)
+(cl-defun agent-shell--get-region-context (&key deactivate no-error agent-cwd shell-buffer)
   "Get region as insertable text, ready for sending to agent.
 
 When DEACTIVATE is non-nil, deactivate region.
 
 When NO-ERROR is non-nil, return nil and continue without error.
 
-Uses AGENT-CWD to shorten file paths where necessary."
+Uses AGENT-CWD to shorten file paths where necessary.
+
+SHELL-BUFFER, when live, is the target shell; its agent identifier and
+current model are passed to `agent-shell-region-context-format-function'."
   (let* ((region (or (agent-shell--get-region :deactivate deactivate)
                      (unless no-error
                        (user-error "No region selected"))))
-         (processed-text (if (map-elt region :file)
-                             (let ((file-link (agent-shell-ui-add-action-to-text
-                                               (format "%s:%d-%d"
-                                                       (if (and agent-cwd (file-in-directory-p (map-elt region :file) agent-cwd))
-                                                           (file-relative-name (map-elt region :file) agent-cwd)
-                                                         (map-elt region :file))
-                                                       (map-elt region :line-start)
-                                                       (map-elt region :line-end))
-                                               (lambda ()
-                                                 (interactive)
-                                                 (if (and (map-elt region :file) (file-exists-p (map-elt region :file)))
-                                                     (if-let* ((window (when (get-file-buffer (map-elt region :file))
-                                                                         (get-buffer-window (get-file-buffer (map-elt region :file))))))
-                                                         (progn
-                                                           (select-window window)
-                                                           (goto-char (point-min))
-                                                           (forward-line (1- (map-elt region :line-start)))
-                                                           (beginning-of-line)
-                                                           (push-mark (save-excursion
-                                                                        (goto-char (point-min))
-                                                                        (forward-line (1- (map-elt region :line-end)))
-                                                                        (end-of-line)
-                                                                        (point))
-                                                                      t t))
-                                                       (find-file (map-elt region :file))
-                                                       (goto-char (point-min))
-                                                       (forward-line (1- (map-elt region :line-start)))
-                                                       (beginning-of-line)
-                                                       (push-mark (save-excursion
-                                                                    (goto-char (point-min))
-                                                                    (forward-line (1- (map-elt region :line-end)))
-                                                                    (end-of-line)
-                                                                    (point))
-                                                                  t t))
-                                                   (message "File not found")))
-                                               (lambda ()
-                                                 (message "Press RET to open file"))
-                                               'agent-shell-link))
-                                   (numbered-preview
-                                    (when-let* ((buffer (get-file-buffer (map-elt region :file))))
-                                      (let ((char-start (map-elt region :char-start))
-                                            (char-end (map-elt region :char-end))
-                                            (max-preview-lines 5))
-                                        (if (= (count-lines char-start char-end) 1)
-                                            ;; Same line region? Avoid numbering.
-                                            (agent-shell--buffer-substring-with-faces
-                                             char-start char-end)
-                                          (agent-shell--get-numbered-region
-                                           :buffer buffer
-                                           :from char-start
-                                           :to char-end
-                                           :cap max-preview-lines))))))
-                               (if numbered-preview
-                                   (concat file-link "\n\n" numbered-preview)
-                                 file-link))
-                           (map-elt region :content))))
+         (processed-text
+          (or (when (and region agent-shell-region-context-format-function)
+                (let ((state (when (buffer-live-p shell-buffer)
+                               (with-current-buffer shell-buffer
+                                 (ignore-errors (agent-shell--state))))))
+                  (funcall agent-shell-region-context-format-function
+                           (list :file (map-elt region :file)
+                                 :language (map-elt region :language)
+                                 :line-start (map-elt region :line-start)
+                                 :line-end (map-elt region :line-end)
+                                 :content (map-elt region :content)
+                                 :agent-cwd agent-cwd
+                                 :agent (map-nested-elt state '(:agent-config :identifier))
+                                 :model (when state
+                                          (agent-shell--current-model-id state))))))
+              (if (map-elt region :file)
+                  (let ((file-link (agent-shell-ui-add-action-to-text
+                                    (format "%s:%d-%d"
+                                            (if (and agent-cwd (file-in-directory-p (map-elt region :file) agent-cwd))
+                                                (file-relative-name (map-elt region :file) agent-cwd)
+                                              (map-elt region :file))
+                                            (map-elt region :line-start)
+                                            (map-elt region :line-end))
+                                    (lambda ()
+                                      (interactive)
+                                      (if (and (map-elt region :file) (file-exists-p (map-elt region :file)))
+                                          (if-let* ((window (when (get-file-buffer (map-elt region :file))
+                                                              (get-buffer-window (get-file-buffer (map-elt region :file))))))
+                                              (progn
+                                                (select-window window)
+                                                (goto-char (point-min))
+                                                (forward-line (1- (map-elt region :line-start)))
+                                                (beginning-of-line)
+                                                (push-mark (save-excursion
+                                                             (goto-char (point-min))
+                                                             (forward-line (1- (map-elt region :line-end)))
+                                                             (end-of-line)
+                                                             (point))
+                                                           t t))
+                                            (find-file (map-elt region :file))
+                                            (goto-char (point-min))
+                                            (forward-line (1- (map-elt region :line-start)))
+                                            (beginning-of-line)
+                                            (push-mark (save-excursion
+                                                         (goto-char (point-min))
+                                                         (forward-line (1- (map-elt region :line-end)))
+                                                         (end-of-line)
+                                                         (point))
+                                                       t t))
+                                        (message "File not found")))
+                                    (lambda ()
+                                      (message "Press RET to open file"))
+                                    'agent-shell-link))
+                        (numbered-preview
+                         (when-let* ((buffer (get-file-buffer (map-elt region :file))))
+                           (let ((char-start (map-elt region :char-start))
+                                 (char-end (map-elt region :char-end))
+                                 (max-preview-lines 5))
+                             (if (= (count-lines char-start char-end) 1)
+                                 ;; Same line region? Avoid numbering.
+                                 (agent-shell--buffer-substring-with-faces
+                                  char-start char-end)
+                               (agent-shell--get-numbered-region
+                                :buffer buffer
+                                :from char-start
+                                :to char-end
+                                :cap max-preview-lines))))))
+                    (if numbered-preview
+                        (concat file-link "\n\n" numbered-preview)
+                      file-link))
+                (map-elt region :content)))))
     processed-text))
 
 (defun agent-shell--buffer-substring-with-faces (start end)
@@ -8133,17 +8200,21 @@ Tries flymake first, then flycheck."
   (or (agent-shell--get-flymake-error-context)
       (agent-shell--get-flycheck-error-context)))
 
-(cl-defun agent-shell--get-current-line-context (&key agent-cwd)
+(cl-defun agent-shell--get-current-line-context (&key agent-cwd shell-buffer)
   "Get the current line as insertable text, ready for sending to agent.
 
-Uses AGENT-CWD to shorten file paths where necessary."
+Uses AGENT-CWD to shorten file paths where necessary.
+
+SHELL-BUFFER is the target shell, forwarded to
+`agent-shell--get-region-context'."
   (save-excursion
     (let ((start (line-beginning-position))
           (end (line-end-position)))
       (goto-char start)
       (set-mark end)
       (activate-mark)
-      (agent-shell--get-region-context :deactivate t :no-error t :agent-cwd agent-cwd))))
+      (agent-shell--get-region-context
+       :deactivate t :no-error t :agent-cwd agent-cwd :shell-buffer shell-buffer))))
 
 (cl-defun agent-shell--context (&key shell-buffer)
   "Return context (if available).  Nil otherwise.
@@ -8165,10 +8236,10 @@ The sources checked are controlled by `agent-shell-context-sources'."
                     :agent-cwd agent-cwd))
            ('region (agent-shell--get-region-context
                      :deactivate t :no-error t
-                     :agent-cwd agent-cwd))
+                     :agent-cwd agent-cwd :shell-buffer shell-buffer))
            ('error (agent-shell--get-error-context))
            ('line (agent-shell--get-current-line-context
-                   :agent-cwd agent-cwd))
+                   :agent-cwd agent-cwd :shell-buffer shell-buffer))
            ((pred functionp) (funcall source))))
        agent-shell-context-sources))))
 

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -752,6 +752,64 @@ highlighting."
           (set-buffer-modified-p nil)))
       (ignore-errors (delete-file temp-file)))))
 
+(ert-deftest agent-shell--get-region-context-format-function-overrides ()
+  "A non-nil formatter replaces the default formatting and sees the region plist.
+
+Also checks that :agent and :model are populated from the target shell."
+  (let* ((temp-file (make-temp-file "agent-shell-region" nil ".py"))
+         (default-directory (file-name-directory temp-file))
+         (captured nil)
+         (state '((:agent-config . ((:identifier . claude-code)))
+                  (:session . ((:model-id . "claude-opus-4-8"))))))
+    (unwind-protect
+        (with-current-buffer (find-file-noselect temp-file)
+          (insert "def foo():\n    return 1\n")
+          (goto-char (point-min))
+          (set-mark (point-max))
+          (activate-mark)
+          (cl-letf (((symbol-function 'agent-shell--state) (lambda () state)))
+            (let* ((agent-shell-region-context-format-function
+                    (lambda (region)
+                      (setq captured region)
+                      (format "%s:%d-%d"
+                              (map-elt region :file)
+                              (map-elt region :line-start)
+                              (map-elt region :line-end))))
+                   (ctx (agent-shell--get-region-context
+                         :deactivate t :shell-buffer (current-buffer))))
+              (should (equal ctx (format "%s:1-2" temp-file)))
+              (should (equal (map-elt captured :file) temp-file))
+              (should (equal (map-elt captured :language) "python"))
+              (should (equal (map-elt captured :line-start) 1))
+              (should (equal (map-elt captured :line-end) 2))
+              (should (equal (map-elt captured :content)
+                             "def foo():\n    return 1\n"))
+              (should (equal (map-elt captured :agent) 'claude-code))
+              (should (equal (map-elt captured :model) "claude-opus-4-8")))))
+      (when (get-file-buffer temp-file)
+        (with-current-buffer (get-file-buffer temp-file)
+          (set-buffer-modified-p nil)))
+      (ignore-errors (delete-file temp-file)))))
+
+(ert-deftest agent-shell--get-region-context-format-function-nil-falls-back ()
+  "A formatter returning nil falls back to the default `path:line-range' header."
+  (let* ((temp-file (make-temp-file "agent-shell-region" nil ".txt"))
+         (default-directory (file-name-directory temp-file)))
+    (unwind-protect
+        (with-current-buffer (find-file-noselect temp-file)
+          (insert "one\ntwo\n")
+          (goto-char (point-min))
+          (set-mark (point-max))
+          (activate-mark)
+          (let* ((agent-shell-region-context-format-function (lambda (_region) nil))
+                 (ctx (agent-shell--get-region-context :deactivate t)))
+            (should (string-prefix-p (format "%s:1-2" temp-file)
+                                     (substring-no-properties ctx)))))
+      (when (get-file-buffer temp-file)
+        (with-current-buffer (get-file-buffer temp-file)
+          (set-buffer-modified-p nil)))
+      (ignore-errors (delete-file temp-file)))))
+
 (ert-deftest agent-shell--get-numbered-region-preserves-source-faces-only ()
   "Numbered region preview must keep faces but not source control properties.
 


### PR DESCRIPTION
## Why

When I send a region to an agent, I prefer to send it as a proper fenced
code block than as a `path:start-end` reference plus a bare numbered preview
in loose prose, as the current behavior.

Three reasons:

- The agent gets cleaner, more familiar input: a fenced block with a
  language tag and a `cat -n`-style body. This is the shape coding agents
  emit and consume for file contents.
- A fenced block makes it much easier to type prose above and below the snippet
  in the same prompt without the pasted lines bleeding into my own text.
- An automatic info string characterizing the fenced blocks; this is a nice
  touch that guides the agent to know what type of input it received (C code, elisp,
  LaTeX, etc).

I have already been doing this on my Emacs setup using "advices"; however, this
solution relied on brittle "advices", and I genuinely believe this solution represents
an improvement for all users of agent shell.

This is all text sent to the agent, so there's no change to any API or
on-disk format.

However, if users for some reason want to opt out from the new behavior, there is a
defcustom: by specifying '`unfenced` instead of `'fenced`, content is passed following
the old behavior. 

## What changed

Three commits, reviewable independently:

### 1. `agent-shell-region-context-style` — fenced code block for regions

New `defcustom` controlling how a selected region is formatted as context.
It's consumed at the single chokepoint `agent-shell--get-region-context`, so
it covers both `agent-shell-send-region` and the `region` source of
`agent-shell-send-dwim`.

- `fenced` (new default): a fenced block whose info string carries the
  buffer language and a clickable `path:line-range`, with the existing
  capped, numbered body (Expand button and all) inside the fence.
- `unfenced`: a clickable `path:line-range` followed by the numbered
  preview, without the fence.

`unfenced`:

```
    path/to/file.el:359-361

    359       (foo)
    360       (bar)
    361       (baz)
```

`fenced`:

````
```elisp path/to/file.el:359-361
359   (foo)
360   (bar)
361   (baz)
```
````

The language tag comes from a new `agent-shell-language-alist` (major mode →
fence identifier, e.g. `emacs-lisp-mode` → `elisp`, `c++-mode` → `cpp`) via a
small helper `agent-shell--language-for-mode`, which falls back to stripping
the `-ts-mode`/`-mode` suffix (so `python-ts-mode` → `python`). This replaces
the inline suffix-strip previously used to compute a region's `:language`.

### 2. Number line context as `cat -n`

`agent-shell--get-numbered-region` previously emitted `   N: line`. This
switches it to the `cat -n` shape (right-aligned line number, a tab, then the
line) — the format agents already produce and read for file contents. It
also touches the error/diff context previews built on the same helper (the
trim regexp and the error-line highlight in `agent-shell--format-diagnostic`,
now `-> N<tab>`).

Before: `   360: (bar)`
After:  `360\t(bar)`

### 3. Collapse single-line range in the header

A single-line selection previously showed its header range as `path:N-N`.
It now emits `path:N`: for one line the header already pins the exact line, so
the range form is redundant, and the body carries the raw line unnumbered
(this preserves the existing `;; Same line region? Avoid numbering.` path):

````
```elisp path/to/file.el:359
(foo)
```
````

## Compatibility

Both defaults change the *text sent to the agent* (region context is now
fenced; numbered previews are now tab-separated), but nothing user-facing
breaks and there's no API/format change. `agent-shell-region-context-style`
can be set to `unfenced` to restore the old region format.

If you'd rather these be opt-in, I'm happy to flip the default of
`agent-shell-region-context-style` to `unfenced`, and/or split the `cat -n`
change into its own PR since it has the wider blast radius.

## Tests

`tests/agent-shell-tests.el`:

- `agent-shell--language-for-mode-test` — alist overrides win, else the
  suffix strip; caller-supplied alist respected.
- `agent-shell--get-region-context-style-test` — both `fenced` and
  `unfenced` output.
- `agent-shell--get-numbered-region-test` updated for the `cat -n` shape.

---

If you wish for any change, I am happy to follow your lead.