### PR TITLE
Transfer shell input to viewport on other-buffer

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1389,13 +1389,27 @@ Includes shells accessed via viewport buffers, preserving visited order."
                                 :no-create t)
                                "No shell available")))
         ((derived-mode-p 'agent-shell-mode)
-         (when-let* ((viewport-buffer (or (agent-shell-viewport--buffer
-                                           :shell-buffer (current-buffer))
-                                          "Not in a shell viewport buffer")))
-           (with-current-buffer viewport-buffer
-             (when (derived-mode-p 'agent-shell-viewport-view-mode)
-               (agent-shell-viewport-refresh)))
-           (switch-to-buffer viewport-buffer)))
+         (if-let* (((shell-maker-point-at-last-prompt-p))
+                   (input (agent-shell--input)))
+             ;; Transfer un-submitted shell input to the viewport
+             ;; compose buffer, mirroring `agent-shell-prompt-compose'.
+             ;; Use delete-region to point-max rather than comint-kill-input
+             ;; which only deletes to point.  Text appended after point
+             ;; (e.g. attachments inserted via save-excursion) would otherwise
+             ;; survive and get duplicated on viewport submission.
+             (progn
+               (delete-region
+                (or (marker-position comint-accum-marker)
+                    (process-mark (get-buffer-process (current-buffer))))
+                (point-max))
+               (agent-shell-viewport--show-buffer :override input))
+           (when-let* ((viewport-buffer (or (agent-shell-viewport--buffer
+                                              :shell-buffer (current-buffer))
+                                             "Not in a shell viewport buffer")))
+             (with-current-buffer viewport-buffer
+               (when (derived-mode-p 'agent-shell-viewport-view-mode)
+                 (agent-shell-viewport-refresh)))
+             (switch-to-buffer viewport-buffer))))
         (t
          (user-error "Not in an agent-shell buffer"))))
 

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -3634,5 +3634,87 @@ with \"Method not found\"."
         (agent-shell--refresh-session-title)
         (should (equal sent-method "session/list"))))))
 
+(ert-deftest agent-shell-other-buffer-transfers-input-to-viewport-test ()
+  "Switching to viewport via `agent-shell-other-buffer' transfers shell input.
+
+When the user has typed un-submitted text at the `agent-shell-mode'
+prompt, `agent-shell-other-buffer' must port that text into the
+viewport compose buffer (via `agent-shell-viewport--show-buffer'
+with :override), mirroring `agent-shell-prompt-compose'."
+  (with-temp-buffer
+    (let ((override-captured nil)
+          (show-buffer-called nil)
+          (switched-to nil)
+          (agent-shell--state (list (cons :buffer (current-buffer))
+                                    (cons :event-subscriptions nil)
+                                    (cons :client 'test-client)
+                                    (cons :session (list (cons :id "test-session")
+                                                         (cons :title "a title")))
+                                    (cons :last-entry-type nil)
+                                    (cons :tool-calls nil)
+                                    (cons :idle-timer nil))))
+      ;; `agent-shell-other-buffer' clears the shell prompt via
+      ;; `delete-region' from `comint-accum-marker' to `point-max'.
+      ;; Give the temp buffer a real marker so that succeeds.
+      (setq-local comint-accum-marker (point-min-marker))
+      (cl-letf (((symbol-function 'agent-shell--state)
+                 (lambda () agent-shell--state))
+                ((symbol-function 'shell-maker-point-at-last-prompt-p)
+                 (lambda () t))
+                ((symbol-function 'agent-shell--input)
+                 (lambda () "my draft prompt"))
+                ((symbol-function 'agent-shell-viewport--show-buffer)
+                 (lambda (&rest args)
+                   (setq show-buffer-called t
+                         override-captured (plist-get args :override))))
+                ((symbol-function 'switch-to-buffer)
+                 (lambda (buf) (setq switched-to buf)))
+                ((symbol-function 'derived-mode-p)
+                 (lambda (&rest modes)
+                   (memq 'agent-shell-mode modes))))
+        (agent-shell-other-buffer)
+        (should show-buffer-called)
+        (should (equal override-captured "my draft prompt"))
+        (should-not switched-to)))))
+
+(ert-deftest agent-shell-other-buffer-no-input-switches-normally-test ()
+  "Switching to viewport via `agent-shell-other-buffer' without input.
+
+When there is no un-submitted text at the shell prompt,
+`agent-shell-other-buffer' should behave as before: switch to the
+viewport buffer directly without invoking `show-buffer'."
+  (with-temp-buffer
+    (let ((show-buffer-called nil)
+          (switched-to nil)
+          (viewport-buffer (generate-new-buffer " *test-viewport*"))
+          (agent-shell--state (list (cons :buffer (current-buffer))
+                                    (cons :event-subscriptions nil)
+                                    (cons :client 'test-client)
+                                    (cons :session (list (cons :id "test-session")
+                                                         (cons :title "a title")))
+                                    (cons :last-entry-type nil)
+                                    (cons :tool-calls nil)
+                                    (cons :idle-timer nil))))
+      (unwind-protect
+          (cl-letf (((symbol-function 'agent-shell--state)
+                     (lambda () agent-shell--state))
+                    ((symbol-function 'shell-maker-point-at-last-prompt-p)
+                     (lambda () t))
+                    ((symbol-function 'agent-shell--input)
+                     (lambda () nil))
+                    ((symbol-function 'agent-shell-viewport--buffer)
+                     (lambda (&rest _) viewport-buffer))
+                    ((symbol-function 'agent-shell-viewport--show-buffer)
+                     (lambda (&rest _) (setq show-buffer-called t)))
+                    ((symbol-function 'switch-to-buffer)
+                     (lambda (buf) (setq switched-to buf)))
+                    ((symbol-function 'derived-mode-p)
+                     (lambda (&rest modes)
+                       (memq 'agent-shell-mode modes))))
+            (agent-shell-other-buffer)
+            (should-not show-buffer-called)
+            (should (eq switched-to viewport-buffer)))
+        (kill-buffer viewport-buffer)))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
## What

When in `agent-shell-mode` with un-submitted text typed at the shell prompt, calling `agent-shell-other-buffer` (bound to `C-c C-o`) would switch to the viewport buffer but silently drop the text the user had already typed. This ports that text into the viewport compose buffer instead, so the user does not lose their draft.

The change mirrors the existing behaviour of `agent-shell-prompt-compose`, which already transfers input from the shell prompt to the viewport via `agent-shell-viewport--show-buffer :override` and clears the shell prompt with `delete-region`.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I have reviewed all code in this PR myself and will vouch for its quality*.
- [x] I have read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I have filed a feature request/discussion for a new feature.
- [ ] I am making visual changes, so I am including screenshots so you can view and discuss.
- [x] I have added tests where applicable.
- [ ] I have updated documentation where necessary.
- [x] I have run `M-x checkdoc` and `M-x byte-compile-file`.