### PR TITLE
Make the markdown render context available via a public function

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -313,6 +313,7 @@ body un-fontified."
                                 '(agent-shell-markdown-watermark nil))))
     (let ((watermark (agent-shell-markdown--watermark-start))
           (external-results)
+          (context)
           (source-blocks)
           (source-ranges)
           (rendered-ranges)
@@ -320,22 +321,22 @@ body un-fontified."
           (avoid-ranges))
       (save-restriction
         (narrow-to-region watermark (point-max))
-        (setq source-blocks (agent-shell-markdown--source-blocks))
-        ;; The avoid ranges need to be of the form (start . end).
-        (setq source-ranges (agent-shell-markdown-sort-ranges
-                             (mapcar (lambda (source-block)
-                                       (cons (map-nested-elt source-block '(:block :start))
-                                             (map-nested-elt source-block '(:block :end))))
-                                     source-blocks)))
+        ;; Build the render context (fenced-block descriptors + inline
+        ;; `code' ranges) once, via the same function any external code
+        ;; renders a static region through, so the two cannot drift.
+        (setq context (agent-shell-markdown-context))
+        (setq source-blocks (map-elt context :source-blocks))
         ;; Inline `code' spans, computed before the renderers run so an
         ;; external renderer can skip verbatim spans the same way it skips
-        ;; fenced blocks.  Nothing is frozen yet, so source blocks are the
-        ;; only avoid-range; the markers survive any buffer edits a
-        ;; renderer makes and are reused as an avoid-range for the built-in
-        ;; passes below.
-        (setq inline-ranges (agent-shell-markdown--make-markers
-                             (agent-shell-markdown--inline-code-ranges
-                              :avoid-ranges source-ranges)))
+        ;; fenced blocks.  The markers survive any buffer edits a renderer
+        ;; makes and are reused as an avoid-range for the built-in passes
+        ;; below.
+        (setq inline-ranges (map-elt context :inline-code-ranges))
+        ;; Re-project the fenced-block descriptors to the plain (start . end)
+        ;; ranges the avoid-range machinery expects.  `agent-shell-markdown-context'
+        ;; is the single source of truth; this is a cheap derivation from
+        ;; its result.
+        (setq source-ranges (agent-shell-markdown--source-block-ranges source-blocks))
         ;; Run external renderers (when any are registered) before the
         ;; styling passes.  They tag their regions
         ;; `agent-shell-markdown-frozen', so the frozen ranges captured
@@ -343,7 +344,7 @@ body un-fontified."
         ;; skip them.
         (when agent-shell-markdown-render-functions
           (setq external-results (agent-shell-markdown--run-render-functions
-                                  source-blocks inline-ranges)))
+                                  context)))
         (setq rendered-ranges (agent-shell-markdown--make-markers
                                (agent-shell-markdown--frozen-ranges)))
         (setq avoid-ranges (agent-shell-markdown-sort-ranges
@@ -409,20 +410,64 @@ body un-fontified."
        :external-candidates (seq-keep (lambda (result) (map-elt result :watermark))
                                       external-results)))))
 
-(defun agent-shell-markdown--run-render-functions (source-blocks inline-code-ranges)
-  "Run `agent-shell-markdown-render-functions' with SOURCE-BLOCKS.
+(defun agent-shell-markdown--source-block-ranges (source-blocks)
+  "Project SOURCE-BLOCKS to sorted (START . END) marker ranges.
 
-Each registered function is called with a single alist context
-holding (:source-blocks . SOURCE-BLOCKS) and
-(:inline-code-ranges . INLINE-CODE-RANGES) and may render and
-freeze regions of the current (narrowed) buffer.  Returns the list
-of non-nil result alists, in hook order.
+Each descriptor in SOURCE-BLOCKS (see
+`agent-shell-markdown--source-blocks') carries a `:block' marker
+range; this returns just those ranges as plain (START . END) conses,
+sorted — the form the avoid-range machinery
+\(`agent-shell-markdown-in-avoid-range-p',
+`agent-shell-markdown-sort-ranges') expects."
+  (agent-shell-markdown-sort-ranges
+   (mapcar (lambda (source-block)
+             (cons (map-nested-elt source-block '(:block :start))
+                   (map-nested-elt source-block '(:block :end))))
+           source-blocks)))
+
+(defun agent-shell-markdown-context ()
+  "Return the render context for the current narrowed region.
+
+Builds the same CONTEXT alist that
+`agent-shell-markdown-replace-markup' hands to the functions in
+`agent-shell-markdown-render-functions', but for whatever region
+the buffer is narrowed to right now:
+
+  ((:source-blocks . SOURCE-BLOCKS)
+   (:inline-code-ranges . INLINE-CODE-RANGES))
+
+SOURCE-BLOCKS are the fenced-block descriptors from
+`agent-shell-markdown--source-blocks'.  INLINE-CODE-RANGES are
+marker ranges covering inline `code' span bodies, computed with the
+fenced blocks as avoid-ranges so backticks inside a fenced block are
+not mistaken for an inline span.  See
+`agent-shell-markdown-render-functions' for the meaning of each key.
+
+`agent-shell-markdown-replace-markup' builds its context through
+this function too, so code that renders a static (non-streamed)
+region — which never passes through the streaming render hook — can
+obtain the identical context and stay in sync with the streaming
+path."
+  (let* ((source-blocks (agent-shell-markdown--source-blocks))
+         (source-ranges (agent-shell-markdown--source-block-ranges source-blocks))
+         (inline-ranges (agent-shell-markdown--make-markers
+                         (agent-shell-markdown--inline-code-ranges
+                          :avoid-ranges source-ranges))))
+    (list (cons :source-blocks source-blocks)
+          (cons :inline-code-ranges inline-ranges))))
+
+(defun agent-shell-markdown--run-render-functions (context)
+  "Run `agent-shell-markdown-render-functions' with CONTEXT.
+
+CONTEXT is the alist from `agent-shell-markdown-context', holding
+\(:source-blocks . SOURCE-BLOCKS) and (:inline-code-ranges .
+INLINE-CODE-RANGES).  Each registered function is called with it
+and may render and freeze regions of the current (narrowed) buffer.
+Returns the list of non-nil result alists, in hook order.
 
 For example, with one renderer returning `((:watermark . 1200))'
 this returns `(((:watermark . 1200)))'."
-  (let ((context (list (cons :source-blocks source-blocks)
-                       (cons :inline-code-ranges inline-code-ranges)))
-        (results '()))
+  (let ((results '()))
     (run-hook-wrapped 'agent-shell-markdown-render-functions
                       (lambda (fn)
                         (when-let* ((result (funcall fn context)))


### PR DESCRIPTION
# Make the markdown render context available via a public function

Follow-up to #674 (7ee6ff9).

## Background

In today's agent-shell, external packages can plug into the markdown renderer through the `agent-shell-markdown-render-functions` hook. When the agent's response streams into the buffer, each registered function is handed a small `context` describing the text it's about to work on:

- where the fenced code blocks are and
- where the inline `` `code` `` spans are,

so the function knows which regions to leave alone (e.g., the package `agent-shell-math-renderer` does not want to render math, say, inside a code block).

That works well for streamed output. But the same hook never fires for **static** text, which is inserted all at once rather than streamed. Static text includes the case of submitted user prompts.
 
## The problem

To render such a region, an external package needs to build the *same* `context` for itself. But in today's agent-shell there is no public way to get it. The code that assembles the context lives inline inside `agent-shell-markdown-replace-markup`, and it is a mix of two things:

- Calls to several private (`--`-prefixed) functions, such as `agent-shell-markdown--source-blocks`, `agent-shell-markdown--inline-code-ranges` and `agent-shell-markdown--make-markers`. These are at least callable, even if private and unsupported.
- Plain inline glue that is not exposed as *any* function, not even a private one. It projects the fenced blocks into sorted ranges, feeds those ranges into the inline-code scan (so backticks that sit inside a code block are ignored), and wires the pieces together in a specific order.

So reproducing the context is not simply "call a few private functions."  An external package would have to reach into some of the private functions and copy the inline glue verbatim, since that glue has no callable form to begin with. Copied code that shadows internals it cannot even name is bound to quietly drift out of sync as the package evolves. This would be a fragile workaround at best.

## What this PR does

It refactors the code without changing any of its current behaviors: it extracts that assembly into a single public function, `agent-shell-markdown-context`, which runs on the current (narrowed) region and returns the very alist the render hook already documents:

```elisp
((:source-blocks . …)        ; the fenced code blocks in the region
 (:inline-code-ranges . …))  ; the inline `code` spans in the region
```

Crucially, `agent-shell-markdown-replace-markup` now builds *its* context by calling this same function, instead of assembling it inline. So the streaming path and any external caller share **one** builder and cannot drift apart — which is the whole point of the change.

Two small internal changes come with it:

- The step that projects the fenced-block descriptors into plain sorted `(start . end)` ranges is now a private helper, `agent-shell-markdown--source-block-ranges`. This projection appears only once in today's code, but after the split it is needed in two places — inside the new function and in `replace-markup` — so factoring it out keeps a single copy instead of pasting the same lines twice.
- `agent-shell-markdown--run-render-functions` now receives the already-built context rather than rebuilding it, so the alist is constructed in exactly one place.

For the public `context` alist, I chose to provide the same two keys the `render-functions` hook is already documented to pass, so it stays faithful to that existing contract used in streamed text.

It is worth repeating that this PR introduces no behavior changes for existing users: same rendering, same hook, same context shape — there's simply now a supported way to obtain that context for regions that didn't come through the streaming path.

## Testing

- Byte-compiles cleanly (no new warnings).
- The full markdown test suite passes (116/116).
- Sanity-checked directly: on a buffer mixing an inline `` `x` ``, a ` ```math ` fenced block, and another inline `` `y` ``, `agent-shell-markdown-context` returns the two expected keys, one source block (language `"math"`), and the two inline ranges (`x`, `y`) — correctly ignoring the backticks that live inside the fenced block.
