### PR TITLE
Fix agent-shell-send-dwim double-inserting context with prefix arg

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -972,6 +972,29 @@ With \\[universal-argument] \\[universal-argument] prefix ARG, prompt to pick an
    (t
     (agent-shell--dwim))))
 
+(defun agent-shell--display-and-insert-context (shell-buffer text)
+  "Display SHELL-BUFFER and insert TEXT into it.
+
+When SHELL-BUFFER uses the `prompt' session strategy and has no session id
+yet, defer displaying and inserting until the `session-selected' event;
+otherwise do so immediately.  TEXT may be nil, in which case nothing is
+inserted."
+  (if (and (eq (buffer-local-value 'agent-shell-session-strategy shell-buffer) 'prompt)
+           (not (map-nested-elt (buffer-local-value 'agent-shell--state shell-buffer)
+                                '(:session :id))))
+      (agent-shell-subscribe-to
+       :shell-buffer shell-buffer
+       :event 'session-selected
+       :on-event (lambda (_event)
+                   (agent-shell--display-buffer shell-buffer)
+                   (when text
+                     (agent-shell--insert-to-shell-buffer :text text
+                                                          :shell-buffer shell-buffer))))
+    (agent-shell--display-buffer shell-buffer)
+    (when text
+      (agent-shell--insert-to-shell-buffer :text text
+                                           :shell-buffer shell-buffer))))
+
 (cl-defun agent-shell--dwim (&key config new-shell switch-to-shell)
   "Start or reuse an agent shell with DWIM behavior.
 
@@ -1027,11 +1050,16 @@ handles viewport mode detection, existing shell reuse, and project context."
                (agent-shell--insert-to-shell-buffer :text text
                                                     :shell-buffer shell-buffer))))
           (new-shell
-           (agent-shell-start :config (or config
-                                          (agent-shell--auto-preferred-config)
-                                          (agent-shell-select-config
-                                           :prompt "Start new agent: ")
-                                          (error "No agent config found"))))
+           (let* ((shell-buffer (agent-shell--start
+                                 :config (or config
+                                             (agent-shell--auto-preferred-config)
+                                             (agent-shell-select-config
+                                              :prompt "Start new agent: ")
+                                             (error "No agent config found"))
+                                 :no-focus t
+                                 :new-session t))
+                  (text (agent-shell--context :shell-buffer shell-buffer)))
+             (agent-shell--display-and-insert-context shell-buffer text)))
           (t
            (if (derived-mode-p 'agent-shell-mode)
                (let* ((shell-buffer (agent-shell--shell-buffer :no-create t))
@@ -1042,22 +1070,7 @@ handles viewport mode detection, existing shell reuse, and project context."
                                                         :shell-buffer shell-buffer)))
              (let* ((shell-buffer (agent-shell--shell-buffer))
                     (text (agent-shell--context :shell-buffer shell-buffer)))
-               (if (and (eq (buffer-local-value 'agent-shell-session-strategy shell-buffer) 'prompt)
-                        (not (map-nested-elt (buffer-local-value 'agent-shell--state shell-buffer)
-                                             '(:session :id))))
-                   ;; Defer viewport display until session is selected.
-                   (agent-shell-subscribe-to
-                    :shell-buffer shell-buffer
-                    :event 'session-selected
-                    :on-event (lambda (_event)
-                                (agent-shell--display-buffer shell-buffer)
-                                (when text
-                                  (agent-shell--insert-to-shell-buffer :text text
-                                                                       :shell-buffer shell-buffer))))
-                 (agent-shell--display-buffer shell-buffer)
-                 (when text
-                   (agent-shell--insert-to-shell-buffer :text text
-                                                        :shell-buffer shell-buffer)))))))))
+               (agent-shell--display-and-insert-context shell-buffer text)))))))
 
 ;;;###autoload
 (defun agent-shell-toggle ()
@@ -7349,22 +7362,22 @@ With \\[universal-argument] prefix ARG, force start a new shell.
 
 With \\[universal-argument] \\[universal-argument] prefix ARG, prompt to pick an existing shell."
   (interactive "P")
-  (let* ((shell-buffer
-          (cond
-           ((equal arg '(16))
-            (agent-shell--dwim :switch-to-shell t)
-            (agent-shell--shell-buffer))
-           ((equal arg '(4))
-            (agent-shell--dwim :new-shell t)
-            (agent-shell--shell-buffer))
-           (t
-            (agent-shell--shell-buffer))))
-         (text (agent-shell--context :shell-buffer shell-buffer)))
-    (if (with-current-buffer shell-buffer (shell-maker-busy))
-        (with-current-buffer shell-buffer
-          (agent-shell-queue-request
-           (agent-shell--read-queue-prompt :initial (concat text "\n\n"))))
-      (agent-shell-insert :text text :shell-buffer shell-buffer))))
+  (cond
+   ;; `agent-shell--dwim' already carries the context to the chosen shell
+   ;; (deferring until the session is selected when needed), so let it own
+   ;; the send rather than inserting a second time here.
+   ((equal arg '(16))
+    (agent-shell--dwim :switch-to-shell t))
+   ((equal arg '(4))
+    (agent-shell--dwim :new-shell t))
+   (t
+    (let* ((shell-buffer (agent-shell--shell-buffer))
+           (text (agent-shell--context :shell-buffer shell-buffer)))
+      (if (with-current-buffer shell-buffer (shell-maker-busy))
+          (with-current-buffer shell-buffer
+            (agent-shell-queue-request
+             (agent-shell--read-queue-prompt :initial (concat text "\n\n"))))
+        (agent-shell-insert :text text :shell-buffer shell-buffer))))))
 
 (cl-defun agent-shell--get-region-context (&key deactivate no-error agent-cwd)
   "Get region as insertable text, ready for sending to agent.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2013,6 +2013,67 @@ remaining subscribers nor propagate out of `agent-shell--emit-event'."
                                "context from source"))))
           (kill-buffer shell-buffer))))))
 
+
+(ert-deftest agent-shell-send-dwim-with-prefix-appends-context-once-test ()
+  "Test `agent-shell-send-dwim' with a prefix arg appends context once.
+
+With \\[universal-argument] \\[universal-argument], the command picks an
+existing shell via `agent-shell--dwim' and must append the DWIM context to
+the viewport exactly once.  `agent-shell--dwim' already performs the append,
+so the command must not append a second time."
+  (let ((agent-shell-prefer-viewport-interaction t))
+    (with-temp-buffer
+      (let ((source-buffer (current-buffer))
+            (shell-buffer (generate-new-buffer " *agent-shell shell*"))
+            (appends nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer shell-buffer
+                (setq-local agent-shell-session-strategy 'reuse)
+                (setq-local agent-shell--state
+                            `((:buffer . ,shell-buffer)
+                              (:session . ((:id . "session-1"))))))
+              (cl-letf (((symbol-function 'agent-shell--shell-buffer)
+                         (lambda (&rest _) shell-buffer))
+                        ((symbol-function 'agent-shell--read-shell-buffer)
+                         (lambda (&rest _) shell-buffer))
+                        ((symbol-function 'agent-shell--context)
+                         (lambda (&key shell-buffer)
+                           (ignore shell-buffer)
+                           "context from source"))
+                        ((symbol-function 'shell-maker-busy)
+                         (lambda (&rest _) nil))
+                        ((symbol-function 'agent-shell-viewport--show-buffer)
+                         (lambda (&rest args)
+                           (push (plist-get args :append) appends))))
+                (with-current-buffer source-buffer
+                  (agent-shell-send-dwim '(16)))
+                (should (equal appends '("context from source")))))
+          (kill-buffer shell-buffer))))))
+
+(ert-deftest agent-shell-send-dwim-without-prefix-appends-context-once-test ()
+  "Test `agent-shell-send-dwim' without a prefix arg appends context once."
+  (let ((agent-shell-prefer-viewport-interaction t))
+    (with-temp-buffer
+      (let ((source-buffer (current-buffer))
+            (shell-buffer (generate-new-buffer " *agent-shell shell*"))
+            (appends nil))
+        (unwind-protect
+            (cl-letf (((symbol-function 'agent-shell--shell-buffer)
+                       (lambda (&rest _) shell-buffer))
+                      ((symbol-function 'agent-shell--context)
+                       (lambda (&key shell-buffer)
+                         (ignore shell-buffer)
+                         "context from source"))
+                      ((symbol-function 'shell-maker-busy)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'agent-shell-viewport--show-buffer)
+                       (lambda (&rest args)
+                         (push (plist-get args :append) appends))))
+              (with-current-buffer source-buffer
+                (agent-shell-send-dwim))
+              (should (equal appends '("context from source"))))
+          (kill-buffer shell-buffer))))))
 (ert-deftest agent-shell--on-request-emits-permission-request-event-test ()
   "Test `agent-shell--on-request' emits permission-request event."
   (let ((received-events nil)


### PR DESCRIPTION
With a prefix argument, `agent-shell-send-dwim` called `agent-shell--dwim` to switch to or start a shell and then inserted the DWIM context itself. But `agent-shell--dwim` already carries the context to the chosen shell, so the context landed twice — most visibly when picking an existing session, where the deferred (post `session-selected`) insert and the trailing insert both fired.

Let `agent-shell--dwim` own the send for the prefix branches. To keep this from regressing `C-u` (new shell) in non-viewport mode — the one prefix case that wasn't doubled, because the new-shell branch was the only branch that didn't carry context — make that branch carry context like the others. Extract the shared display-and-insert logic into `agent-shell--display-and-insert-context`.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
