### PR TITLE
Fix streamed heading visibility

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -653,7 +653,7 @@ with face `agent-shell-markdown-header-2' on \"My title\"."
             (goto-char markup-start)
             (insert text "\n")
             (when carried
-              (add-text-properties markup-start (point) carried))
+              (add-text-properties (1- (point)) (point) carried))
             (let ((end (+ markup-start (length text))))
               (add-face-text-property
                markup-start end

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -1313,6 +1313,26 @@ A " nil)
                     (get-text-property pos 'agent-shell-ui-section)))
         (should (eq t (get-text-property pos 'invisible)))))))
 
+(ert-deftest agent-shell-markdown-header-keeps-visible-title-before-hidden-newline ()
+  (with-temp-buffer
+    (insert (propertize "# Title"
+                        'agent-shell-ui-section 'body))
+    (insert (propertize "\n"
+                        'agent-shell-ui-section 'body
+                        'invisible t))
+    (agent-shell-markdown-replace-markup)
+    (should (equal (substring-no-properties (buffer-string))
+                   "Title\n"))
+    (dotimes (i (length "Title"))
+      (let ((pos (+ (point-min) i)))
+        (should (eq 'body
+                    (get-text-property pos 'agent-shell-ui-section)))
+        (should-not (get-text-property pos 'invisible))))
+    (let ((newline-pos (+ (point-min) (length "Title"))))
+      (should (eq 'body
+                  (get-text-property newline-pos 'agent-shell-ui-section)))
+      (should (eq t (get-text-property newline-pos 'invisible))))))
+
 (ert-deftest agent-shell-markdown-watermark-keeps-pending-table-in-scope ()
   ;; When table rows stream in one at a time, the table needs at least
   ;; two consecutive pipe-rows in scope before `--find-tables' will


### PR DESCRIPTION
## Summary

The captured response began with this heading, followed by a table:

```markdown
## `telega-webpage-mode` design

| Key | Action |
```

It arrived in separate chunks: the heading text, then `"\n\n"`, then the table. When the newline chunk arrived, agent-shell marked it `invisible=t` as trailing whitespace before rendering the completed heading.

The header renderer carries the deleted newline's properties onto its replacement, but used the whole heading as the destination range:

```elisp
(add-text-properties markup-start (point) carried)
```

That copied `invisible=t` from the newline onto the title. The next table chunk then saw an invisible first body character, treated the response as collapsed, and was hidden too.

Apply the properties only to the replacement newline:

```elisp
(add-text-properties (1- (point)) (point) carried)
```

The regression test reproduces the same property shape: a visible heading followed by an invisible trailing newline.

## Verification

- All eight Markdown heading tests pass.
- The captured 303-chunk response replays with no hidden non-whitespace content.
- Checkdoc, check-parens, and byte compilation pass for the changed files.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
