### PR TITLE
Fix hidden streamed Markdown headings

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -641,20 +641,18 @@ with face `agent-shell-markdown-header-2' on \"My title\"."
                                                     'agent-shell-markdown-source)
                            (agent-shell-markdown-reconstruct
                             markup-start (match-end 2))))
-                 ;; The trailing `\\n' we re-insert below would otherwise
-                 ;; punch a hole in the caller's contiguous block range
-                 ;; (eg. `invisible'/`agent-shell-ui-section') and break
-                 ;; toggle/replace operations — same hazard called out in
-                 ;; `--style-source-blocks'.  Carry over the original
-                 ;; newline's caller props.
-                 (carried (agent-shell-markdown--carry-properties
-                           (1- markup-end))))
+                 ;; `text' keeps the title's own properties.  Carry the newline
+                 ;; separately so its trailing-whitespace invisibility does not
+                 ;; hide the title.
+                 (newline-properties
+                  (agent-shell-markdown--carry-properties (1- markup-end))))
             (delete-region markup-start markup-end)
             (goto-char markup-start)
-            (insert text "\n")
-            (when carried
-              (add-text-properties markup-start (point) carried))
-            (let ((end (+ markup-start (length text))))
+            (insert text)
+            (let ((end (point)))
+              (insert "\n")
+              (when newline-properties
+                (add-text-properties end (point) newline-properties))
               (add-face-text-property
                markup-start end
                (intern (format "agent-shell-markdown-header-%d"

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -1295,6 +1295,29 @@ A " nil)
     (should (equal (substring-no-properties (buffer-string))
                    "@@ -1,2 +1,2 @@\n # Test Document Title\n-old\n+new\n"))))
 
+(ert-deftest agent-shell-markdown-header-keeps-properties-scoped ()
+  (with-temp-buffer
+    (insert (propertize "# "
+                        'agent-shell-ui-section 'body
+                        'invisible 'markdown-markup))
+    (insert (propertize "Title"
+                        'agent-shell-ui-section 'body))
+    (insert (propertize "\n"
+                        'agent-shell-ui-section 'body
+                        'invisible t))
+    (agent-shell-markdown-replace-markup)
+    (should (equal (substring-no-properties (buffer-string))
+                   "Title\n"))
+    (dotimes (i (length "Title"))
+      (let ((pos (+ (point-min) i)))
+        (should (eq 'body
+                    (get-text-property pos 'agent-shell-ui-section)))
+        (should-not (get-text-property pos 'invisible))))
+    (let ((newline-pos (+ (point-min) (length "Title"))))
+      (should (eq 'body
+                  (get-text-property newline-pos 'agent-shell-ui-section)))
+      (should (eq t (get-text-property newline-pos 'invisible))))))
+
 (ert-deftest agent-shell-markdown-header-preserves-caller-text-properties ()
   ;; The header pass deletes the matched `#…\n' and re-inserts the
   ;; faced title plus a fresh `\n'.  The inserted newline must carry


### PR DESCRIPTION
Hi @xenodium 

I was facing the issue in the image where at first seemed that I was not getting a response back. Though after a close inspection I could see that the response was just being marked as invisible.

<img width="348" height="273" alt="image" src="https://github.com/user-attachments/assets/5295fa92-b703-48e7-9865-1ec5be033f98" />


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
