### PR TITLE
Align embedded-image rendering with link rendering

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -773,6 +773,14 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                                                   (match-end 1))))
                  (url (buffer-substring-no-properties
                        (match-beginning 2) (match-end 2)))
+                 ;; Stash the original `![alt](url)' markup so
+                 ;; `agent-shell-copy-as-markdown' round-trips the image back to
+                 ;; source rather than yielding the bare alt placeholder (mirrors
+                 ;; `--replace-links').  Guarded so a re-render doesn't overwrite
+                 ;; an already-captured source.
+                 (source (unless (get-text-property markup-start
+                                                    'agent-shell-markdown-source)
+                           (agent-shell-markdown-reconstruct markup-start markup-end)))
                  (path (agent-shell-markdown--resolve-image-url
                         url image-cache-directory)))
             (cond
@@ -792,7 +800,10 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                                      (agent-shell-markdown--make-ret-binding-map
                                       (lambda () (interactive)
                                         (find-file path))))
-                  (put-text-property markup-start end 'mouse-face 'highlight))))
+                  (put-text-property markup-start end 'mouse-face 'highlight)
+                  (when source
+                    (put-text-property markup-start end
+                                       'agent-shell-markdown-source source)))))
              ;; Remote image we couldn't show inline (no cache configured, the
              ;; download failed, or a non-graphical display): render a link
              ;; that opens the url, rather than leaving raw `![alt](url)' text.
@@ -810,7 +821,10 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                                      (agent-shell-markdown--make-ret-binding-map
                                       (lambda () (interactive)
                                         (agent-shell-markdown--open-link url))))
-                  (put-text-property markup-start end 'mouse-face 'highlight))))))))))))
+                  (put-text-property markup-start end 'mouse-face 'highlight)
+                  (when source
+                    (put-text-property markup-start end
+                                       'agent-shell-markdown-source source)))))))))))))
 
 (cl-defun agent-shell-markdown--replace-image-file-paths (&key avoid-ranges)
   "Render bare image-path lines as displayed images.

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -755,6 +755,22 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
          (t
           (let* ((alt (buffer-substring-no-properties
                        (match-beginning 1) (match-end 1)))
+                 ;; The placeholder that replaces the markup must carry the
+                 ;; surrounding text's properties -- the shell tags the whole
+                 ;; body run with `agent-shell-ui-section', read-only, and an
+                 ;; invisibility state, and the fragment layer locates the body
+                 ;; by that contiguous run.  Reinserting a bare string (as
+                 ;; `buffer-substring-no-properties' would give) punches a hole
+                 ;; in the run, so the next streaming chunk mis-locates the body
+                 ;; and hides the text after the image.  Mirror
+                 ;; `--replace-links': keep the alt's properties for a non-empty
+                 ;; alt, and inherit the markup's own properties for the empty
+                 ;; case (space placeholder).
+                 (placeholder (if (string-empty-p alt)
+                                  (apply #'propertize " "
+                                         (text-properties-at markup-start))
+                                (buffer-substring (match-beginning 1)
+                                                  (match-end 1))))
                  (url (buffer-substring-no-properties
                        (match-beginning 2) (match-end 2)))
                  (path (agent-shell-markdown--resolve-image-url
@@ -765,10 +781,7 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                    (display-graphic-p))
               (let ((image (create-image
                             path nil nil
-                            :max-width (agent-shell-markdown--image-max-width)))
-                    (placeholder (if (string-empty-p alt) " " alt))
-                    (line-prefix (get-text-property markup-start 'line-prefix))
-                    (wrap-prefix (get-text-property markup-start 'wrap-prefix)))
+                            :max-width (agent-shell-markdown--image-max-width))))
                 (image-flush image)
                 (delete-region markup-start markup-end)
                 (goto-char markup-start)
@@ -779,26 +792,25 @@ For example, the buffer \"see ![logo](logo.png)\" becomes
                                      (agent-shell-markdown--make-ret-binding-map
                                       (lambda () (interactive)
                                         (find-file path))))
-                  (put-text-property markup-start end 'mouse-face 'highlight)
-                  (when line-prefix
-                    (put-text-property markup-start end 'line-prefix line-prefix))
-                  (when wrap-prefix
-                    (put-text-property markup-start end 'wrap-prefix wrap-prefix)))))
+                  (put-text-property markup-start end 'mouse-face 'highlight))))
              ;; Remote image we couldn't show inline (no cache configured, the
              ;; download failed, or a non-graphical display): render a link
              ;; that opens the url, rather than leaving raw `![alt](url)' text.
              ((string-match-p "\\`https?://" url)
-              (delete-region markup-start markup-end)
-              (goto-char markup-start)
-              (let* ((label (if (string-empty-p alt) url alt))
-                     (end (+ markup-start (length label))))
+              (let ((label (if (string-empty-p alt)
+                               (apply #'propertize url
+                                      (text-properties-at markup-start))
+                             placeholder)))
+                (delete-region markup-start markup-end)
+                (goto-char markup-start)
                 (insert label)
-                (add-face-text-property markup-start end 'agent-shell-markdown-link)
-                (put-text-property markup-start end 'keymap
-                                   (agent-shell-markdown--make-ret-binding-map
-                                    (lambda () (interactive)
-                                      (agent-shell-markdown--open-link url))))
-                (put-text-property markup-start end 'mouse-face 'highlight)))))))))))
+                (let ((end (+ markup-start (length label))))
+                  (add-face-text-property markup-start end 'agent-shell-markdown-link)
+                  (put-text-property markup-start end 'keymap
+                                     (agent-shell-markdown--make-ret-binding-map
+                                      (lambda () (interactive)
+                                        (agent-shell-markdown--open-link url))))
+                  (put-text-property markup-start end 'mouse-face 'highlight))))))))))))
 
 (cl-defun agent-shell-markdown--replace-image-file-paths (&key avoid-ranges)
   "Render bare image-path lines as displayed images.

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -267,6 +267,40 @@ streaming **not bold**" nil)))))
                                      'agent-shell-ui-section nil))))
       (delete-file image-file))))
 
+(ert-deftest agent-shell-markdown-image-reconstructs-to-source ()
+  ;; A rendered `![alt](url)' image shows only the alt placeholder, but
+  ;; `agent-shell-copy-as-markdown' must round-trip it back to the original
+  ;; markdown.  The renderer stashes the source on `agent-shell-markdown-source'
+  ;; (like links do) so `agent-shell-markdown-reconstruct' recovers it.
+  (let ((image-file (make-temp-file "agent-shell-test" nil ".svg")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _d) t))
+                  ((symbol-function 'image-supported-file-p) (lambda (_f) t))
+                  ((symbol-function 'create-image)
+                   (lambda (&rest _) '(image :type svg :fake t)))
+                  ((symbol-function 'image-flush) (lambda (&rest _) nil)))
+          (with-temp-buffer
+            (insert (format "see ![svg graphics](%s) end" image-file))
+            (agent-shell-markdown-replace-markup :render-images t)
+            ;; Visible text is the bare placeholder...
+            (should (equal (substring-no-properties (buffer-string))
+                           "see svg graphics end"))
+            ;; ...but reconstruction restores the full markup.
+            (should (equal (agent-shell-markdown-reconstruct (point-min) (point-max))
+                           (format "see ![svg graphics](%s) end" image-file)))))
+      (delete-file image-file))))
+
+(ert-deftest agent-shell-markdown-remote-image-fallback-reconstructs-to-source ()
+  ;; A remote image that falls back to a link (non-graphical display in batch)
+  ;; also round-trips to its original `![alt](url)' markup, not the link label.
+  (with-temp-buffer
+    (insert "x ![](https://example.com/a.png) y")
+    (agent-shell-markdown-replace-markup :render-images t)
+    (should (equal (substring-no-properties (buffer-string))
+                   "x https://example.com/a.png y"))
+    (should (equal (agent-shell-markdown-reconstruct (point-min) (point-max))
+                   "x ![](https://example.com/a.png) y"))))
+
 (ert-deftest agent-shell-markdown-convert-link-in-fenced-block-untouched ()
   ;; The `[b](v)' inside fences stays literal — it isn't re-processed
   ;; as a link.  Body chars carry the `agent-shell-markdown-frozen'

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -230,6 +230,43 @@ streaming **not bold**" nil)))))
                   (agent-shell-markdown-convert "![](https://example.com/a.png)"))
                  '(("https://example.com/a.png" (agent-shell-markdown-link))))))
 
+(ert-deftest agent-shell-markdown-image-render-preserves-surrounding-properties ()
+  ;; Regression: an inline `![alt](file)' image renders by replacing the
+  ;; markup with a placeholder carrying the `display' image.  That placeholder
+  ;; must keep the properties of the surrounding text, otherwise it punches a
+  ;; hole in an otherwise-contiguous property run.  The shell tags a whole
+  ;; streamed message body with `agent-shell-ui-section' body; a hole there
+  ;; makes the fragment layer mis-locate the body on the next chunk and hide
+  ;; every line after the image.  (`[title](url)' links already do this by
+  ;; capturing the title with its properties; images used to drop them.)
+  (let ((image-file (make-temp-file "agent-shell-test" nil ".svg")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _d) t))
+                  ((symbol-function 'image-supported-file-p) (lambda (_f) t))
+                  ((symbol-function 'create-image)
+                   (lambda (&rest _) '(image :type svg :fake t)))
+                  ((symbol-function 'image-flush) (lambda (&rest _) nil)))
+    (with-temp-buffer
+      (insert (format "before\n\n![svg graphics](%s)\n\nafter\n" image-file))
+      (put-text-property (point-min) (point-max) 'agent-shell-ui-section 'body)
+      (agent-shell-markdown-replace-markup :render-images t)
+      ;; The markup is replaced by the alt-text placeholder shown as an image.
+      (should (equal (substring-no-properties (buffer-string))
+                     "before\n\nsvg graphics\n\nafter\n"))
+      (goto-char (point-min))
+      (search-forward "svg graphics")
+      (let ((placeholder-start (match-beginning 0)))
+        ;; The placeholder carries the `display' image...
+        (should (get-text-property placeholder-start 'display))
+        ;; ...and still carries the surrounding body-section tag.
+        (should (eq (get-text-property placeholder-start 'agent-shell-ui-section)
+                    'body)))
+      ;; The whole body stays one contiguous `agent-shell-ui-section' run --
+      ;; the image placeholder leaves no gap for the fragment layer to trip on.
+      (should-not (text-property-any (point-min) (point-max)
+                                     'agent-shell-ui-section nil))))
+      (delete-file image-file))))
+
 (ert-deftest agent-shell-markdown-convert-link-in-fenced-block-untouched ()
   ;; The `[b](v)' inside fences stays literal — it isn't re-processed
   ;; as a link.  Body chars carry the `agent-shell-markdown-frozen'


### PR DESCRIPTION
## Short description

Embedded images (`![alt](url)`) are rendered by *replacing* the markdown markup with the alt text and painting the image on top. Links (`[title](url)`) work the same way. But the image renderer had quietly drifted away from the link renderer in two respects, and each drift caused a user-visible bug. This PR closes both gaps.

Both fixes are small and confined to one function, `agent-shell-markdown--replace-images`; each comes with a regression test that fails before the change and passes after.

## Bug 1 — content after an image disappears

### Reproducer

When the agent's reply contained an image on its own line, like:

```
paragraph before

![svg graphics](~/.cache/arXiv/2603.15561v1/figure_1_final.svg)

paragraph after
```

the image rendered fine, but **everything after it vanished** — `paragraph after` (and any further paragraphs) was not shown.

Clues that helped localize it:

- A plain link `[svg graphics](…)` (no leading `!`) rendered everything correctly.
- A bare image path on its own line (no markdown syntax) rendered everything correctly.
- Replaying the full conversation later (`agent-shell-session-restore-verbosity 'full`) showed the missing text.

So it only happened with the `![alt](url)` form, and only the *first* time the reply was streamed in — never on a full re-render.

### Why it happened

Agent replies arrive in small chunks and are appended to the buffer as they stream.  To know where each new chunk goes, the shell marks the whole message body with a single, **continuous** "this is body text" tag and locates the body by that continuous run.

Most renderers keep the underlying text (and its tags) and only *paint* styling on top. The image renderer was the exception: it **deleted** the `![alt](url)` markup and **re-inserted** the alt text as a brand-new, untagged string. That untagged placeholder punched a hole in the continuous "body" run, splitting it into a piece before the image and a piece after it.

On the next streamed chunk, the code that locates the body got confused by the gap and latched onto the piece *after* the image — which begins with the blank line following the image, already marked "invisible" (that is how trailing blank lines are normally hidden). The visibility check saw an invisible first character, concluded the whole body was collapsed, and every line appended from then on was hidden too. The text was still in the buffer, just invisible — which is exactly why a fresh full re-render displayed it correctly.

This also explains the working cases: links already capture their title *with* its tags, and bare image paths never delete anything.

### The fix

Make the placeholder carry the surrounding text's properties, exactly as the link renderer already does, so the body run stays continuous. The empty-alt case and the remote-image fallback inherit the surrounding tags the same way.

## Bug 2 — `agent-shell-copy-as-markdown` doesn't round-trip images

### Reproducer

Copying a rendered image with `agent-shell-copy-as-markdown` produced the bare alt text `svg graphics` instead of restoring the original `![svg graphics](url)`.

### Why it happened

`agent-shell-copy-as-markdown` reconstructs the original markdown from an `agent-shell-markdown-source` text property that each markup-stripping renderer is expected to leave behind (bold, italics, headings, links, code blocks, tables all do this). The image renderer never set it, so there was nothing to reconstruct from and copying fell back to the visible placeholder text.

### The fix

Stash the original `![alt](url)` markup on `agent-shell-markdown-source` when rendering the image — the same way the link renderer does — for both the inline-image and the remote-fallback paths.

## Testing

- `agent-shell-markdown-image-render-preserves-surrounding-properties` — guards Bug 1 (the property run is not broken by the placeholder).
- `agent-shell-markdown-image-reconstructs-to-source` and `agent-shell-markdown-remote-image-fallback-reconstructs-to-source` — guard Bug 2 (copy round-trips back to the original markup).
- Nothing that already worked changes: the image still renders in place, and a plain (non-markdown) copy still yields the alt text.
- Full test suite passes. The only failure is the pre-existing, timing-based flaky `agent-shell-idle-event-rearms-on-new-trigger-test`, which is unrelated and documented as flaky in batch.
