### PR TITLE
fix mouse-copy inside formatted text

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -385,7 +385,15 @@ body un-fontified."
         (put-text-property (point-min) (point-max)
                            'yank-handler
                            (list (lambda (s)
-                                   (insert (substring-no-properties s))))))
+                                   (insert (substring-no-properties s)))))
+        ;; Mark rendered chars `fontified' so jit-lock never re-runs over
+        ;; them during a mouse drag.  We style via `face'/`font-lock-face'
+        ;; text properties, not font-lock keywords (`font-lock-defaults'
+        ;; is `(nil t)'), so an in-drag jit-lock pass applies nothing —
+        ;; but firing at all disturbs drag tracking and collapses the
+        ;; selection to empty, silently breaking mouse copy of rendered
+        ;; text (keyboard selection is unaffected).
+        (put-text-property (point-min) (point-max) 'fontified t))
       (agent-shell-markdown--update-watermark
        :source-blocks source-blocks
        :external-candidates (seq-keep (lambda (result) (map-elt result :watermark))

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -381,6 +381,20 @@ print(\"hi\")
     (should (eq t (get-text-property 13 'agent-shell-markdown-frozen s)))
     (should (null (get-text-property 0 'agent-shell-markdown-frozen s)))))
 
+(ert-deftest agent-shell-markdown-convert-rendered-text-marked-fontified ()
+  ;; Rendered chars carry `fontified t' so jit-lock never re-runs over
+  ;; them.  We style via `face'/`font-lock-face' text properties, not
+  ;; font-lock keywords, so a jit-lock pass applies nothing — but its
+  ;; firing mid-drag disturbs mouse drag-tracking and collapses the
+  ;; selection to empty, silently breaking mouse copy of rendered text.
+  ;; Marking `fontified t' up front prevents that pass entirely.
+  (let ((s (agent-shell-markdown-convert "hello **world**")))
+    (should (eq t (get-text-property 0 'fontified s)))
+    (should (eq t (get-text-property (1- (length s)) 'fontified s))))
+  ;; Also holds for fenced source blocks (the reported failure case).
+  (let ((s (agent-shell-markdown-convert "```\ncode\n```")))
+    (should (eq t (get-text-property 1 'fontified s)))))
+
 (ert-deftest agent-shell-markdown-source-block-streamed-in-chunks ()
   ;; Real-world LLM streaming: a fenced code block arrives in small
   ;; chunks that split the opening fence, the language line, body


### PR DESCRIPTION
This fixes the copy (yank) of the text inside formatted Markdown with a mouse. Not sure if the test makes sense here. Because you can't actually test this. You need a real window and a mouse to reproduce.

I use this code to be able to use the mouse to yank text:

```lisp
(setq x-select-enable-clipboard t)
(setq mouse-drag-copy-region 'non-empty)
(setq x-select-enable-clipboard-manager nil)
;; (setq interprogram-paste-function 'x-cut-buffer-or-selection-value)
(setq interprogram-paste-function 'x-selection-value)
(delete-selection-mode t)

(add-to-list 'yank-excluded-properties 'font)
(add-to-list 'yank-excluded-properties 'font-lock-face)
```

Before the fix, when you copy the text with the mouse and select it (exactly the formatted text or inside), the text is not copied because the selection is empty.

The keyboard copy works fine. Only the mouse selection (yank) is affected.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
