### PR TITLE
Prevent programmatic fragments ending up in undo history

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3755,7 +3755,7 @@ NAVIGATION for navigation style, EXPANDED to show block expanded
 by default, RENDER-BODY-IMAGES to enable inline image rendering in
 body, ABOVE-LAST-PROMPT to land content above the active prompt
 instead of after it (typical for notifications arriving out of
-turn)."
+turn).  Programmatic fragment updates do not enter undo history."
   (when label-right
     (setq label-right (string-trim label-right)))
   ;; Convert non-standard multiline single-backtick code spans to fenced
@@ -3783,7 +3783,8 @@ turn)."
               ((with-current-buffer viewport-buffer
                  (derived-mode-p 'agent-shell-viewport-view-mode))))
     (with-current-buffer viewport-buffer
-      (let ((inhibit-read-only t)
+      (let ((buffer-undo-list t)
+            (inhibit-read-only t)
             (auto-scroll (shell-maker--should-auto-scroll-p)))
         (when-let* ((range (agent-shell-ui-update-fragment
                             (agent-shell-ui-make-fragment-model
@@ -3831,7 +3832,8 @@ turn)."
                  (equal (current-buffer)
                         (map-elt state :buffer)))
       (error "Editing the wrong buffer: %s" (current-buffer)))
-    (let* ((window (get-buffer-window (current-buffer)))
+    (let* ((buffer-undo-list t)
+           (window (get-buffer-window (current-buffer)))
            (auto-scroll (eobp))
            (saved-point (point))
            (saved-mark (mark t))


### PR DESCRIPTION
Running latest agent-shell against GPT 5.6 Sol, I noticed streaming output and Markdown rendering
were recorded in undo history.

Basically I had a busy session accumulate over 50 MB of undo data which exceeded `undo-outer-limit`
and triggered repeated warnings.

The fix I've been using for ~1 day is to bind `buffer-undo-list` to `t` (disable recording) around
programmatic fragment updates in both shell and viewport buffers. This prevents agent-generated
output from entering undo history while preserving undo for user edits.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
