### PR TITLE
Fix table column wrapping for CJK text

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -1510,19 +1510,39 @@ pipes between rows."
     (string-width str)))
 
 (cl-defun agent-shell-markdown--table-longest-word (&key str window)
-  "Return display width of longest word in STR.
-Uses `agent-shell-markdown--table-display-width' so non-ASCII words
-get accurate measurement when WINDOW is given."
+  "Return display width of the longest unbreakable unit in STR.
+
+Runs of non-breakable characters form unbreakable words, measured
+via `agent-shell-markdown--table-display-width' (pixel-accurate
+when WINDOW is given).  Line-breakable characters (category `|':
+CJK ideographs, kana, Hangul, etc.) can wrap anywhere, so each
+contributes only its own `char-width'.  Otherwise a
+whitespace-free CJK sentence would count as one word and pin its
+column at the full sentence width.
+
+For example, \"foo bar\" yields 3 (\"foo\"), \"日本語\" yields 2,
+and \"日本のfoo語\" yields 3 (\"foo\")."
   (if (or (null str) (string-empty-p str))
       0
-    (let ((words (split-string str "[ \t\n]+" t)))
-      (if words
-          (apply #'max
-                 (mapcar (lambda (w)
-                           (agent-shell-markdown--table-display-width
-                            :str w :window window))
-                         words))
-        0))))
+    (let ((len (length str))
+          (longest 0)
+          (word-start nil))
+      (dotimes (i (1+ len))
+        (let* ((ch (and (< i len) (seq-elt str i)))
+               (separator (or (null ch) (memq ch '(?\s ?\t ?\n))))
+               (breakable (and (not separator)
+                               (aref (char-category-set ch) ?|))))
+          (when (and word-start (or separator breakable))
+            (setq longest (max longest
+                               (agent-shell-markdown--table-display-width
+                                :str (substring str word-start i)
+                                :window window)))
+            (setq word-start nil))
+          (cond
+           (breakable (setq longest (max longest (char-width ch))))
+           ((and (not separator) (not word-start))
+            (setq word-start i)))))
+      longest)))
 
 (defun agent-shell-markdown--table-total-width (widths)
   "Return total rendered width for a table with column WIDTHS.
@@ -1626,9 +1646,21 @@ rendered width rather than the unstyled char count."
                     text i window))))
     sum))
 
+(defun agent-shell-markdown--table-break-after-p (text i)
+  "Return non-nil when a wrapped line may break after index I in TEXT.
+I + 1 must be a valid index into TEXT.  Breaks are allowed after a
+line-breakable character (category `|': CJK ideographs, kana,
+Hangul, etc.), unless the next character is zero-width (combining
+character, variation selector, ZWJ) and must stay attached."
+  (and (aref (char-category-set (seq-elt text i)) ?|)
+       (> (char-width (seq-elt text (1+ i))) 0)))
+
 (cl-defun agent-shell-markdown--table-wrap-text (text width &optional window)
   "Wrap TEXT to fit within WIDTH, returning a list of lines.
 Preserves text properties across wrapped lines.
+
+Breaks after whitespace or a line-breakable (CJK) character; a
+run with no break point splits at the width limit.
 
 Uses the VS-16-aware width helper so that emoji presentation
 sequences (`⚠️') count as their actual rendered width (2 cells)
@@ -1674,14 +1706,19 @@ width exceeds the column budget, drifting the right pipe."
           ;; first char already exceeds WIDTH (e.g. wide glyph).
           (when (= end-pos pos)
             (setq end-pos (1+ pos)))
-          ;; Try to break at the last whitespace within [pos, end-pos).
+          ;; Try to break at the last clean break point within
+          ;; [pos, end-pos): after whitespace, or after a
+          ;; line-breakable (CJK) character.
           (let ((break-pos end-pos))
             (when (< end-pos len)
               (let ((scan (1- end-pos)))
-                (while (and (> scan pos)
-                            (not (memq (seq-elt text scan) '(?\s ?\t))))
+                (while (and (>= scan pos)
+                            (not (and (> scan pos)
+                                      (memq (seq-elt text scan) '(?\s ?\t))))
+                            (not (agent-shell-markdown--table-break-after-p
+                                  text scan)))
                   (setq scan (1- scan)))
-                (when (> scan pos)
+                (when (>= scan pos)
                   (setq break-pos (1+ scan)))))
             (push (string-trim-right (substring text pos break-pos)) lines)
             (setq pos break-pos)

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -616,6 +616,43 @@ after" nil)))))
 │ quite long  │ cell also   │
 │ content     │ long enough │")))))
 
+(ert-deftest agent-shell-markdown-convert-table-output-wraps-cjk-cell-without-spaces ()
+  ;; A whitespace-free CJK cell must still wrap: CJK characters are
+  ;; individually breakable, while ASCII words (here \"Cage\", \"4\",
+  ;; \"33\", \"20\") stay intact.
+  (let ((agent-shell-markdown-table-max-width-fraction 1.0))
+    (cl-letf (((symbol-function 'agent-shell-markdown--display-width)
+               (lambda () 36)))
+      (should (equal (substring-no-properties
+                      (agent-shell-markdown-convert
+                       "| 作曲家 | 主な特徴 |
+|---|---|
+| Cage | 「4分33秒」に代表される偶然性の音楽の導入で20世紀音楽の概念を根本から問い直した |"))
+                     "│ 作曲 │ 主な特徴                 │
+│ 家   │                          │
+├──────┼──────────────────────────┤
+│ Cage │ 「4分33秒」に代表される  │
+│      │ 偶然性の音楽の導入で20世 │
+│      │ 紀音楽の概念を根本から問 │
+│      │ い直した                 │")))))
+
+(ert-deftest agent-shell-markdown-table-longest-word-breaks-at-cjk-chars ()
+  ;; Words are unbreakable; line-breakable (category `|') characters
+  ;; contribute their own char-width.  Emoji sequences are not
+  ;; breakable, so a modifier stays attached to its base.
+  (should (= 0 (agent-shell-markdown--table-longest-word :str nil)))
+  (should (= 0 (agent-shell-markdown--table-longest-word :str "")))
+  (should (= 3 (agent-shell-markdown--table-longest-word :str "foo ba")))
+  (should (= 2 (agent-shell-markdown--table-longest-word :str "現代音楽")))
+  (should (= 3 (agent-shell-markdown--table-longest-word :str "日本のfoo語")))
+  (should (= 4 (agent-shell-markdown--table-longest-word :str "👍🏽"))))
+
+(ert-deftest agent-shell-markdown-table-wrap-text-breaks-after-cjk-not-inside-ascii ()
+  ;; Wrapping breaks after CJK characters rather than inside an
+  ;; embedded ASCII word.
+  (should (equal (agent-shell-markdown--table-wrap-text "日本のfoo語" 3)
+                 '("日" "本" "の" "foo" "語"))))
+
 (ert-deftest agent-shell-markdown-mirrors-face-to-font-lock-face ()
   ;; Faces are mirrored to `font-lock-face' so our styling survives
   ;; `font-lock-mode' re-fontification in comint / shell-maker buffers.


### PR DESCRIPTION
## Summary

Tables containing Japanese (or other CJK) text never shrink to fit the window: `agent-shell-markdown-table-wrap-columns` has no effect and the table overflows.

Cause: `agent-shell-markdown--table-longest-word` splits cell content on whitespace only. CJK sentences contain no spaces.

Fix:

- In the minimum-width calculation, treat line-breakable characters (category `|`: CJK ideographs, kana, Hangul, etc.) as individually breakable, each contributing its own `char-width`. Emoji sequences (ZWJ, skin-tone modifiers) don't have category `|`, so they stay unbreakable as before.
- Teach `agent-shell-markdown--table-wrap-text` to break after line-breakable characters in addition to whitespace, so an ASCII word embedded in CJK text (e.g. "API") is not split mid-word. A zero-width follower (combining char, variation selector, ZWJ) blocks the break.

Wide characters contribute `char-width` directly instead of being pixel-measured one by one, since tables re-render on every streamed chunk.

## Before / after

before:
<img width="1540" height="894" alt="before" src="https://github.com/user-attachments/assets/020a53d7-9626-41f6-94ca-33bcc216c3de" />

after:
<img width="1540" height="894" alt="after" src="https://github.com/user-attachments/assets/f3dd138c-2a30-478d-bcf1-72b3594ddbf3" />



## Testing

- Added three tests to `tests/agent-shell-markdown-tests.el`; all 113 tests pass.
- Verified interactively in my own agent-shell sessions with Japanese tables.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
