### PR TITLE
Queue requests sent during session/push and submit them when it ends

### DIFF
--- a/agent-shell-experimental.el
+++ b/agent-shell-experimental.el
@@ -41,6 +41,7 @@
 (declare-function agent-shell-heartbeat-stop "agent-shell-heartbeat")
 
 (defvar agent-shell-show-busy-indicator)
+(defvar shell-maker--busy)
 
 (cl-defun agent-shell-experimental--on-session-push-request (&key state acp-request)
   "Handle an incoming session/push ACP-REQUEST with STATE.
@@ -70,6 +71,7 @@ in progress), the request is immediately rejected with an error."
                 (cons request (map-elt state :active-requests))))
     ;; Remove trailing empty shell prompt before push notifications render.
     (agent-shell-experimental--remove-trailing-prompt)
+    (setq shell-maker--busy t)
     (when agent-shell-show-busy-indicator
       (agent-shell-heartbeat-start
        :heartbeat (map-elt state :heartbeat)))

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2503,7 +2503,8 @@ No-op with no members yet."
             :state state
             :on-finished (lambda ()
                            (shell-maker-finish-output :config shell-maker--config
-                                                      :success t))))
+                                                      :success t)
+                           (agent-shell--process-pending-request))))
           (acp-logging-enabled
            (agent-shell--update-fragment
             :state state


### PR DESCRIPTION
Mark the shell busy while a session/push is in flight, so requests sent via agent-shell-queue-request are queued instead of being submitted mid-push.  And submit those requests when the session/push ends.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
