### PR TITLE
Fetches the proper Pi logo

### DIFF
--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -77,6 +77,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :buffer-name "Pi"
    :shell-prompt "Pi> "
    :shell-prompt-regexp "Pi> "
+   :icon-name "pi.png"
    :welcome-function #'agent-shell-pi--welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-pi-make-client :buffer buffer))


### PR DESCRIPTION
Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [X] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.

This is a very simple one-line change that adds the filename for the Pi logo from `lobe-icons` instead of merely displaying the fallback "P".

<img width="770" height="736" alt="2026-07-20-11-55" src="https://github.com/user-attachments/assets/9a0f712b-0587-499d-9581-ca10051f7c90" />
<img width="770" height="744" alt="2026-07-20-11-56" src="https://github.com/user-attachments/assets/437850ca-3a9f-4ca4-b0e2-776c870e3e70" />
<img width="286" height="145" alt="2026-07-20-12-04" src="https://github.com/user-attachments/assets/2595c715-8c6d-4218-a7e6-d09f8bc2f2a6" />
