### PR TITLE
minor fix: add hermes to default agent configs

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -602,6 +602,7 @@ Goose, Cursor, CodeBuddy, Auggie, and others."
         (agent-shell-github-make-copilot-config)
         (agent-shell-google-make-gemini-config)
         (agent-shell-goose-make-agent-config)
+        (agent-shell-hermes-make-agent-config)
         (agent-shell-kimi-make-config)
         (agent-shell-kiro-make-config)
         (agent-shell-mistral-make-config)


### PR DESCRIPTION
since hermes support was added in 0.55, add hermes to agent picker

## Checklist

- [ x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [ x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
