### PR TITLE
Auto-retry turns that end with a retriable error

### DIFF
--- a/README.org
+++ b/README.org
@@ -791,6 +791,23 @@ To turn it off:
 (setopt agent-shell-inhibit-system-sleep nil)
 #+end_src
 
+*** Auto-retrying turns that end with a transient error
+
+Some agents catch a transient error internally, print it as regular agent output (for example Cursor's =Error: RetriableError: [unavailable]=), and end the turn as if it had succeeded, leaving the task unfinished. When enabled, =agent-shell= detects such turns by their final output line and automatically sends a continue prompt after a short backoff, displaying a "Retrying" block in the shell. Interrupting the session cancels any pending retry.
+
+Off by default. To enable:
+
+#+begin_src emacs-lisp
+(setq agent-shell-auto-retry t)
+#+end_src
+
+Related variables:
+
+- =agent-shell-retry-max-retries=: retries per turn before giving up (default 2).
+- =agent-shell-retry-backoff-seconds=: seconds to wait before each retry (default =(2 5)=; the last entry repeats for further retries).
+- =agent-shell-retriable-turn-tail-regexps=: case-insensitive patterns a completed turn's final line must match to be considered retriable.
+- =agent-shell-retry-prompt=: the continue prompt sent to the agent on retry.
+
 All of the above settings can be applied on a per-project basis using [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html][directory-local variables]].
 
 ** Key bindings

--- a/agent-shell-retry.el
+++ b/agent-shell-retry.el
@@ -1,0 +1,214 @@
+;;; agent-shell-retry.el --- Turn auto-retry support -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Zhixu Zhao
+
+;; This package is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This package is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Report issues at https://github.com/xenodium/agent-shell/issues
+;;
+;; ✨ Please support this work https://github.com/sponsors/xenodium ✨
+
+;;; Commentary:
+;;
+;; Provides auto-retry support for turns failing with retriable errors.
+
+;;; Code:
+
+(eval-when-compile
+  (require 'cl-lib))
+(require 'map)
+(require 'seq)
+
+(declare-function agent-shell--send-command "agent-shell")
+(declare-function agent-shell--separate-transcript-after-agent-message "agent-shell")
+(declare-function agent-shell--update-fragment "agent-shell")
+
+(defvar agent-shell--transcript-file)
+
+(defvar agent-shell-auto-retry nil
+  "Non-nil to auto-retry a turn that ends with a retriable error.
+
+Off by default.
+
+Some agents catch a transient error internally, print it as ordinary
+assistant text, and finish the turn normally, leaving the task
+unfinished.  When such a turn's final line matches
+`agent-shell-retriable-turn-tail-regexps', agent-shell sends
+`agent-shell-retry-prompt' as a new user turn (up to
+`agent-shell-retry-max-retries' times) rather than stopping.  Unlike
+an agent's own internal API retries, this recovers the whole turn at
+the ACP layer.  Interrupting the session cancels any pending retry.")
+
+(defvar agent-shell-retry-prompt
+  "[agent-shell auto-retry] The previous turn failed with a retriable error. Please continue working on the task where you left off."
+  "Prompt sent as a new user turn to recover from a retriable error.
+The \"[agent-shell auto-retry]\" marker keeps it distinguishable from a
+user-authored prompt in the shell, transcript, and to the agent.")
+
+(defvar agent-shell-retry-max-retries 2
+  "Maximum number of auto-retry turns before surfacing the error.")
+
+(defvar agent-shell-retry-backoff-seconds '(2 5)
+  "Backoff delays (in seconds) indexed by 1-based retry number.
+Has one entry per `agent-shell-retry-max-retries'; the last entry is
+reused for any retry beyond the list length.")
+
+(defvar agent-shell-retriable-turn-tail-regexps
+  '("^Error: RetriableError:")
+  "Case-insensitive regexps for a retriable error emitted as agent text.
+
+Matched against the final non-blank line of a turn that completed with an
+\"end_turn\" stop reason.")
+
+(defun agent-shell--retriable-turn-tail-p (text)
+  "Return TEXT's final non-blank line when that line is a retriable error.
+
+The line (trimmed) is matched case-insensitively against
+`agent-shell-retriable-turn-tail-regexps'; returns it on a match, nil
+otherwise (so callers can reuse it as the error message).
+
+Deliberately narrow and anchored to the trailing line; a broad match would
+misfire on turns that merely analyze error logs, which mention errors
+mid-message rather than ending on one."
+  (when-let* ((line (car (last (seq-remove #'string-empty-p
+                                           (seq-map #'string-trim
+                                                   (split-string (or text "") "\n"))))))
+              (case-fold-search t)
+              ((seq-some (lambda (regexp)
+                           (string-match-p regexp line))
+                         agent-shell-retriable-turn-tail-regexps)))
+    line))
+
+;; TODO: Not retry-specific: generic per-turn message accumulation,
+;; kept here while retry detection is its only consumer.  If another
+;; feature ever needs the full turn text, move ownership to
+;; agent-shell.el and accumulate a chunk list (O(1) per chunk, joined
+;; on read); tail detection can then read that field's tail instead of
+;; keeping this capped copy.
+(defun agent-shell--accumulate-turn-agent-message (state content)
+  "Append CONTENT to STATE's `:turn-agent-message', keeping a bounded tail.
+
+Only the turn's trailing text is needed to detect a retriable error emitted
+as the final line, so the stored string is capped rather than growing with
+the whole message.  A no-op on sessions predating the field."
+  (when (and content (assq :turn-agent-message state))
+    (let ((combined (concat (map-elt state :turn-agent-message) content)))
+      (map-put! state :turn-agent-message
+                (if (> (length combined) 4000)
+                    (substring combined -4000)
+                  combined)))))
+
+(defun agent-shell--retry-backoff-for-attempt (retry-number)
+  "Return the backoff delay in seconds before RETRY-NUMBER (1-based).
+
+Clamps to the last entry of `agent-shell-retry-backoff-seconds'.
+
+For example, with `agent-shell-retry-backoff-seconds' set to (2 5 10):
+  (agent-shell--retry-backoff-for-attempt 1) => 2
+  (agent-shell--retry-backoff-for-attempt 4) => 10"
+  (or (nth (1- retry-number) agent-shell-retry-backoff-seconds)
+      (car (last agent-shell-retry-backoff-seconds))
+      0))
+
+(defun agent-shell--retry-prompt (state)
+  "Return auto-retry prompt for STATE.
+
+Includes STATE's `:last-user-prompt' when available, so a retry turn can
+recover even if the agent lost the user request that failed."
+  (if-let* ((last-user-prompt (map-elt state :last-user-prompt))
+            ((not (string-empty-p (string-trim last-user-prompt)))))
+      (format "%s
+
+Last user prompt before the failure:
+
+%s"
+              agent-shell-retry-prompt last-user-prompt)
+    agent-shell-retry-prompt))
+
+(cl-defun agent-shell--retry-completed-turn-p (&key state stop-reason message)
+  "Return the offending trailing line if a COMPLETED turn should be retried.
+
+Returns MESSAGE's trailing line (for use as the error message) when
+auto-retry is enabled, STOP-REASON is \"end_turn\", that line matches
+`agent-shell-retriable-turn-tail-regexps', and the retry budget (STATE's
+`:retry-attempt') is not exhausted; nil otherwise."
+  (and agent-shell-auto-retry
+       (equal stop-reason "end_turn")
+       (< (map-elt state :retry-attempt 0) agent-shell-retry-max-retries)
+       (agent-shell--retriable-turn-tail-p message)))
+
+(defun agent-shell--cancel-retry-timer (state)
+  "Cancel and clear STATE's pending `:retry-timer', if any."
+  (when-let* ((timer (map-elt state :retry-timer)))
+    (cancel-timer timer)
+    (map-put! state :retry-timer nil)))
+
+(cl-defun agent-shell--schedule-retry (&key state shell-buffer acp-error)
+  "Schedule an auto-retry turn after a backoff delay.
+
+Once the delay elapses, sends `agent-shell-retry-prompt' as a new user
+turn via `agent-shell--send-command', incrementing STATE's
+`:retry-attempt'.  This recovers a turn that ended with a retriable
+error by asking the agent to continue, keeping it distinct from an
+agent's own internal API retries.
+
+The heartbeat and busy state are left untouched so the shell keeps
+signaling work in progress during the wait, and the pending timer is
+stored in STATE's `:retry-timer' so `agent-shell-interrupt' or shutdown
+can cancel it.
+
+STATE and SHELL-BUFFER identify the shell.  ACP-ERROR is the failure
+payload shown in the on-screen retry notice."
+  (let* ((retry-number (1+ (map-elt state :retry-attempt 0)))
+         (delay (agent-shell--retry-backoff-for-attempt retry-number))
+         (error-message (or (map-elt acp-error 'message) "unknown error"))
+         (retry-prompt (agent-shell--retry-prompt state)))
+    (map-put! state :retry-attempt retry-number)
+    ;; A failed turn may have stopped mid agent_message_chunk, leaving the
+    ;; transcript body without a trailing newline.  Separate it so the
+    ;; retry's user header lands on its own line.
+    (agent-shell--separate-transcript-after-agent-message
+     :last-entry-type (map-elt state :last-entry-type)
+     :file-path agent-shell--transcript-file)
+    (agent-shell--update-fragment
+     :state state
+     :block-id (format "%s-retry-%s" (map-elt state :request-count) retry-number)
+     :label-left (propertize "Retrying" 'font-lock-face 'agent-shell-warning)
+     :body (format "%s
+
+Retrying in %ds (retry %d/%d) with prompt:
+
+%s"
+                   (propertize (format "Retriable error: %s" error-message)
+                               'font-lock-face 'agent-shell-warning)
+                   delay retry-number agent-shell-retry-max-retries
+                   retry-prompt)
+     :create-new t)
+    (map-put! state :retry-timer
+              (run-at-time
+               delay nil
+               (lambda ()
+                 (when (buffer-live-p shell-buffer)
+                   (with-current-buffer shell-buffer
+                     (map-put! state :retry-timer nil)
+                     (agent-shell--send-command
+                      :prompt retry-prompt
+                      :shell-buffer shell-buffer
+                      :retry t))))))))
+
+(provide 'agent-shell-retry)
+
+;;; agent-shell-retry.el ends here

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -81,6 +81,7 @@
 (require 'agent-shell-pi)
 (require 'agent-shell-project)
 (require 'agent-shell-qwen)
+(require 'agent-shell-retry)
 (require 'agent-shell-styles)
 (require 'agent-shell-usage)
 (require 'agent-shell-worktree)
@@ -1058,6 +1059,10 @@ OUTGOING-REQUEST-DECORATOR (passed through to `acp-make-client')."
         (cons :sleep-token nil)
         (cons :active-requests nil)
         (cons :pending-requests nil)
+        (cons :retry-timer nil)
+        (cons :retry-attempt 0)
+        (cons :last-user-prompt nil)
+        (cons :turn-agent-message "")
         (cons :usage (list (cons :total-tokens 0)
                            (cons :input-tokens 0)
                            (cons :output-tokens 0)
@@ -1829,6 +1834,7 @@ See also `agent-shell-confirm-interrupt'."
     (error "Not in a shell"))
   (cond ((map-nested-elt (agent-shell--state) '(:session :id))
          (when (or force (agent-shell-interrupt-confirmed-p))
+           (agent-shell--cancel-retry-timer (agent-shell--state))
            ;; First cancel all pending permission requests
            (map-do
             (lambda (tool-call-id tool-call-data)
@@ -2547,6 +2553,7 @@ No-op while that function has nothing to summarize (an empty group)."
              (agent-shell--append-transcript
               :text (agent-shell--indent-markdown-headers content)
               :file-path agent-shell--transcript-file)
+             (agent-shell--accumulate-turn-agent-message state content)
              (agent-shell--update-fragment
               :state state
               ;; Out of turn, key under a dedicated namespace so the
@@ -3727,6 +3734,7 @@ For example, shut down ACP client."
   "Shut down shell activity."
   (unless (derived-mode-p 'agent-shell-mode)
     (error "Not in a shell"))
+  (agent-shell--cancel-retry-timer (agent-shell--state))
   (when (map-elt (agent-shell--state) :client)
     (acp-shutdown :client (map-elt (agent-shell--state) :client))
     (map-put! (agent-shell--state) :client nil)
@@ -7163,8 +7171,12 @@ Each marked span is replaced by its `agent-shell-region-text' value."
           (insert full-text))))
     (buffer-string)))
 
-(cl-defun agent-shell--send-command (&key prompt shell-buffer)
-  "Send PROMPT to agent using SHELL-BUFFER."
+(cl-defun agent-shell--send-command (&key prompt shell-buffer retry)
+  "Send PROMPT to agent using SHELL-BUFFER.
+
+When RETRY is non-nil, PROMPT is an auto-retry turn (see
+`agent-shell--schedule-retry'): the per-turn retry counter is
+preserved rather than reset."
   (let* ((expanded-prompt (agent-shell--expand-truncated-regions prompt))
          (content-blocks (condition-case nil
                              (agent-shell--build-content-blocks expanded-prompt)
@@ -7179,6 +7191,13 @@ Each marked span is replaced by its `agent-shell-region-text' value."
 
     (agent-shell--cancel-idle-timer)
     (agent-shell--emit-event :event 'input-submitted)
+
+    (map-put! agent-shell--state :turn-agent-message "")
+    (unless retry
+      (agent-shell--cancel-retry-timer agent-shell--state)
+      (map-put! agent-shell--state :retry-attempt 0)
+      (map-put! agent-shell--state :last-user-prompt
+                (substring-no-properties expanded-prompt)))
 
     (map-put! agent-shell--state :last-entry-type nil)
 
@@ -7225,6 +7244,15 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                      (agent-shell--save-usage :state (agent-shell--state) :acp-usage (map-elt acp-response 'usage)))
                    (let ((success (equal (map-elt acp-response 'stopReason)
                                          "end_turn")))
+                     (if-let* ((retry-tail (agent-shell--retry-completed-turn-p
+                                            :state (agent-shell--state)
+                                            :stop-reason (map-elt acp-response 'stopReason)
+                                            :message (map-elt (agent-shell--state) :turn-agent-message))))
+                         (agent-shell--schedule-retry
+                          :state agent-shell--state
+                          :shell-buffer shell-buffer
+                          :acp-error (list (cons 'message retry-tail)))
+                       (progn
                      ;; Display usage box at end of turn if enabled and data available
                      (when (and success
                                 agent-shell-show-usage-at-turn-end
@@ -7262,7 +7290,7 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                        (with-current-buffer viewport-buffer
                          (agent-shell-viewport--update-header)))
                      (when success
-                       (agent-shell--process-pending-request))))
+                       (agent-shell--process-pending-request))))))
      :on-failure (lambda (acp-error raw-message)
                    ;; A failed/interrupted turn may have stopped mid
                    ;; agent_message_chunk, leaving the transcript body

--- a/tests/agent-shell-retry-tests.el
+++ b/tests/agent-shell-retry-tests.el
@@ -1,0 +1,95 @@
+;;; agent-shell-retry-tests.el --- Tests for agent-shell-retry -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'agent-shell-retry)
+
+;;; Code:
+
+(ert-deftest agent-shell--retry-backoff-for-attempt-test ()
+  "Test `agent-shell--retry-backoff-for-attempt' delay lookup and clamping."
+  (let ((agent-shell-retry-backoff-seconds '(2 5 10)))
+    (should (equal (agent-shell--retry-backoff-for-attempt 1) 2))
+    (should (equal (agent-shell--retry-backoff-for-attempt 2) 5))
+    (should (equal (agent-shell--retry-backoff-for-attempt 3) 10))
+    ;; Beyond the list length clamps to the last entry.
+    (should (equal (agent-shell--retry-backoff-for-attempt 4) 10))
+    (should (equal (agent-shell--retry-backoff-for-attempt 99) 10))))
+
+(ert-deftest agent-shell--retry-prompt-test ()
+  "Test `agent-shell--retry-prompt' includes the failed user prompt."
+  (let ((agent-shell-retry-prompt "Continue from the failure."))
+    (should (equal (agent-shell--retry-prompt nil)
+                   "Continue from the failure."))
+    (should (equal (agent-shell--retry-prompt '((:last-user-prompt . "   ")))
+                   "Continue from the failure."))
+    (should (equal (agent-shell--retry-prompt
+                    '((:last-user-prompt . "Patch the retry tests.")))
+                   "Continue from the failure.
+
+Last user prompt before the failure:
+
+Patch the retry tests."))))
+
+(ert-deftest agent-shell--retriable-turn-tail-p-test ()
+  "Test `agent-shell--retriable-turn-tail-p' anchors to the final line."
+  ;; The reported Cursor case: error emitted as the turn's final line, the
+  ;; matched line is returned so it can be reused as the error message.
+  (should (equal (agent-shell--retriable-turn-tail-p
+                  "Let me continue waiting for the save/upload.\nError: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)")
+                 "Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)"))
+  ;; Trailing blank lines are ignored.
+  (should (equal (agent-shell--retriable-turn-tail-p
+                  "Error: RetriableError: [canceled] stream closed\n\n")
+                 "Error: RetriableError: [canceled] stream closed"))
+  ;; A turn that merely analyzes error logs mid-message is not retried:
+  ;; the error is not the final line.
+  (should-not (agent-shell--retriable-turn-tail-p
+               "Error: RetriableError: x\nThat log line is expected; all good now."))
+  ;; Non-matching / empty input.
+  (should-not (agent-shell--retriable-turn-tail-p "All done, no problems."))
+  (should-not (agent-shell--retriable-turn-tail-p ""))
+  (should-not (agent-shell--retriable-turn-tail-p nil)))
+
+(ert-deftest agent-shell--accumulate-turn-agent-message-test ()
+  "Test `agent-shell--accumulate-turn-agent-message' appends a bounded tail."
+  (let ((state (list (cons :turn-agent-message ""))))
+    (agent-shell--accumulate-turn-agent-message state "Hello ")
+    (agent-shell--accumulate-turn-agent-message state "world")
+    (should (equal (map-elt state :turn-agent-message) "Hello world"))
+    ;; The stored string is capped so it never grows with the whole message,
+    ;; while preserving the trailing text used for tail detection.
+    (agent-shell--accumulate-turn-agent-message state (make-string 5000 ?x))
+    (should (<= (length (map-elt state :turn-agent-message)) 4000))
+    (should (string-suffix-p "xxxx" (map-elt state :turn-agent-message))))
+  ;; A no-op (no error) on sessions predating the field.
+  (let ((state (list (cons :other t))))
+    (agent-shell--accumulate-turn-agent-message state "content")
+    (should-not (map-elt state :turn-agent-message))))
+
+(ert-deftest agent-shell--retry-completed-turn-p-test ()
+  "Test `agent-shell--retry-completed-turn-p' gating of success-path retries."
+  (let ((agent-shell-auto-retry t)
+        (agent-shell-retry-max-retries 2)
+        (tail "Working...\nError: RetriableError: [canceled] stream closed")
+        (clean "All done."))
+    ;; A normally-finished turn whose final line is a retriable error.
+    (should (agent-shell--retry-completed-turn-p
+             :state '((:retry-attempt . 0)) :stop-reason "end_turn" :message tail))
+    (should (agent-shell--retry-completed-turn-p
+             :state '((:retry-attempt . 1)) :stop-reason "end_turn" :message tail))
+    ;; Retry budget exhausted.
+    (should-not (agent-shell--retry-completed-turn-p
+                 :state '((:retry-attempt . 2)) :stop-reason "end_turn" :message tail))
+    ;; Non-end_turn stop reasons go through the normal (failure) paths.
+    (should-not (agent-shell--retry-completed-turn-p
+                 :state '((:retry-attempt . 0)) :stop-reason "cancelled" :message tail))
+    ;; Clean turn is never retried.
+    (should-not (agent-shell--retry-completed-turn-p
+                 :state '((:retry-attempt . 0)) :stop-reason "end_turn" :message clean))
+    ;; Auto-retry disabled.
+    (let ((agent-shell-auto-retry nil))
+      (should-not (agent-shell--retry-completed-turn-p
+                   :state '((:retry-attempt . 0)) :stop-reason "end_turn" :message tail)))))
+
+(provide 'agent-shell-retry-tests)
+;;; agent-shell-retry-tests.el ends here


### PR DESCRIPTION
## What this does

Feature Request: https://github.com/xenodium/agent-shell/issues/734

Some agents (e.g. Cursor) catch a transient stream error internally, print it as ordinary assistant text ("Error: RetriableError: ..."), and finish the turn normally, leaving the task unfinished.  

With `agent-shell-auto-retry` enabled, agent-shell detects such turns by their final output line and sends a continue prompt (including the last user prompt for context) after a short backoff, showing a "Retrying" block in the shell, up to `agent-shell-retry-max-retries` times.  Interrupting cancels any pending retry.

Off by default; enable with `(setq agent-shell-auto-retry t)`.

Detection helpers live in the new `agent-shell-retry.el`; the shell wiring (state, scheduling, send-command integration) stays in `agent-shell.el`.

## Try it live

Instead of waiting for a real transient error, you can simulate one by printing the pattern as its final line:

1. Enable the feature: `(setq agent-shell-auto-retry t)`
2. Start any agent shell (e.g. `M-x agent-shell-anthropic-start-claude-code`) and send:

   ```
   End your reply with this exact line, with nothing after it:
   Error: RetriableError: [test] simulated transient failure
   ```

3. When the turn completes, a "Retrying" block appears with the detected error and a 2s countdown, then the continue prompt (marked `[agent-shell auto-retry]`, quoting the prompt above) is sent as a new user turn. Because the quoted prompt re-instructs the agent, it usually triggers again: retry 2/2 with the escalated 5s backoff, after which the budget is exhausted and the chain stops — one prompt demos detection, backoff escalation, and the cap.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.