### PR TITLE
Handle Cursor extension requests: create_plan, ask_question, update_todos

### DIFF
--- a/agent-shell-cursor.el
+++ b/agent-shell-cursor.el
@@ -35,6 +35,18 @@
 (autoload 'agent-shell-make-agent-config "agent-shell")
 (declare-function agent-shell--make-acp-client "agent-shell")
 (declare-function agent-shell--dwim "agent-shell")
+(declare-function agent-shell--update-fragment "agent-shell")
+(declare-function agent-shell--delete-fragment "agent-shell")
+(declare-function agent-shell--format-plan "agent-shell")
+(declare-function agent-shell--make-permission-button "agent-shell")
+(declare-function agent-shell-jump-to-latest-permission-button-row "agent-shell")
+(declare-function agent-shell-interrupt "agent-shell")
+(declare-function agent-shell-viewport--buffer "agent-shell-viewport")
+(declare-function agent-shell--cancel-idle-timer "agent-shell")
+(declare-function agent-shell--emit-event "agent-shell")
+(declare-function agent-shell--start-idle-timer "agent-shell")
+(declare-function agent-shell--active-requests-p "agent-shell")
+(defvar agent-shell-permission-icon)
 
 (cl-defun agent-shell-cursor-make-authentication (&key api-key auth-token login none)
   "Create Cursor authentication configuration.
@@ -351,6 +363,362 @@ VALUE may be a string or a function that returns a string."
     (propertize text 'font-lock-face (if is-dark
                                          '(:foreground "#00d4ff" :inherit fixed-pitch)
                                        '(:foreground "#0066cc" :inherit fixed-pitch)))))
+
+(cl-defun agent-shell-cursor--on-request (&key state acp-request)
+  "Handle Cursor ACP extension ACP-REQUEST using STATE.
+
+Supports methods documented at
+https://cursor.com/docs/cli/acp#cursor-extension-methods.
+
+`cursor/update_todos' is documented as a notification, but Cursor
+often sends it as a request; reply so the agent does not stall.
+
+Return non-nil when the request was handled."
+  (pcase (map-elt acp-request 'method)
+    ("cursor/create_plan"
+     (agent-shell-cursor--on-create-plan-request
+      :state state
+      :acp-request acp-request)
+     t)
+    ("cursor/ask_question"
+     (agent-shell-cursor--on-ask-question-request
+      :state state
+      :acp-request acp-request)
+     t)
+    ("cursor/update_todos"
+     (agent-shell-cursor--on-update-todos-request
+      :state state
+      :acp-request acp-request)
+     t)
+    (_ nil)))
+
+(cl-defun agent-shell-cursor--merge-todos (&key existing incoming merge)
+  "Return todo list after applying INCOMING to EXISTING.
+
+When MERGE is non-nil, update or append by `id'.  Otherwise replace
+with INCOMING.  EXISTING and INCOMING may be lists or vectors."
+  (let ((incoming-list (append incoming nil))
+        (existing-list (append existing nil)))
+    (if (not merge)
+        incoming-list
+      (append
+       (mapcar (lambda (todo)
+                 (or (seq-find (lambda (inc)
+                                 (equal (map-elt inc 'id)
+                                        (map-elt todo 'id)))
+                               incoming-list)
+                     todo))
+               existing-list)
+       (seq-remove (lambda (todo)
+                     (seq-find (lambda (ex)
+                                 (equal (map-elt ex 'id)
+                                        (map-elt todo 'id)))
+                               existing-list))
+                   incoming-list)))))
+
+(cl-defun agent-shell-cursor--make-extension-response (&key request-id outcome)
+  "Build an ACP response for REQUEST-ID with Cursor extension OUTCOME.
+
+OUTCOME is an alist such as ((outcome . \"accepted\"))."
+  (unless request-id
+    (error ":request-id is required"))
+  (unless outcome
+    (error ":outcome is required"))
+  `((:request-id . ,request-id)
+    (:result . ((outcome . ,outcome)))))
+
+(cl-defun agent-shell-cursor--send-extension-response (&key state request-id block-ids outcome message-text interrupt)
+  "Send Cursor extension response and clean up dialog UI.
+
+STATE is agent-shell state.  REQUEST-ID identifies the ACP request.
+BLOCK-IDS are fragments to remove after responding.  OUTCOME is the
+Cursor outcome alist.  MESSAGE-TEXT is shown after sending.  INTERRUPT
+non-nil also interrupts the shell after a rejection."
+  (acp-send-response
+   :client (map-elt state :client)
+   :response (agent-shell-cursor--make-extension-response
+              :request-id request-id
+              :outcome outcome))
+  (with-current-buffer (map-elt state :buffer)
+    (dolist (block-id (ensure-list block-ids))
+      (agent-shell--delete-fragment :state state :block-id block-id))
+    (agent-shell--cancel-idle-timer)
+    (agent-shell--emit-event
+     :event 'cursor-extension-response
+     :data (list (cons :request-id request-id)
+                 (cons :outcome outcome)))
+    (when message-text
+      (message "%s" message-text))
+    (or (agent-shell-jump-to-latest-permission-button-row)
+        (goto-char (point-max)))
+    (when-let* ((viewport-buffer (agent-shell-viewport--buffer
+                                  :shell-buffer (map-elt state :buffer)
+                                  :existing-only t)))
+      (with-current-buffer viewport-buffer
+        (or (agent-shell-jump-to-latest-permission-button-row)
+            (goto-char (point-max)))))
+    (when interrupt
+      (agent-shell-interrupt t))))
+
+(defun agent-shell-cursor--format-create-plan-body (params)
+  "Return display text for cursor/create_plan PARAMS."
+  (let* ((name (map-elt params 'name))
+         (overview (map-elt params 'overview))
+         (plan (map-elt params 'plan))
+         (todos (map-elt params 'todos))
+         (phases (map-elt params 'phases))
+         (parts (delq nil
+                      (list
+                       (when name
+                         (propertize name 'font-lock-face 'agent-shell-section-heading))
+                       (when overview overview)
+                       (when plan plan)
+                       (when (and todos (> (length todos) 0))
+                         (concat (propertize "Todos" 'font-lock-face 'agent-shell-section-heading)
+                                 "\n"
+                                 (agent-shell--format-plan todos)))
+                       (when (and phases (> (length phases) 0))
+                         (mapconcat
+                          (lambda (phase)
+                            (concat (propertize (or (map-elt phase 'name) "Phase")
+                                                'font-lock-face 'agent-shell-section-heading)
+                                    "\n"
+                                    (agent-shell--format-plan (map-elt phase 'todos))))
+                          phases
+                          "\n\n"))))))
+    (string-trim (mapconcat #'identity parts "\n\n"))))
+
+(cl-defun agent-shell-cursor--make-create-plan-dialog (&key state request-id block-ids)
+  "Return Accept/Reject/Cancel dialog text for create_plan.
+
+STATE, REQUEST-ID, and BLOCK-IDS identify the pending request UI."
+  (let* ((shell-buffer (map-elt state :buffer))
+         (respond (lambda (outcome message &optional interrupt)
+                    (lambda ()
+                      (interactive)
+                      (agent-shell-cursor--send-extension-response
+                       :state state
+                       :request-id request-id
+                       :block-ids block-ids
+                       :outcome outcome
+                       :message-text message
+                       :interrupt interrupt))))
+         (actions (list
+                   (list (cons :char "y")
+                         (cons :label "Accept (y)")
+                         (cons :option "accept")
+                         (cons :outcome '((outcome . "accepted")))
+                         (cons :message "Plan accepted")
+                         (cons :interrupt nil))
+                   (list (cons :char "n")
+                         (cons :label "Reject (n)")
+                         (cons :option "reject")
+                         (cons :outcome '((outcome . "rejected")
+                                          (reason . "User rejected the plan")))
+                         (cons :message "Plan rejected")
+                         (cons :interrupt t))
+                   (list (cons :char "c")
+                         (cons :label "Cancel (c)")
+                         (cons :option "cancel")
+                         (cons :outcome '((outcome . "cancelled")))
+                         (cons :message "Plan cancelled")
+                         (cons :interrupt t))))
+         (keymap (let ((map (make-sparse-keymap)))
+                   (dolist (action actions)
+                     (define-key map (kbd (map-elt action :char))
+                                 (funcall respond
+                                          (map-elt action :outcome)
+                                          (map-elt action :message)
+                                          (map-elt action :interrupt))))
+                   (define-key map (kbd "C-c C-c")
+                               (lambda ()
+                                 (interactive)
+                                 (with-current-buffer shell-buffer
+                                   (agent-shell-interrupt t))))
+                   map)))
+    (format "╭─
+
+    %s %s %s
+
+
+    %s
+
+
+╰─"
+            (propertize agent-shell-permission-icon
+                        'font-lock-face 'agent-shell-warning)
+            (propertize "Plan Approval" 'font-lock-face 'agent-shell-permission-title)
+            (propertize agent-shell-permission-icon
+                        'font-lock-face 'agent-shell-warning)
+            (mapconcat
+             (lambda (action)
+               (agent-shell--make-permission-button
+                :text (map-elt action :label)
+                :help (map-elt action :label)
+                :action (funcall respond
+                                 (map-elt action :outcome)
+                                 (map-elt action :message)
+                                 (map-elt action :interrupt))
+                :keymap keymap
+                :char (map-elt action :char)
+                :option (map-elt action :option)
+                :navigatable t))
+             actions
+             " "))))
+
+(cl-defun agent-shell-cursor--on-create-plan-request (&key state acp-request)
+  "Handle blocking cursor/create_plan ACP-REQUEST with STATE."
+  (let* ((params (map-elt acp-request 'params))
+         (request-id (map-elt acp-request 'id))
+         (tool-call-id (or (map-elt params 'toolCallId) request-id))
+         (dialog-block-id (format "cursor-create-plan-%s" tool-call-id))
+         (plan-block-id (concat dialog-block-id "-body"))
+         (block-ids (list plan-block-id dialog-block-id)))
+    (agent-shell--update-fragment
+     :state state
+     :block-id plan-block-id
+     :label-left (propertize "Proposed plan" 'font-lock-face 'agent-shell-section-heading)
+     :body (agent-shell-cursor--format-create-plan-body params)
+     :expanded t)
+    (agent-shell--update-fragment
+     :state state
+     :block-id dialog-block-id
+     :body (agent-shell-cursor--make-create-plan-dialog
+            :state state
+            :request-id request-id
+            :block-ids block-ids)
+     :expanded t
+     :navigation 'never)
+    (agent-shell-jump-to-latest-permission-button-row)
+    (when-let* ((viewport-buffer (agent-shell-viewport--buffer
+                                  :shell-buffer (map-elt state :buffer)
+                                  :existing-only t)))
+      (with-current-buffer viewport-buffer
+        (agent-shell-jump-to-latest-permission-button-row)))
+    (let ((data (list (cons :request-id request-id)
+                      (cons :tool-call-id tool-call-id)
+                      (cons :method "cursor/create_plan"))))
+      (agent-shell--emit-event :event 'cursor-create-plan :data data)
+      (agent-shell--start-idle-timer :event 'cursor-create-plan :data data))
+    (map-put! state :last-entry-type "cursor/create_plan")))
+
+(cl-defun agent-shell-cursor--read-ask-question-answers (questions)
+  "Prompt for answers to QUESTIONS from cursor/ask_question.
+
+Return a vector of answer alists, or nil if the user quits."
+  (condition-case nil
+      (vconcat
+       (mapcar
+        (lambda (question)
+          (let* ((prompt (or (map-elt question 'prompt)
+                             (map-elt question 'id)
+                             "Select option"))
+                 (options (append (map-elt question 'options) nil))
+                 (allow-multiple (map-elt question 'allowMultiple))
+                 (choices (mapcar (lambda (option)
+                                    (cons (or (map-elt option 'label)
+                                              (map-elt option 'id))
+                                          (map-elt option 'id)))
+                                  options))
+                 (selected
+                  (if allow-multiple
+                      (completing-read-multiple
+                       (format "%s (comma-separated): " prompt)
+                       (mapcar #'car choices)
+                       nil t)
+                    (list (completing-read
+                           (format "%s: " prompt)
+                           (mapcar #'car choices)
+                           nil t)))))
+            `((questionId . ,(map-elt question 'id))
+              (selectedOptionIds . ,(vconcat
+                                    (mapcar (lambda (label)
+                                              (map-elt choices label))
+                                            selected))))))
+        (append questions nil)))
+    (quit nil)))
+
+(cl-defun agent-shell-cursor--on-ask-question-request (&key state acp-request)
+  "Handle blocking cursor/ask_question ACP-REQUEST with STATE."
+  (let* ((params (map-elt acp-request 'params))
+         (request-id (map-elt acp-request 'id))
+         (title (map-elt params 'title))
+         (questions (map-elt params 'questions))
+         (block-id (format "cursor-ask-question-%s"
+                           (or (map-elt params 'toolCallId) request-id)))
+         (body (string-trim
+                (mapconcat
+                 (lambda (question)
+                   (concat
+                    (propertize (or (map-elt question 'prompt)
+                                    (map-elt question 'id)
+                                    "Question")
+                                'font-lock-face 'agent-shell-section-heading)
+                    "\n"
+                    (mapconcat
+                     (lambda (option)
+                       (format "  - %s" (or (map-elt option 'label)
+                                            (map-elt option 'id))))
+                     (append (map-elt question 'options) nil)
+                     "\n")))
+                 (append questions nil)
+                 "\n\n"))))
+    (agent-shell--update-fragment
+     :state state
+     :block-id block-id
+     :label-left (propertize (or title "Cursor question")
+                             'font-lock-face 'agent-shell-section-heading)
+     :body body
+     :expanded t)
+    (if-let* ((answers (agent-shell-cursor--read-ask-question-answers questions)))
+        (agent-shell-cursor--send-extension-response
+         :state state
+         :request-id request-id
+         :block-ids block-id
+         :outcome `((outcome . "answered")
+                    (answers . ,answers))
+         :message-text "Answered Cursor question")
+      (agent-shell-cursor--send-extension-response
+       :state state
+       :request-id request-id
+       :block-ids block-id
+       :outcome '((outcome . "cancelled"))
+       :message-text "Cancelled Cursor question"
+       :interrupt t))
+    (map-put! state :last-entry-type "cursor/ask_question")))
+
+(cl-defun agent-shell-cursor--on-update-todos-request (&key state acp-request)
+  "Handle cursor/update_todos ACP-REQUEST with STATE.
+
+Display the todo list and auto-accept so the agent can continue."
+  (let* ((params (map-elt acp-request 'params))
+         (request-id (map-elt acp-request 'id))
+         (tool-call-id (map-elt params 'toolCallId))
+         (merge (map-elt params 'merge))
+         (todos (agent-shell-cursor--merge-todos
+                 :existing (map-elt state :cursor-todos)
+                 :incoming (map-elt params 'todos)
+                 :merge merge)))
+    (map-put! state :cursor-todos todos)
+    (agent-shell--update-fragment
+     :state state
+     :block-id "cursor-todos"
+     :label-left (propertize "Todos" 'font-lock-face 'agent-shell-section-heading)
+     :body (agent-shell--format-plan todos)
+     :expanded t
+     :above-last-prompt (not (agent-shell--active-requests-p state)))
+    (agent-shell-cursor--send-extension-response
+     :state state
+     :request-id request-id
+     :outcome `((outcome . "accepted")
+                (todos . ,(vconcat todos))))
+    (agent-shell--emit-event
+     :event 'cursor-update-todos
+     :data (list (cons :request-id request-id)
+                 (cons :tool-call-id tool-call-id)
+                 (cons :merge merge)
+                 (cons :todos todos)))
+    (map-put! state :last-entry-type "cursor/update_todos")))
 
 (provide 'agent-shell-cursor)
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2932,6 +2932,11 @@ No-op with no members yet."
          (agent-shell-experimental--on-session-push-request
           :state state
           :acp-request acp-request))
+        ((and (stringp (map-elt acp-request 'method))
+              (string-prefix-p "cursor/" (map-elt acp-request 'method))
+              (agent-shell-cursor--on-request
+               :state state
+               :acp-request acp-request)))
         (t
          (let ((method (map-elt acp-request 'method)))
            (agent-shell--update-fragment

--- a/tests/agent-shell-cursor-tests.el
+++ b/tests/agent-shell-cursor-tests.el
@@ -164,5 +164,183 @@
                            (content (type . "text")
                                     (text . "```\nhello\n```"))))))))
 
+
+(ert-deftest agent-shell-cursor--make-extension-response-test ()
+  "Test `agent-shell-cursor--make-extension-response'."
+  (let ((accepted (agent-shell-cursor--make-extension-response
+                   :request-id "req-1"
+                   :outcome '((outcome . "accepted"))))
+        (rejected (agent-shell-cursor--make-extension-response
+                   :request-id 7
+                   :outcome '((outcome . "rejected")
+                              (reason . "nope")))))
+    (should (equal (map-elt accepted :request-id) "req-1"))
+    (should (equal (map-nested-elt accepted '(:result outcome outcome))
+                   "accepted"))
+    (should (equal (map-elt rejected :request-id) 7))
+    (should (equal (map-nested-elt rejected '(:result outcome outcome))
+                   "rejected"))
+    (should (equal (map-nested-elt rejected '(:result outcome reason))
+                   "nope"))))
+
+(ert-deftest agent-shell-cursor--format-create-plan-body-test ()
+  "Test `agent-shell-cursor--format-create-plan-body'."
+  (let* ((todos (vector
+                 '((id . "t1") (content . "Inspect") (status . "completed"))
+                 '((id . "t2") (content . "Update") (status . "pending"))))
+         (body (agent-shell-cursor--format-create-plan-body
+                `((name . "Refactor")
+                  (overview . "Tighten layout.")
+                  (plan . "1. Inspect\n2. Update")
+                  (todos . ,todos)))))
+    (should (string-match-p "Refactor" body))
+    (should (string-match-p "Tighten layout" body))
+    (should (string-match-p "1\\. Inspect" body))
+    (should (string-match-p "Inspect" body))
+    (should (string-match-p "Update" body))))
+
+(ert-deftest agent-shell-cursor--on-request-create-plan-test ()
+  "Test `agent-shell-cursor--on-request' handles cursor/create_plan."
+  (with-temp-buffer
+    (let* ((captured-response nil)
+           (fragments nil)
+           (state `((:buffer . ,(current-buffer))
+                    (:client . test-client)
+                    (:event-subscriptions . nil)
+                    (:idle-timer . nil)
+                    (:last-entry-type . nil))))
+      (cl-letf (((symbol-function 'agent-shell--update-fragment)
+                 (lambda (&rest args)
+                   (push (plist-get args :block-id) fragments)))
+                ((symbol-function 'agent-shell-cursor--make-create-plan-dialog)
+                 (lambda (&rest _) "dialog"))
+                ((symbol-function 'agent-shell-jump-to-latest-permission-button-row)
+                 (lambda ()))
+                ((symbol-function 'agent-shell-viewport--buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'agent-shell--emit-event)
+                 (lambda (&rest _)))
+                ((symbol-function 'agent-shell--start-idle-timer)
+                 (lambda (&rest _)))
+                ((symbol-function 'acp-send-response)
+                 (lambda (&rest args)
+                   (setq captured-response (plist-get args :response)))))
+        (should (agent-shell-cursor--on-request
+                 :state state
+                 :acp-request
+                 '((id . "req-plan")
+                   (method . "cursor/create_plan")
+                   (params . ((toolCallId . "call-1")
+                              (name . "Plan")
+                              (overview . "Do the thing")
+                              (plan . "Step one")
+                              (todos . []))))))
+        (should (equal (map-elt state :last-entry-type) "cursor/create_plan"))
+        (should (member "cursor-create-plan-call-1" fragments))
+        (should (member "cursor-create-plan-call-1-body" fragments))
+        (should-not captured-response)))))
+
+(ert-deftest agent-shell--on-request-cursor-create-plan-integration-test ()
+  "Test `agent-shell--on-request' dispatches cursor/create_plan."
+  (with-temp-buffer
+    (let* ((handled nil)
+           (state `((:buffer . ,(current-buffer))
+                    (:client . test-client)
+                    (:last-entry-type . nil))))
+      (cl-letf (((symbol-function 'agent-shell-cursor--on-request)
+                 (lambda (&rest _)
+                   (setq handled t)
+                   t))
+                ((symbol-function 'agent-shell--update-fragment)
+                 (lambda (&rest _)))
+                ((symbol-function 'acp-send-response)
+                 (lambda (&rest _)
+                   (error "Should not send method-not-found for create_plan"))))
+        (agent-shell--on-request
+         :state state
+         :acp-request '((id . "req-plan")
+                        (method . "cursor/create_plan")
+                        (params . ((plan . "x")))))
+        (should handled)))))
+
+(ert-deftest agent-shell-cursor--on-request-unknown-method-test ()
+  "Test `agent-shell-cursor--on-request' ignores unknown cursor methods."
+  (should-not (agent-shell-cursor--on-request
+               :state nil
+               :acp-request '((id . "1")
+                              (method . "cursor/unknown_method")))))
+
+(ert-deftest agent-shell-cursor--merge-todos-test ()
+  "Test `agent-shell-cursor--merge-todos'."
+  (let* ((existing (list '((id . "1") (content . "A") (status . "pending"))
+                         '((id . "2") (content . "B") (status . "pending"))))
+         (incoming (vector '((id . "2") (content . "B2") (status . "completed"))
+                           '((id . "3") (content . "C") (status . "pending"))))
+         (replaced (agent-shell-cursor--merge-todos
+                    :existing existing
+                    :incoming incoming
+                    :merge nil))
+         (merged (agent-shell-cursor--merge-todos
+                  :existing existing
+                  :incoming incoming
+                  :merge t)))
+    (should (equal replaced (append incoming nil)))
+    (should (equal merged
+                   (list '((id . "1") (content . "A") (status . "pending"))
+                         '((id . "2") (content . "B2") (status . "completed"))
+                         '((id . "3") (content . "C") (status . "pending")))))))
+
+(ert-deftest agent-shell-cursor--on-request-update-todos-test ()
+  "Test `agent-shell-cursor--on-request' handles cursor/update_todos."
+  (with-temp-buffer
+    (let* ((captured-response nil)
+           (fragment-body nil)
+           (todos (vector
+                   '((id . "1") (content . "New") (status . "completed"))
+                   '((id . "2") (content . "Next") (status . "pending"))))
+           (request `((id . "req-todos")
+                      (method . "cursor/update_todos")
+                      (params (toolCallId . "call-t")
+                              (merge . t)
+                              (todos . ,todos))))
+           (state `((:buffer . ,(current-buffer))
+                    (:client . test-client)
+                    (:event-subscriptions . nil)
+                    (:cursor-todos . (((id . "1")
+                                       (content . "Old")
+                                       (status . "pending"))))
+                    (:last-entry-type . nil))))
+      (cl-letf (((symbol-function 'agent-shell--update-fragment)
+                 (lambda (&rest args)
+                   (setq fragment-body (plist-get args :body))))
+                ((symbol-function 'agent-shell--active-requests-p)
+                 (lambda (_) t))
+                ((symbol-function 'agent-shell--emit-event)
+                 (lambda (&rest _)))
+                ((symbol-function 'agent-shell--cancel-idle-timer)
+                 (lambda ()))
+                ((symbol-function 'agent-shell-jump-to-latest-permission-button-row)
+                 (lambda ()))
+                ((symbol-function 'agent-shell-viewport--buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'acp-send-response)
+                 (lambda (&rest args)
+                   (setq captured-response (plist-get args :response)))))
+        (should (agent-shell-cursor--on-request
+                 :state state
+                 :acp-request request))
+        (should (equal (map-elt state :last-entry-type) "cursor/update_todos"))
+        (should (equal (map-elt state :cursor-todos)
+                       (list '((id . "1") (content . "New") (status . "completed"))
+                             '((id . "2") (content . "Next") (status . "pending")))))
+        (should (string-match-p "New" fragment-body))
+        (should (string-match-p "Next" fragment-body))
+        (should (equal (map-elt captured-response :request-id) "req-todos"))
+        (should (equal (map-nested-elt captured-response '(:result outcome outcome))
+                       "accepted"))
+        (should (= (length (map-nested-elt captured-response
+                                           '(:result outcome todos)))
+                   2))))))
+
 (provide 'agent-shell-cursor-tests)
 ;;; agent-shell-cursor-tests.el ends here


### PR DESCRIPTION
## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

## Summary

Fixes #704.

Cursor sends a few custom ACP methods that agent-shell currently replies to with method-not-found, which stalls the agent. Docs: https://cursor.com/docs/cli/acp#cursor-extension-methods

This handles the three I've actually hit:

- `cursor/create_plan` (blocking): show the plan, Accept (y) / Reject (n) / Cancel (c) dialog in the same style as permission prompts
- `cursor/ask_question` (blocking): `completing-read` for answers (CRM when `allowMultiple`)
- `cursor/update_todos` (docs call this a notification, but Cursor sends it as a request): update a Todos fragment and auto-accept so we don't stall

`agent-shell--on-request` now routes `cursor/*` to `agent-shell-cursor--on-request`.

## Tests

11 ERT tests in `tests/agent-shell-cursor-tests.el` for response shape, plan formatting, create_plan dispatch, update_todos merge/response, and the `agent-shell--on-request` integration path. Unknown `cursor/*` methods still fall through.
