### PR TITLE
Add a workaround for goose.

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3353,7 +3353,15 @@ rawInput variants to that shape."
         (list `((oldText . ,(car parsed))
                 (newText . ,(cdr parsed))
                 (path . ,(or (map-elt raw-input 'fileName)
-                             (map-elt raw-input 'path))))))))))
+                             (map-elt raw-input 'path)))))))
+     ;; Attempt to diff from rawInput (goose)
+     ((and raw-input (map-elt raw-input 'before))
+      (let ((old-text (or (map-elt raw-input 'before) ""))
+            (new-text (map-elt raw-input 'after))
+            (path (map-elt raw-input 'path)))
+        (list `((oldText . ,old-text)
+                (newText . ,new-text)
+                (path . ,path))))))))
 
 (cl-defun agent-shell--make-diff-info (&key acp-diff-item locations)
   "Convert a single ACP-DIFF-ITEM to a diff info alist.


### PR DESCRIPTION
Goose's diffs look like this:
```
 '((sessionUpdate . "tool_call")
   (toolCallId . "<some_id>")
   (title . "edit · /tmp/test.txt")
   (rawInput (path . "/tmp/test.txt") (before . #2="")
             (after . "Test"))
   (_meta (goose (toolCall (toolName . "edit") (extensionName . "developer"))))))
```

There is an open issue for this: https://github.com/xenodium/agent-shell/issues/569 - I added this snippet and for me locally it now shows the 'View (v)' option with goose.

Thank you for contributing to agent-shell!

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [X] I've run `M-x checkdoc` and `M-x byte-compile-file`.
