### PR TITLE
fix: reverse mouse selection

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1602,10 +1602,19 @@ See also `agent-shell-confirm-interrupt'."
 
 (defun agent-shell--filter-buffer-substring (start end &optional delete)
   "Return visible text between START and END, stripping hidden markup.
-If DELETE is non-nil, delete the text between START and END."
-  (let ((text "")
-        (pos start))
-    (while (< pos end)
+If DELETE is non-nil, delete the text between START and END.
+
+START and END may be given in either order: like the stock
+`buffer-substring', a reversed range (START > END, e.g. a
+right-to-left mouse selection or a kill where mark > point) is
+normalized.  Without this, the loop below would never run and the
+function would return the empty string, silently breaking mouse
+copy depending on selection direction."
+  (let* ((beg (min start end))
+         (fin (max start end))
+         (text "")
+         (pos beg))
+    (while (< pos fin)
       (let ((next (next-overlay-change pos))
             (exclude (seq-find (lambda (ov)
                                  (memq (overlay-get ov 'markdown-overlays-markup-type)
@@ -1613,10 +1622,10 @@ If DELETE is non-nil, delete the text between START and END."
                                                bold italic strikethrough header)))
                                (overlays-at pos))))
         (unless exclude
-          (setq text (concat text (buffer-substring pos (min next end)))))
+          (setq text (concat text (buffer-substring pos (min next fin)))))
         (setq pos (max next (1+ pos)))))
     (when delete
-      (delete-region start end))
+      (delete-region beg fin))
     (remove-text-properties 0 (length text)
                             '(line-prefix nil wrap-prefix nil)
                             text)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -3488,6 +3488,19 @@ and it must handle that cleanly."
     (let ((result (agent-shell--filter-buffer-substring (point-min) (point-max))))
       (should (equal result "Use foo-bar for that.")))))
 
+(ert-deftest agent-shell-filter-buffer-substring-handles-reversed-range ()
+  "START may be greater than END (e.g. a right-to-left mouse
+selection, or a kill where mark > point).  Like the stock
+`buffer-substring', the result must match the forward range rather
+than the empty string -- otherwise mouse copy silently yields
+nothing depending on selection direction."
+  (with-temp-buffer
+    (insert "hello world")
+    (let ((forward  (agent-shell--filter-buffer-substring (point-min) (point-max)))
+          (reversed (agent-shell--filter-buffer-substring (point-max) (point-min))))
+      (should (equal forward "hello world"))
+      (should (equal reversed forward)))))
+
 (ert-deftest agent-shell-trim-strips-untagged-whitespace ()
   ;; Plain `string-trim'-style behavior when nothing is tagged: outer
   ;; whitespace is removed.


### PR DESCRIPTION
This is another fix for the mouse selection.

The bug was that the selection only worked from smaller point to bigger; it was not working when you selected the range in reverse order.

The bug was causing an empty string to be returned by the filter and added to the kill-ring when using a mouse. There is also a separate bug in Emacs that the empty string is added to the kill ring.

To reproduce, you need to enable mouse selection. This is my setup:

```elisp
(setq x-select-enable-clipboard t)
(setq kill-read-only-ok t)
(setq mouse-drag-copy-region t)
(setq x-select-enable-clipboard-manager nil)

(if (fboundp 'x-cut-buffer-or-selection-value)
    (setq interprogram-paste-function 'x-cut-buffer-or-selection-value)
  (setq interprogram-paste-function 'x-selection-value))

(delete-selection-mode t)

(add-to-list 'yank-excluded-properties 'font)
(add-to-list 'yank-excluded-properties 'font-lock-face)
```

The same bug is in Emacs filter for the `*Backtrace*` buffer. Reported [here](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81365)

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
