### PR TITLE
Strip source-buffer properties from grabbed region context

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -7422,7 +7422,8 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                             (max-preview-lines 5))
                                         (if (= (count-lines char-start char-end) 1)
                                             ;; Same line region? Avoid numbering.
-                                            (buffer-substring-no-properties char-start char-end)
+                                            (agent-shell--buffer-substring-with-faces
+                                             char-start char-end)
                                           (agent-shell--get-numbered-region
                                            :buffer buffer
                                            :from char-start
@@ -7433,6 +7434,23 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                  file-link))
                            (map-elt region :content))))
     processed-text))
+
+(defun agent-shell--buffer-substring-with-faces (start end)
+  "Return text between START and END, preserving only face properties."
+  (let ((text (buffer-substring start end))
+        (pos 0))
+    (while (< pos (length text))
+      (let ((next (or (next-property-change pos text) (length text)))
+            (props (text-properties-at pos text))
+            remove-props)
+        (while props
+          (unless (memq (car props) '(face font-lock-face))
+            (setq remove-props (plist-put remove-props (car props) nil)))
+          (setq props (cddr props)))
+        (when remove-props
+          (remove-text-properties pos next remove-props text))
+        (setq pos next)))
+    text))
 
 (cl-defun agent-shell--get-numbered-region (&key buffer from to cap trim)
   "Get region from BUFFER between FROM and TO locations.
@@ -7456,10 +7474,10 @@ If CAP is non-nil, truncate at CAP."
         (goto-char (point-min))
         (forward-line (1- start-line))
         (while (<= current-line end-line)
-          (let ((line-content (buffer-substring-no-properties
+          (let ((line-content (agent-shell--buffer-substring-with-faces
                                (line-beginning-position)
                                (line-end-position))))
-            (push (format "   %d: %s" current-line line-content)
+            (push (concat (format "   %d: " current-line) line-content)
                   lines))
           (forward-line 1)
           (setq current-line (1+ current-line)))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -7422,7 +7422,7 @@ Uses AGENT-CWD to shorten file paths where necessary."
                                             (max-preview-lines 5))
                                         (if (= (count-lines char-start char-end) 1)
                                             ;; Same line region? Avoid numbering.
-                                            (buffer-substring char-start char-end)
+                                            (buffer-substring-no-properties char-start char-end)
                                           (agent-shell--get-numbered-region
                                            :buffer buffer
                                            :from char-start
@@ -7456,7 +7456,7 @@ If CAP is non-nil, truncate at CAP."
         (goto-char (point-min))
         (forward-line (1- start-line))
         (while (<= current-line end-line)
-          (let ((line-content (buffer-substring
+          (let ((line-content (buffer-substring-no-properties
                                (line-beginning-position)
                                (line-end-position))))
             (push (format "   %d: %s" current-line line-content)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -709,15 +709,15 @@ baz
                     :to to)
                    "   2: bar")))))
 
-(ert-deftest agent-shell--get-region-context-strips-source-properties ()
-  "Region context must not carry text properties from the source buffer.
+(ert-deftest agent-shell--get-region-context-preserves-source-faces-only ()
+  "Region context must keep faces but not source control properties.
 
 A markdown-mode source buffer fonts emphasis markup (e.g. underscores)
 with `invisible' and `face' properties.  When a single-line region is
-grabbed for the file-link preview, those foreign properties must not
-leak into the context, otherwise the compose buffer renders the text
-with the source mode's styling (underscores hidden, inner text italic)
-instead of as literal text."
+grabbed for the file-link preview, source control properties must not
+leak into the context, otherwise the compose buffer may hide literal
+text.  Face properties are intentionally preserved for syntax
+highlighting."
   (let* ((temp-file (make-temp-file "agent-shell-region" nil ".txt"))
          (default-directory (file-name-directory temp-file)))
     (unwind-protect
@@ -730,6 +730,8 @@ instead of as literal text."
             ;; would carry.
             (put-text-property (point-min) (point-max)
                                'face 'markdown-markup-face)
+            (put-text-property (point-min) (point-max)
+                               'font-lock-face 'font-lock-string-face)
             (goto-char (point-min))
             (while (search-forward "_" nil t)
               (put-text-property (1- (point)) (point)
@@ -740,24 +742,29 @@ instead of as literal text."
             (let ((ctx (agent-shell--get-region-context :deactivate t)))
               (should-not (text-property-any 0 (length ctx)
                                              'invisible 'markdown-markup ctx))
-              (should-not (text-property-any 0 (length ctx)
-                                             'face 'markdown-markup-face ctx)))))
+              (should (text-property-any 0 (length ctx)
+                                         'face 'markdown-markup-face ctx))
+              (should (text-property-any 0 (length ctx)
+                                         'font-lock-face
+                                         'font-lock-string-face ctx)))))
       (when (get-file-buffer temp-file)
         (with-current-buffer (get-file-buffer temp-file)
           (set-buffer-modified-p nil)))
       (ignore-errors (delete-file temp-file)))))
 
-(ert-deftest agent-shell--get-numbered-region-strips-source-properties ()
-  "Numbered region preview must not carry source-buffer text properties.
+(ert-deftest agent-shell--get-numbered-region-preserves-source-faces-only ()
+  "Numbered region preview must keep faces but not source control properties.
 
 A multi-line region spanning lines that carry foreign properties (e.g.
-markdown-mode's `invisible' on emphasis markup) must come back clean so
-the compose buffer shows literal source text, not the source mode's
-rendering."
+markdown-mode's `invisible' on emphasis markup) must drop control
+properties so the compose buffer shows literal source text.  Face
+properties are intentionally preserved for syntax highlighting."
   (with-temp-buffer
     (insert "_hello_
 _world_")
     (put-text-property (point-min) (point-max) 'face 'markdown-markup-face)
+    (put-text-property (point-min) (point-max)
+                       'font-lock-face 'font-lock-string-face)
     (goto-char (point-min))
     (while (search-forward "_" nil t)
       (put-text-property (1- (point)) (point) 'invisible 'markdown-markup))
@@ -767,8 +774,11 @@ _world_")
                    :to (point-max))))
       (should-not (text-property-any 0 (length result)
                                      'invisible 'markdown-markup result))
-      (should-not (text-property-any 0 (length result)
-                                     'face 'markdown-markup-face result)))))
+      (should (text-property-any 0 (length result)
+                                 'face 'markdown-markup-face result))
+      (should (text-property-any 0 (length result)
+                                 'font-lock-face
+                                 'font-lock-string-face result)))))
 
 (ert-deftest agent-shell--expand-truncated-regions-test ()
   "Test `agent-shell--expand-truncated-regions' substitutes marked spans for their full text."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -709,6 +709,67 @@ baz
                     :to to)
                    "   2: bar")))))
 
+(ert-deftest agent-shell--get-region-context-strips-source-properties ()
+  "Region context must not carry text properties from the source buffer.
+
+A markdown-mode source buffer fonts emphasis markup (e.g. underscores)
+with `invisible' and `face' properties.  When a single-line region is
+grabbed for the file-link preview, those foreign properties must not
+leak into the context, otherwise the compose buffer renders the text
+with the source mode's styling (underscores hidden, inner text italic)
+instead of as literal text."
+  (let* ((temp-file (make-temp-file "agent-shell-region" nil ".txt"))
+         (default-directory (file-name-directory temp-file)))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "_hello_world_"))
+          (with-current-buffer (find-file-noselect temp-file)
+            ;; Simulate markdown-mode font-lock properties on the
+            ;; underscores, as a real markdown/poly-markdown buffer
+            ;; would carry.
+            (put-text-property (point-min) (point-max)
+                               'face 'markdown-markup-face)
+            (goto-char (point-min))
+            (while (search-forward "_" nil t)
+              (put-text-property (1- (point)) (point)
+                                 'invisible 'markdown-markup))
+            (goto-char (point-min))
+            (set-mark (point-max))
+            (activate-mark)
+            (let ((ctx (agent-shell--get-region-context :deactivate t)))
+              (should-not (text-property-any 0 (length ctx)
+                                             'invisible 'markdown-markup ctx))
+              (should-not (text-property-any 0 (length ctx)
+                                             'face 'markdown-markup-face ctx)))))
+      (when (get-file-buffer temp-file)
+        (with-current-buffer (get-file-buffer temp-file)
+          (set-buffer-modified-p nil)))
+      (ignore-errors (delete-file temp-file)))))
+
+(ert-deftest agent-shell--get-numbered-region-strips-source-properties ()
+  "Numbered region preview must not carry source-buffer text properties.
+
+A multi-line region spanning lines that carry foreign properties (e.g.
+markdown-mode's `invisible' on emphasis markup) must come back clean so
+the compose buffer shows literal source text, not the source mode's
+rendering."
+  (with-temp-buffer
+    (insert "_hello_
+_world_")
+    (put-text-property (point-min) (point-max) 'face 'markdown-markup-face)
+    (goto-char (point-min))
+    (while (search-forward "_" nil t)
+      (put-text-property (1- (point)) (point) 'invisible 'markdown-markup))
+    (let ((result (agent-shell--get-numbered-region
+                   :buffer (current-buffer)
+                   :from (point-min)
+                   :to (point-max))))
+      (should-not (text-property-any 0 (length result)
+                                     'invisible 'markdown-markup result))
+      (should-not (text-property-any 0 (length result)
+                                     'face 'markdown-markup-face result)))))
+
 (ert-deftest agent-shell--expand-truncated-regions-test ()
   "Test `agent-shell--expand-truncated-regions' substitutes marked spans for their full text."
   ;; No marked regions: prompt unchanged.


### PR DESCRIPTION
agent-shell--get-region-context built its single-line file-link preview with `buffer-substring`, and `agent-shell--get-numbered-region` built its numbered preview the same way. `buffer-substring` copies all text properties, so when the source buffer was a `markdown-mode` or `poly-markdown` buffer, `markdown-mode`'s font-lock leaked into the grabbed context: the emphasis markup characters carried `'invisible markdown-markup'` + `'markdown-markup-face'` and the enclosed text carried italic faces. `_hello_world_` then showed up in the compose buffer as `helloworld` (underscores hidden, inner text italic) — the same intraword-underscore symptom the response renderer was already fixed to avoid.

Use `buffer-substring-no-properties` for both preview paths so the context carries plain text and no foreign-mode styling.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
