### PR TITLE
add cursor toolcall output adapter

### DIFF
--- a/agent-shell-cursor.el
+++ b/agent-shell-cursor.el
@@ -60,12 +60,12 @@ Only one of API-KEY, AUTH-TOKEN, LOGIN, or NONE should be provided."
   (agent-shell-cursor-make-authentication :none t)
   "Configuration for Cursor authentication.
 
-By default authentication is handled externally: agent-shell sends no
+By default authentication is handled externally: `agent-shell' sends no
 ACP authenticate request and relies on an existing Cursor login (run
 `agent login' once outside Emacs).  This matches how Cursor was used
 before and needs no configuration.
 
-Optionally, configure agent-shell to manage authentication instead.
+Optionally, configure `agent-shell' to manage authentication instead.
 
 For no authentication, handled externally (default):
 
@@ -121,6 +121,145 @@ starting the Cursor agent process."
   :type '(repeat string)
   :group 'agent-shell)
 
+(defun agent-shell-cursor--make-text-content-block (text)
+  "Wrap TEXT in a standard ACP tool-call content block alist.
+
+Return nil when TEXT is nil or empty.
+
+Examples:
+
+  (agent-shell-cursor--make-text-content-block \"hello\")
+    => \\='((type . \"content\")
+         (content (type . \"text\") (text . \"hello\")))"
+  (when (and (stringp text) (not (string-empty-p text)))
+    `((type . "content")
+      (content (type . "text") (text . ,text)))))
+
+(defun agent-shell-cursor--content-from-raw-output (raw-output)
+  "Convert Cursor-style RAW-OUTPUT alist into ACP content blocks.
+
+Examples:
+
+  ;; raw output
+  (agent-shell-cursor--content-from-raw-output \\='((stdout . \"done\")))
+    => \\='(((type . \"content\")
+          (content (type . \"text\") (text . \"```\\ndone\\n```\"))))
+
+  ;; error message
+  (agent-shell-cursor--content-from-raw-output
+   \\='((error . \"permission denied\")))
+   => \\='(((type . \"content\")
+          (content (type . \"text\") (text . \"permission denied\"))))
+
+  ;; read/content
+  (agent-shell-cursor--content-from-raw-output
+   \\='((content . \"file contents\")))
+   => \\='(((type . \"content\")
+          (content (type . \"text\") (text . \"file contents\"))))
+
+  ;; grep matches
+  (agent-shell-cursor--content-from-raw-output
+   \\='((totalMatches . 42) (truncated . t)))
+   => \\='(((type . \"content\")
+          (content (type . \"text\") (text . \"42 matches (truncated)\"))))
+
+  ;; glob/search results
+  (agent-shell-cursor--content-from-raw-output \\='((resultCount . 7)))
+   => \\='(((type . \"content\")
+          (content (type . \"text\") (text . \"7 results\"))))"
+  (when raw-output
+    (cond
+     ((map-elt raw-output 'error)
+      (list (agent-shell-cursor--make-text-content-block
+             (map-elt raw-output 'error))))
+     ((stringp (map-elt raw-output 'content))
+      (list (agent-shell-cursor--make-text-content-block
+             (map-elt raw-output 'content))))
+     ((or (map-elt raw-output 'stdout)
+          (map-elt raw-output 'stderr)
+          (map-elt raw-output 'exitCode))
+      (let* ((exit (map-elt raw-output 'exitCode))
+             (stdout (or (map-elt raw-output 'stdout) ""))
+             (stderr (or (map-elt raw-output 'stderr) ""))
+             (parts (delq nil
+                          (list (when (numberp exit) (format "Exit code: %s" exit))
+                                (when (not (string-empty-p stdout)) stdout)
+                                (when (and (stringp stderr)
+                                           (not (string-empty-p stderr)))
+                                  stderr))))
+             (text (if parts
+                       (mapconcat #'identity parts "\n\n")
+                     "(no output)")))
+        (list (agent-shell-cursor--make-text-content-block
+               (format "```\n%s\n```" text)))))
+     ((map-elt raw-output 'totalMatches)
+      (list (agent-shell-cursor--make-text-content-block
+             (format "%s matches%s"
+                     (map-elt raw-output 'totalMatches)
+                     (if (map-elt raw-output 'truncated)
+                         " (truncated)"
+                       "")))))
+     ((map-elt raw-output 'resultCount)
+      (list (agent-shell-cursor--make-text-content-block
+             (format "%s results"
+                     (map-elt raw-output 'resultCount)))))
+     (t nil))))
+
+(cl-defun agent-shell-cursor--notification-adapter (&key acp-notification)
+  "Adapt Cursor ACP notifications by filling tool call content from rawOutput.
+
+When a completed `tool_call_update' notification has `rawOutput' but no
+`content', convert `rawOutput' into standard ACP content blocks and
+attach them to the notification in place.
+
+Examples:
+
+  ;; completed shell tool with stdout only
+  (agent-shell-cursor--notification-adapter :ACP-NOTIFICATION
+      \\='((method . \"session/update\")
+                 (params (update (sessionUpdate . \"tool_call_update\")
+                                 (status . \"completed\")
+                                 (rawOutput (stdout . \"done\"))))))
+
+   => \\='((method . \"session/update\")
+        (params (update (sessionUpdate . \"tool_call_update\")
+                        (status . \"completed\")
+                        (content ((type . \"content\")
+                                  (content (type . \"text\")
+                                           (text . \"```\\ndone\\n```\")))))))
+
+
+  ;; existing content is left unchanged
+  (agent-shell-cursor--notification-adapter :acp-notification
+      \\='((method . \"session/update\")
+          (params (update (sessionUpdate . \"tool_call_update\")
+                          (status . \"completed\")
+                          (content ((type . \"content\")
+                                    (content (type . \"text\")
+                                             (text . \"keep me\"))))
+                          (rawOutput (stdout . \"ignored\"))))))
+  
+    => \\='((method . \"session/update\")
+          (params (update (sessionUpdate . \"tool_call_update\")
+                          (status . \"completed\")
+                          (content ((type . \"content\")
+                                      (content (type . \"text\")
+                                               (text . \"keep me\"))))
+                          (rawOutput (stdout . \"ignored\")))))"
+  (when-let* ((method (map-elt acp-notification 'method))
+              ((equal method "session/update"))
+              (update-type (map-nested-elt acp-notification
+                                            '(params update sessionUpdate)))
+              ((equal update-type "tool_call_update"))
+              ((seq-empty-p (map-nested-elt acp-notification
+                                                 '(params update content))))
+              (raw-output (map-nested-elt acp-notification
+                                          '(params update rawOutput)))
+              (content (agent-shell-cursor--content-from-raw-output raw-output)))
+    (setf (alist-get 'content (alist-get 'update (alist-get 'params acp-notification)))
+          content))
+  acp-notification)
+
 (defun agent-shell-cursor-make-agent-config ()
   "Create a Cursor agent configuration.
 
@@ -142,6 +281,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
                                  (acp-make-authenticate-request :method-id "cursor_login"))
    :client-maker (lambda (buffer)
                    (agent-shell-cursor-make-client :buffer buffer))
+   :notification-adapter #'agent-shell-cursor--notification-adapter
    :install-instructions "See https://cursor.com/docs/cli for installation."))
 
 (defun agent-shell-cursor-start-agent ()

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -470,7 +470,7 @@ is added automatically."
 
 Long-running agent turns can outlast the system idle-sleep timeout,
 suspending the machine (and the agent) before the turn completes.  When
-non-nil, agent-shell blocks system idle sleep for the duration of each
+non-nil, `agent-shell' blocks system idle sleep for the duration of each
 turn and releases the block once the turn finishes, so the system is
 only kept awake while there is work in progress.  The display is still
 allowed to blank.
@@ -564,6 +564,7 @@ Each element can be:
                                               authenticate-request-maker
                                               default-model-id
                                               default-session-mode-id
+                                              notification-adapter
                                               icon-name
                                               install-instructions)
   "Create an agent configuration alist.
@@ -580,6 +581,7 @@ Keyword arguments:
 - AUTHENTICATE-REQUEST-MAKER: Function to create authentication requests
 - DEFAULT-MODEL-ID: Default model ID (function returning value).
 - DEFAULT-SESSION-MODE-ID: Default session mode ID (function returning value).
+- NOTIFICATION-ADAPTER: Optional function to modify/normalize `notification'
 - ICON-NAME: Name of the icon to use
 - INSTALL-INSTRUCTIONS: Instructions to show when executable is not found
 
@@ -595,6 +597,7 @@ Returns an alist with all specified values."
     (:authenticate-request-maker . ,authenticate-request-maker) ;; function
     (:default-model-id . ,default-model-id)                     ;; function
     (:default-session-mode-id . ,default-session-mode-id)       ;; function
+    (:notification-adapter . ,notification-adapter)            ;; function
     (:icon-name . ,icon-name)
     (:install-instructions . ,install-instructions)))
 
@@ -737,7 +740,7 @@ value and signals a migration error.")
 (defun agent-shell--validate-session-strategy (value)
   "Signal an error if VALUE is not a supported `agent-shell-session-strategy'.
 
-`new-deferred' was removed in agent-shell 0.54.  Use `new' for a fresh
+`new-deferred' was removed in `agent-shell' 0.54.  Use `new' for a fresh
 session without prompting, or `prompt' to choose."
   (unless (memq value '(new latest prompt))
     (user-error
@@ -2018,6 +2021,17 @@ Includes pretty-printed JSON and a `file a feature request' link."
             (insert (json-serialize acp-notification))
             (json-pretty-print (point-min) (point-max))
             (buffer-string))))
+
+(cl-defun agent-shell--adapt-notification (&key state acp-notification)
+  "Return ACP-NOTIFICATION after optional agent-specific adaptation.
+
+When STATE's agent config defines `:notification-adapter', invoke it
+with `:acp-notification' and return the result.  Otherwise return
+original ACP-NOTIFICATION."
+  (if-let* ((adapter (map-nested-elt state '(:agent-config :notification-adapter)))
+            ((functionp adapter)))
+      (funcall adapter :acp-notification acp-notification)
+    acp-notification))
 
 (defun agent-shell--format-tool-call-input (acp-raw-input)
   "Format ACP-RAW-INPUT from a tool call as a fenced code block.
@@ -6321,7 +6335,13 @@ Each entry is normalized via `agent-shell--make-mcp-server'."
   (acp-subscribe-to-notifications
    :client (map-elt state :client)
    :on-notification (lambda (acp-notification)
-                      (agent-shell--on-notification :state state :acp-notification acp-notification)))
+                      (agent-shell--on-notification
+                       :state state
+                       :acp-notification
+                       (agent-shell--adapt-notification
+                        :state state
+                        :acp-notification acp-notification)
+                       )))
   (acp-subscribe-to-requests
    :client (map-elt state :client)
    :on-request (lambda (acp-request)

--- a/tests/agent-shell-cursor-tests.el
+++ b/tests/agent-shell-cursor-tests.el
@@ -1,0 +1,168 @@
+;;; agent-shell-cursor-tests.el --- Tests for agent-shell-cursor -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'agent-shell)
+(require 'agent-shell-cursor)
+
+;;; Code:
+
+(ert-deftest agent-shell-cursor--make-text-content-block-test ()
+  "Test `agent-shell-cursor--make-text-content-block'."
+  (should (equal (agent-shell-cursor--make-text-content-block "hello")
+                 '((type . "content")
+                   (content (type . "text") (text . "hello")))))
+  (should-not (agent-shell-cursor--make-text-content-block ""))
+  (should-not (agent-shell-cursor--make-text-content-block nil)))
+
+(ert-deftest agent-shell-cursor--content-from-raw-output-test ()
+  "Test `agent-shell-cursor--content-from-raw-output'."
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((error . "permission denied")))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "permission denied"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((content . "file contents")))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "file contents"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((stdout . "hello")
+                    (stderr . "warning")
+                    (exitCode . 0)))
+                 (list '((type . "content")
+                         (content (type . "text")
+                                  (text . "```\nExit code: 0\n\nhello\n\nwarning\n```"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((stdout . "done")))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "```\ndone\n```"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((exitCode . 1)))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "```\nExit code: 1\n```"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((totalMatches . 42)))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "42 matches"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((totalMatches . 42)
+                    (truncated . t)))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "42 matches (truncated)"))))))
+  (should (equal (agent-shell-cursor--content-from-raw-output
+                  '((resultCount . 7)))
+                 (list '((type . "content")
+                         (content (type . "text") (text . "7 results"))))))
+  (should-not (agent-shell-cursor--content-from-raw-output nil))
+  (should-not (agent-shell-cursor--content-from-raw-output '((unknown . "value")))))
+
+(ert-deftest agent-shell-cursor--notification-adapter-test ()
+  "Test `agent-shell-cursor--notification-adapter'."
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (rawOutput (stdout . "hello")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "```\nhello\n```")))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (content . ((type . "content")
+                                       (content (type . "text")
+                                                (text . "keep me"))))
+                           (rawOutput (stdout . "ignored")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   '((type . "content")
+                     (content (type . "text") (text . "keep me"))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (content . ())
+                           (rawOutput (stdout . "hello")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "```\nhello\n```")))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "in_progress")
+                           (rawOutput (error . "permission denied")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "permission denied")))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (rawOutput (content . "file contents")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "file contents")))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (rawOutput (totalMatches . 42)
+                                      (truncated . t)))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "42 matches (truncated)")))))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed")
+                           (rawOutput (unknown . "value")))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (null (map-nested-elt notification '(params update content)))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "tool_call_update")
+                           (status . "completed"))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (null (map-nested-elt notification '(params update content)))))
+  (let ((notification
+         '((method . "session/update")
+           (params (update (sessionUpdate . "agent_message_chunk")
+                           (content . "hello"))))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   "hello")))
+  (let ((notification
+         '((method . "session/request")
+           (params (foo . "bar")))))
+    (agent-shell-cursor--notification-adapter :acp-notification notification)
+    (should (equal notification
+                   '((method . "session/request")
+                     (params (foo . "bar")))))))
+
+(ert-deftest agent-shell--adapt-notification-cursor-integration-test ()
+  "Test `agent-shell--adapt-notification' with Cursor config."
+  (let* ((config (agent-shell-cursor-make-agent-config))
+         (state (agent-shell--make-state :agent-config config))
+         (notification
+          '((method . "session/update")
+            (params (update (sessionUpdate . "tool_call_update")
+                            (status . "completed")
+                            (rawOutput (stdout . "hello")))))))
+    (agent-shell--adapt-notification :state state :acp-notification notification)
+    (should (equal (map-nested-elt notification '(params update content))
+                   (list '((type . "content")
+                           (content (type . "text")
+                                    (text . "```\nhello\n```"))))))))
+
+(provide 'agent-shell-cursor-tests)
+;;; agent-shell-cursor-tests.el ends here

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -4110,5 +4110,24 @@ and the completed/total count lets a non-completed member lift the total only."
                              (label '("completed" "completed" "in_progress"
                                       "pending" "in_progress"))))))
 
+(ert-deftest agent-shell--adapt-notification-test ()
+  "Test `agent-shell--adapt-notification'."
+  (let ((state (agent-shell--make-state
+                :agent-config (agent-shell-make-agent-config :identifier 'test))))
+    (should (equal (agent-shell--adapt-notification
+                    :state state
+                    :acp-notification '((some-key . "some-value")))
+                  '((some-key . "some-value")))))
+  (let* ((adapter (lambda (&key acp-notification)
+                    (cons '(adapted . t) acp-notification)))
+         (state (agent-shell--make-state
+                 :agent-config (agent-shell-make-agent-config
+                                :identifier 'test
+                                :notification-adapter adapter))))
+    (should (equal (agent-shell--adapt-notification
+                    :state state
+                    :acp-notification '((some-key . "some-value")))
+                  '((adapted . t) (some-key . "some-value"))))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

# Render Cursor tool output from ACP `rawOutput`

## Problem

In Cursor ACP sessions, tool_call blocks show status transitions (`pending` → `in_progress` → `completed`) but have **no output body**. Edit tools still work because Cursor populates standard `content` diff blocks for those.

Cursor ACP completes tools with agent-specific data in `rawOutput` while leaving `content` empty:

```json
{
  "sessionUpdate": "tool_call_update",
  "toolCallId": "call_001",
  "status": "completed",
  "rawOutput": { "stdout": "...", "stderr": "", "exitCode": 0 }
}
```

`agent-shell` only read `params.update.content` and rendered it through the existing markdown path. `rawOutput` was ignored, so the UI stayed empty even though the session was otherwise healthy.

This is not an ACP protocol violation. Both `content` and `rawOutput` are optional on [`ToolCallUpdate`](https://agentclientprotocol.com/protocol/v1/schema#param-tool-call-update). Cursor leans on `rawOutput` with agent-specific shapes (`stdout`/`exitCode`, `content`, `totalMatches`, etc.) rather than the `content` text blocks shown in spec examples. Interpreting `rawOutput` is the client's responsibility.

## Solution

Add a small, agent-agnostic hook in core and a Cursor-specific adapter that converts known `rawOutput` shapes into standard ACP content blocks before the existing render/transcript path runs.

## Related issues

- https://github.com/xenodium/agent-shell/issues/386
- https://github.com/xenodium/agent-shell/issues/688
