### PR TITLE
Add a `when-active` option to `agent-shell-activity-group-expand-by-default`

### DIFF
--- a/README.org
+++ b/README.org
@@ -885,6 +885,7 @@ always go to Evil modes if you need to with ~C-z~).
 #+RESULTS:
 | Custom variable                               | Description                                                                     |
 |-----------------------------------------------+---------------------------------------------------------------------------------|
+| agent-shell-activity-group-expand-by-default  | When activity group sections should be expanded.                                |
 | agent-shell-agent-configs                     | The list of known agent configurations.                                         |
 | agent-shell-anthropic-authentication          | Configuration for Anthropic authentication.                                     |
 | agent-shell-anthropic-claude-acp-command      | Command and parameters for the Anthropic Claude client.                         |

--- a/agent-shell-ui.el
+++ b/agent-shell-ui.el
@@ -1048,6 +1048,31 @@ state-property range first.  User-facing toggling goes through
              t)
         (agent-shell-ui--toggle-fragment-at-point)))))
 
+(cl-defun agent-shell-ui-set-group-collapsed-by-id (&key namespace-id block-id collapsed no-undo)
+  "Fold or unfold the group header NAMESPACE-ID/BLOCK-ID to match COLLAPSED.
+
+Unlike `agent-shell-ui-collapse-fragment-by-id', this sets the fold state
+rather than toggling it, so repeat calls with the same COLLAPSED are a
+no-op.  Does nothing when NAMESPACE-ID/BLOCK-ID names no rendered group
+header, or when it already matches COLLAPSED.  When NO-UNDO is non-nil,
+disable undo recording for this operation.
+
+  ;; Group \"ns-grp\" is expanded.
+  (agent-shell-ui-set-group-collapsed-by-id
+   :namespace-id \"ns\" :block-id \"grp\" :collapsed t)
+  ;; Its members are now hidden and its indicator reads `▶'."
+  (save-mark-and-excursion
+    (let ((inhibit-read-only t)
+          (buffer-undo-list (if no-undo t buffer-undo-list))
+          (qualified-id (format "%s-%s" namespace-id block-id)))
+      (when-let* ((header (agent-shell-ui--group-header-range qualified-id))
+                  (state (get-text-property (map-elt header :start)
+                                            'agent-shell-ui-state))
+                  ((eq (map-elt state :kind) 'group))
+                  ((not (eq (and (map-elt state :collapsed) t)
+                            (and collapsed t)))))
+        (agent-shell-ui--set-group-collapsed qualified-id (and collapsed t))))))
+
 (defvar-local agent-shell-ui--fold-toggle-state nil
   "Current global fold state for the buffer.
 One of `expanded', `collapsed', or nil (first call — derive from buffer).

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -139,17 +139,53 @@ When non-nil, tool use sections are expanded."
   :type 'boolean
   :group 'agent-shell)
 
-(defcustom agent-shell-activity-group-expand-by-default nil
-  "Whether an activity group header is expanded by default.
+(defcustom agent-shell-activity-group-expand-by-default 'never
+  "When activity group headers should be expanded.
 
 An activity group is a run of consecutive agent actions (tool calls,
-and eventually thoughts) rendered under one collapsible header.  When
-non-nil (the default), the group shows its members.  When nil, it starts
-collapsed, showing only the header with its aggregated status and
-completed/total count.  Individual members still follow
+and eventually thoughts) rendered under one collapsible header.
+
+  `never'       Groups start collapsed, showing only the header with its
+                aggregated status and completed/total count.
+  `always'      Groups show their members.
+  `when-active' The group the agent is currently working in shows its
+                members, and collapses once the agent moves on to a new
+                group or the turn ends.  Keeps the session tidy while
+                still making the agent's current activity followable.
+
+The legacy boolean values remain supported: nil reads as `never' and t
+as `always'.  Individual members still follow
 `agent-shell-tool-use-expand-by-default'."
-  :type 'boolean
+  :type '(choice (const :tag "Never" never)
+                 (const :tag "Always" always)
+                 (const :tag "While the agent is working in it" when-active))
   :group 'agent-shell)
+
+(defun agent-shell--activity-group-expand-policy ()
+  "Return `agent-shell-activity-group-expand-by-default' as a policy symbol.
+
+One of `never', `always', or `when-active'.  Maps the legacy boolean
+values onto the symbols: nil reads as `never' and any other unrecognized
+value as `always' (matching the pre-symbol \"non-nil means expanded\"
+behavior).
+
+  ;; `agent-shell-activity-group-expand-by-default' = t
+  (agent-shell--activity-group-expand-policy)
+  ;; => always"
+  (pcase agent-shell-activity-group-expand-by-default
+    ('never 'never)
+    ('always 'always)
+    ('when-active 'when-active)
+    ('nil 'never)
+    (_ 'always)))
+
+(defun agent-shell--activity-group-initial-expanded-p ()
+  "Return non-nil when a newly created activity group starts expanded.
+
+Both `always' and `when-active' start expanded; `when-active' collapses
+the group again once the agent moves on (see
+`agent-shell--sync-activity-group-fold')."
+  (and (memq (agent-shell--activity-group-expand-policy) '(always when-active)) t))
 
 (defvar agent-shell-mode-hook nil
   "Hook run after an `agent-shell-mode' buffer is fully initialized.
@@ -1081,6 +1117,7 @@ OUTGOING-REQUEST-DECORATOR (passed through to `acp-make-client')."
         (cons :chunked-group-count 0)
         (cons :activity-group-count 0)
         (cons :activity-thoughts nil)
+        (cons :expanded-activity-group nil)
         (cons :request-count 0)
         (cons :last-activity-time nil)
         (cons :tool-calls nil)
@@ -2278,6 +2315,17 @@ same group."
                   agent-shell--activity-group-run-entry-types)
     (map-put! state :activity-group-count
               (1+ (or (map-elt state :activity-group-count) 0))))
+  (agent-shell--activity-group-latest-id state))
+
+(defun agent-shell--activity-group-latest-id (state)
+  "Return the id of the most recently started activity group in STATE.
+
+Unlike `agent-shell--activity-group-current-id', never advances the run
+counter, so callers can tell whether the group they are rendering into is
+the agent's current run or an earlier one taking a late update.
+
+  (agent-shell--activity-group-latest-id \\='((:activity-group-count . 2)))
+  ;; => \"activity-2\""
   (format "activity-%s" (map-elt state :activity-group-count)))
 
 (defun agent-shell--activity-group-id (state tool-call-id)
@@ -2602,6 +2650,39 @@ No-op while that function has nothing to summarize (an empty group)."
      :label-left label
      :above-last-prompt (not (agent-shell--active-requests-p state)))))
 
+(cl-defun agent-shell--sync-activity-group-fold (&key state group-id namespace-id)
+  "Leave GROUP-ID the only expanded activity group in STATE.
+
+No-op unless `agent-shell-activity-group-expand-by-default' is
+`when-active', where the group the agent is working in stays expanded and
+earlier ones fold away.  GROUP-ID is ignored unless it is STATE's latest
+run, so a late update to an earlier group neither re-expands that group
+nor collapses the one the agent is currently in.
+
+NAMESPACE-ID is the fragment namespace GROUP-ID's header was rendered
+under (nil for STATE's request count), recorded alongside the group so it
+can still be found once the turn ends."
+  (when-let* (((eq (agent-shell--activity-group-expand-policy) 'when-active))
+              ((equal group-id (agent-shell--activity-group-latest-id state)))
+              ((not (equal group-id (map-nested-elt state '(:expanded-activity-group :group-id))))))
+    (agent-shell--collapse-expanded-activity-group state)
+    (map-put! state :expanded-activity-group
+              (list (cons :namespace-id (or namespace-id (map-elt state :request-count)))
+                    (cons :group-id group-id)))))
+
+(defun agent-shell--collapse-expanded-activity-group (state)
+  "Collapse the activity group STATE last left expanded, if any.
+
+Called both when the agent moves on to a new group and when the turn ends,
+so a `when-active' session is left with every activity group folded.
+Clears STATE's `:expanded-activity-group'."
+  (when-let* ((group (map-elt state :expanded-activity-group)))
+    (agent-shell--collapse-fragment-group
+     :state state
+     :namespace-id (map-elt group :namespace-id)
+     :block-id (map-elt group :group-id))
+    (map-put! state :expanded-activity-group nil)))
+
 (cl-defun agent-shell--on-notification (&key state acp-notification)
   "Handle incoming ACP-NOTIFICATION using STATE."
   (map-put! state :last-activity-time (current-time))
@@ -2627,6 +2708,11 @@ No-op while that function has nothing to summarize (an empty group)."
           ((map-elt state :pending-restore)
            (agent-shell--append-restore-notification state acp-notification))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "agent_message_chunk")
+           ;; The agent has stopped acting and started answering, which
+           ;; breaks the activity run.  Fold the group `when-active' left
+           ;; expanded now, rather than leaving it open behind a response
+           ;; that may stream for a while before the next group starts.
+           (agent-shell--collapse-expanded-activity-group state)
            ;; Decide message boundaries by ACP's `messageId' when present:
            ;; distinct messages must never coalesce, even if an interleaved
            ;; entry (e.g. a tool call) failed to advance `:last-entry-type'
@@ -2713,10 +2799,11 @@ No-op while that function has nothing to summarize (an empty group)."
               :label-right (map-elt tool-call-labels :title)
               :group-id group-id
               :group-label agent-shell--activity-group-label
-              :group-expanded agent-shell-activity-group-expand-by-default
+              :group-expanded (agent-shell--activity-group-initial-expanded-p)
               :expanded agent-shell-tool-use-expand-by-default
               :above-last-prompt (not (agent-shell--active-requests-p state)))
              (agent-shell--refresh-activity-group-header state group-id)
+             (agent-shell--sync-activity-group-fold :state state :group-id group-id)
              ;; Display plan as markdown block if present
              (when (map-nested-elt acp-notification '(params update rawInput plan))
                (agent-shell--update-fragment
@@ -2769,7 +2856,7 @@ No-op while that function has nothing to summarize (an empty group)."
               :expanded agent-shell-thought-process-expand-by-default
               :group-id group-id
               :group-label agent-shell--activity-group-label
-              :group-expanded agent-shell-activity-group-expand-by-default
+              :group-expanded (agent-shell--activity-group-initial-expanded-p)
               :render-body-images t
               :above-last-prompt (not (agent-shell--active-requests-p state)))
              ;; Count this thought and relabel the header so a thought-only
@@ -2782,7 +2869,10 @@ No-op while that function has nothing to summarize (an empty group)."
              ;; chunk repeats an identical update and its buffer scan.
              (when new-thought-p
                (agent-shell--count-group-thought state group-id)
-               (agent-shell--refresh-activity-group-header state group-id)))
+               (agent-shell--refresh-activity-group-header state group-id)
+               (agent-shell--sync-activity-group-fold
+                :state state :group-id group-id
+                :namespace-id (unless (agent-shell--active-requests-p state) "out-of-turn")))
            (map-put! state :last-entry-type "agent_thought_chunk"))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "user_message_chunk")
            ;; A user_message_chunk replays a user submission.  Render it
@@ -2979,7 +3069,7 @@ No-op while that function has nothing to summarize (an empty group)."
                 :label-right (map-elt tool-call-labels :title)
                 :group-id group-id
                 :group-label agent-shell--activity-group-label
-                :group-expanded agent-shell-activity-group-expand-by-default
+                :group-expanded (agent-shell--activity-group-initial-expanded-p)
                 :body (cond
                        (command-block
                         (concat command-block "\n\n" (string-trim body-text)))
@@ -2989,7 +3079,8 @@ No-op while that function has nothing to summarize (an empty group)."
                         (string-trim body-text)))
                 :expanded agent-shell-tool-use-expand-by-default
                 :above-last-prompt (not (agent-shell--active-requests-p state)))
-               (agent-shell--refresh-activity-group-header state group-id))
+               (agent-shell--refresh-activity-group-header state group-id)
+               (agent-shell--sync-activity-group-fold :state state :group-id group-id))
              ;; Only advance the run boundary when this update introduced a new
              ;; tool call (appended at the end).  An in-place update of an
              ;; earlier tool must not erase an intervening entry's boundary.
@@ -4452,6 +4543,29 @@ variable (see makunbound)"))
                         (map-elt state :buffer)))
       (error "Editing the wrong buffer: %s" (current-buffer)))
     (agent-shell-ui-delete-fragment :namespace-id (map-elt state :request-count) :block-id block-id :no-undo t)))
+
+(cl-defun agent-shell--collapse-fragment-group (&key state namespace-id block-id)
+  "Collapse group header BLOCK-ID under NAMESPACE-ID in STATE's buffers.
+
+Mirrors `agent-shell--delete-fragment', applying to both the shell buffer
+and, when it is displaying the conversation, its viewport buffer.  Does
+nothing when BLOCK-ID names no rendered group header."
+  (when-let* (((map-elt state :buffer))
+              (viewport-buffer (agent-shell-viewport--buffer
+                                :shell-buffer (map-elt state :buffer)
+                                :existing-only t))
+              ;; Folding only makes sense when viewport is displaying
+              ;; conversation, never while it's an active compose buffer.
+              ((with-current-buffer viewport-buffer
+                 (derived-mode-p 'agent-shell-viewport-view-mode))))
+    (with-current-buffer viewport-buffer
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id namespace-id :block-id block-id :collapsed t :no-undo t)))
+  (when-let* ((shell-buffer (map-elt state :buffer))
+              ((buffer-live-p shell-buffer)))
+    (with-current-buffer shell-buffer
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id namespace-id :block-id block-id :collapsed t :no-undo t))))
 
 (defun agent-shell--live-input-prompt-p (prompt)
   "Non-nil when PROMPT is a live input prompt at the end of the buffer.
@@ -6724,6 +6838,10 @@ pending-restore state once replay completes."
                                       'rear-nonsticky '(field read-only))))
                 (map-put! state :last-entry-type nil))))
         (map-put! state :active-requests saved-active-requests))
+      ;; Replay renders history as a live turn would, so the last replayed
+      ;; group is left expanded under `when-active'.  Nothing is actually
+      ;; running, so fold it like a completed turn.
+      (agent-shell--collapse-expanded-activity-group state)
       ;; Point followed the narrowed history insertions up above the live
       ;; prompt.  Return it to the input area so the cursor lands where the
       ;; user types (matching pre-early-prompt restore behavior).
@@ -7474,6 +7592,9 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                    ;; a session prompt request is finished.
                    ;; Avoid accumulating them unnecessarily.
                    (map-put! (agent-shell--state) :tool-calls nil)
+                   ;; The turn is over, so nothing is active any more: fold
+                   ;; the last activity group `when-active' left expanded.
+                   (agent-shell--collapse-expanded-activity-group (agent-shell--state))
                    ;; Extract usage information from response
                    (when (map-elt acp-response 'usage)
                      (agent-shell--save-usage :state (agent-shell--state) :acp-usage (map-elt acp-response 'usage)))
@@ -7525,6 +7646,8 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                    (agent-shell--separate-transcript-after-agent-message
                     :last-entry-type (map-elt agent-shell--state :last-entry-type)
                     :file-path agent-shell--transcript-file)
+                   ;; An interrupted turn leaves no group active either.
+                   (agent-shell--collapse-expanded-activity-group agent-shell--state)
                    ;; Display pending requests on failure.
                    (agent-shell--prompt-queue-display)
                    (funcall (agent-shell--make-error-handler :state agent-shell--state :shell-buffer shell-buffer)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -139,53 +139,32 @@ When non-nil, tool use sections are expanded."
   :type 'boolean
   :group 'agent-shell)
 
-(defcustom agent-shell-activity-group-expand-by-default 'never
-  "When activity group headers should be expanded.
+(defcustom agent-shell-activity-group-expand-by-default nil
+  "When activity group sections should be expanded.
 
 An activity group is a run of consecutive agent actions (tool calls,
 and eventually thoughts) rendered under one collapsible header.
 
-  `never'       Groups start collapsed, showing only the header with its
-                aggregated status and completed/total count.
-  `always'      Groups show their members.
-  `when-active' The group the agent is currently working in shows its
-                members, and collapses once the agent moves on to a new
-                group or the turn ends.  Keeps the session tidy while
-                still making the agent's current activity followable.
+  nil      Groups start collapsed, showing only the header with its
+           aggregated status and completed/total count.
+  t        Groups show their members.
+  `latest' The group the agent is currently working in shows its
+           members, and collapses once the agent moves on to a new
+           group or the turn ends.  Keeps the session tidy while
+           still making the agent's current activity followable.
 
-The legacy boolean values remain supported: nil reads as `never' and t
-as `always'.  Individual members still follow
-`agent-shell-tool-use-expand-by-default'."
-  :type '(choice (const :tag "Never" never)
-                 (const :tag "Always" always)
-                 (const :tag "While the agent is working in it" when-active))
+Individual members still follow `agent-shell-tool-use-expand-by-default'."
+  :type '(choice (const :tag "Never (collapsed)" nil)
+                 (const :tag "Always (expanded)" t)
+                 (const :tag "While the agent is working in it" latest))
   :group 'agent-shell)
-
-(defun agent-shell--activity-group-expand-policy ()
-  "Return `agent-shell-activity-group-expand-by-default' as a policy symbol.
-
-One of `never', `always', or `when-active'.  Maps the legacy boolean
-values onto the symbols: nil reads as `never' and any other unrecognized
-value as `always' (matching the pre-symbol \"non-nil means expanded\"
-behavior).
-
-  ;; `agent-shell-activity-group-expand-by-default' = t
-  (agent-shell--activity-group-expand-policy)
-  ;; => always"
-  (pcase agent-shell-activity-group-expand-by-default
-    ('never 'never)
-    ('always 'always)
-    ('when-active 'when-active)
-    ('nil 'never)
-    (_ 'always)))
 
 (defun agent-shell--activity-group-initial-expanded-p ()
   "Return non-nil when a newly created activity group starts expanded.
 
-Both `always' and `when-active' start expanded; `when-active' collapses
-the group again once the agent moves on (see
-`agent-shell--sync-activity-group-fold')."
-  (and (memq (agent-shell--activity-group-expand-policy) '(always when-active)) t))
+Both t and `latest' start expanded; `latest' collapses the group again
+once the agent moves on (see `agent-shell--sync-activity-group-fold')."
+  (and agent-shell-activity-group-expand-by-default t))
 
 (defvar agent-shell-mode-hook nil
   "Hook run after an `agent-shell-mode' buffer is fully initialized.
@@ -2654,7 +2633,7 @@ No-op while that function has nothing to summarize (an empty group)."
   "Leave GROUP-ID the only expanded activity group in STATE.
 
 No-op unless `agent-shell-activity-group-expand-by-default' is
-`when-active', where the group the agent is working in stays expanded and
+`latest', where the group the agent is working in stays expanded and
 earlier ones fold away.  GROUP-ID is ignored unless it is STATE's latest
 run, so a late update to an earlier group neither re-expands that group
 nor collapses the one the agent is currently in.
@@ -2662,7 +2641,7 @@ nor collapses the one the agent is currently in.
 NAMESPACE-ID is the fragment namespace GROUP-ID's header was rendered
 under (nil for STATE's request count), recorded alongside the group so it
 can still be found once the turn ends."
-  (when-let* (((eq (agent-shell--activity-group-expand-policy) 'when-active))
+  (when-let* (((eq agent-shell-activity-group-expand-by-default 'latest))
               ((equal group-id (agent-shell--activity-group-latest-id state)))
               ((not (equal group-id (map-nested-elt state '(:expanded-activity-group :group-id))))))
     (agent-shell--collapse-expanded-activity-group state)
@@ -2674,7 +2653,7 @@ can still be found once the turn ends."
   "Collapse the activity group STATE last left expanded, if any.
 
 Called both when the agent moves on to a new group and when the turn ends,
-so a `when-active' session is left with every activity group folded.
+so a `latest' session is left with every activity group folded.
 Clears STATE's `:expanded-activity-group'."
   (when-let* ((group (map-elt state :expanded-activity-group)))
     (agent-shell--collapse-fragment-group
@@ -2709,7 +2688,7 @@ Clears STATE's `:expanded-activity-group'."
            (agent-shell--append-restore-notification state acp-notification))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "agent_message_chunk")
            ;; The agent has stopped acting and started answering, which
-           ;; breaks the activity run.  Fold the group `when-active' left
+           ;; breaks the activity run.  Fold the group `latest' left
            ;; expanded now, rather than leaving it open behind a response
            ;; that may stream for a while before the next group starts.
            (agent-shell--collapse-expanded-activity-group state)
@@ -2872,7 +2851,7 @@ Clears STATE's `:expanded-activity-group'."
                (agent-shell--refresh-activity-group-header state group-id)
                (agent-shell--sync-activity-group-fold
                 :state state :group-id group-id
-                :namespace-id (unless (agent-shell--active-requests-p state) "out-of-turn")))
+                :namespace-id (unless (agent-shell--active-requests-p state) "out-of-turn"))))
            (map-put! state :last-entry-type "agent_thought_chunk"))
           ((equal (map-nested-elt acp-notification '(params update sessionUpdate)) "user_message_chunk")
            ;; A user_message_chunk replays a user submission.  Render it
@@ -6839,7 +6818,7 @@ pending-restore state once replay completes."
                 (map-put! state :last-entry-type nil))))
         (map-put! state :active-requests saved-active-requests))
       ;; Replay renders history as a live turn would, so the last replayed
-      ;; group is left expanded under `when-active'.  Nothing is actually
+      ;; group is left expanded under `latest'.  Nothing is actually
       ;; running, so fold it like a completed turn.
       (agent-shell--collapse-expanded-activity-group state)
       ;; Point followed the narrowed history insertions up above the live
@@ -7593,7 +7572,7 @@ Each marked span is replaced by its `agent-shell-region-text' value."
                    ;; Avoid accumulating them unnecessarily.
                    (map-put! (agent-shell--state) :tool-calls nil)
                    ;; The turn is over, so nothing is active any more: fold
-                   ;; the last activity group `when-active' left expanded.
+                   ;; the last activity group `latest' left expanded.
                    (agent-shell--collapse-expanded-activity-group (agent-shell--state))
                    ;; Extract usage information from response
                    (when (map-elt acp-response 'usage)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -4561,6 +4561,128 @@ agent activity), while an `agent_message_chunk' starts a fresh group."
     (map-put! state :last-entry-type "agent_message_chunk")
     (should (equal "activity-2" (agent-shell--activity-group-current-id state)))))
 
+(ert-deftest agent-shell--activity-group-expand-policy-test ()
+  "The expand policy resolves symbols and the legacy booleans."
+  (dolist (case '((never . never)
+                  (always . always)
+                  (when-active . when-active)
+                  ;; Legacy booleans: nil collapsed, non-nil expanded.
+                  (nil . never)
+                  (t . always)))
+    (let ((agent-shell-activity-group-expand-by-default (car case)))
+      (should (eq (cdr case) (agent-shell--activity-group-expand-policy)))
+      ;; `when-active' groups are born expanded and folded once done.
+      (should (eq (not (eq (cdr case) 'never))
+                  (agent-shell--activity-group-initial-expanded-p))))))
+
+(ert-deftest agent-shell--sync-activity-group-fold-test ()
+  "`when-active' keeps only the agent's current activity group expanded."
+  (let ((collapsed '())
+        (state (list (cons :activity-group-count 1)
+                     (cons :request-count 3)
+                     (cons :expanded-activity-group nil))))
+    (cl-letf (((symbol-function 'agent-shell--collapse-fragment-group)
+               (lambda (&rest args)
+                 (push (cons (plist-get args :namespace-id)
+                             (plist-get args :block-id))
+                       collapsed))))
+      ;; Other policies never fold anything.
+      (dolist (policy '(never always))
+        (let ((agent-shell-activity-group-expand-by-default policy))
+          (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
+          (should-not collapsed)
+          (should-not (map-elt state :expanded-activity-group))))
+      (let ((agent-shell-activity-group-expand-by-default 'when-active))
+        ;; The current run is recorded, with nothing to fold yet.
+        (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
+        (should-not collapsed)
+        (should (equal '((:namespace-id . 3) (:group-id . "activity-1"))
+                       (map-elt state :expanded-activity-group)))
+        ;; Further members of the same run leave it expanded.
+        (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
+        (should-not collapsed)
+        ;; The agent moves on: the previous run folds away.
+        (map-put! state :activity-group-count 2)
+        (agent-shell--sync-activity-group-fold :state state :group-id "activity-2")
+        (should (equal '((3 . "activity-1")) collapsed))
+        (should (equal "activity-2"
+                       (map-nested-elt state '(:expanded-activity-group :group-id))))
+        ;; A late update to the earlier run neither re-expands it nor folds
+        ;; the run the agent is currently in.
+        (setq collapsed '())
+        (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
+        (should-not collapsed)
+        (should (equal "activity-2"
+                       (map-nested-elt state '(:expanded-activity-group :group-id))))
+        ;; Turn end folds the last expanded run and forgets it.
+        (agent-shell--collapse-expanded-activity-group state)
+        (should (equal '((3 . "activity-2")) collapsed))
+        (should-not (map-elt state :expanded-activity-group))
+        (setq collapsed '())
+        (agent-shell--collapse-expanded-activity-group state)
+        (should-not collapsed)))))
+
+(ert-deftest agent-shell--activity-grouping-when-active-folds-previous-group-test ()
+  "Driving notifications under `when-active' folds each group as it is left.
+Groups are created expanded, and a group folds as soon as the agent starts
+answering rather than waiting for the next run to begin, so only the run
+in flight shows its members."
+  (let ((collapsed '())
+        (expanded '())
+        (agent-shell-activity-group-expand-by-default 'when-active)
+        (state (list (cons :tool-calls nil)
+                     (cons :last-entry-type nil)
+                     (cons :last-agent-message-id nil)
+                     (cons :activity-group-count 0)
+                     (cons :chunked-group-count 0)
+                     (cons :request-count 1)
+                     (cons :expanded-activity-group nil)
+                     (cons :active-requests t)
+                     (cons :last-activity-time nil)
+                     (cons :buffer nil))))
+    (cl-letf (((symbol-function 'agent-shell--update-fragment)
+               (lambda (&rest args)
+                 (when-let* ((group-id (plist-get args :group-id)))
+                   (push (cons group-id (plist-get args :group-expanded)) expanded))))
+              ((symbol-function 'agent-shell--collapse-fragment-group)
+               (lambda (&rest args)
+                 (push (plist-get args :block-id) collapsed)))
+              ((symbol-function 'agent-shell--refresh-activity-group-header) #'ignore)
+              ((symbol-function 'agent-shell--append-transcript) #'ignore)
+              ((symbol-function 'agent-shell--make-transcript-tool-call-entry)
+               (lambda (&rest _) ""))
+              ((symbol-function 'agent-shell--delete-fragment) #'ignore)
+              ((symbol-function 'agent-shell--cancel-idle-timer) #'ignore)
+              ((symbol-function 'agent-shell--emit-event) #'ignore)
+              ((symbol-function 'agent-shell-make-tool-call-label)
+               (lambda (&rest _) '((:status . "s") (:title . "t")))))
+      (cl-flet ((notify (update)
+                  (agent-shell--on-notification
+                   :state state
+                   :acp-notification `((method . "session/update")
+                                       (params (update . ,update))))))
+        (notify '((sessionUpdate . "tool_call") (toolCallId . "A")
+                  (title . "A") (kind . "other") (status . "pending")))
+        (should-not collapsed)
+        ;; The agent starts answering: group 1 folds right away, without
+        ;; waiting for the next group to open.
+        (notify '((sessionUpdate . "agent_message_chunk")
+                  (content (type . "text") (text . "msg"))))
+        (should (equal '("activity-1") collapsed))
+        ;; Further chunks of the same response have nothing left to fold.
+        (notify '((sessionUpdate . "agent_message_chunk")
+                  (content (type . "text") (text . " more"))))
+        (should (equal '("activity-1") collapsed))
+        ;; B lands in a fresh group, expanded, leaving group 1 folded.
+        (notify '((sessionUpdate . "tool_call") (toolCallId . "B")
+                  (title . "B") (kind . "other") (status . "pending")))
+        (should (equal '("activity-1") collapsed)))
+      ;; Both groups were created expanded.
+      (should (equal '(("activity-1" . t) ("activity-2" . t)) (nreverse expanded)))
+      ;; Turn end folds the group still in flight.
+      (agent-shell--collapse-expanded-activity-group state)
+      (should (equal '("activity-2" "activity-1") collapsed)))))
+
 (ert-deftest agent-shell--activity-grouping-late-update-starts-new-group-test ()
   "A message between a tool call and the next starts a fresh group.
 Regression for xenodium/agent-shell-js#31: a late in-place completion

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -4561,22 +4561,18 @@ agent activity), while an `agent_message_chunk' starts a fresh group."
     (map-put! state :last-entry-type "agent_message_chunk")
     (should (equal "activity-2" (agent-shell--activity-group-current-id state)))))
 
-(ert-deftest agent-shell--activity-group-expand-policy-test ()
-  "The expand policy resolves symbols and the legacy booleans."
-  (dolist (case '((never . never)
-                  (always . always)
-                  (when-active . when-active)
-                  ;; Legacy booleans: nil collapsed, non-nil expanded.
-                  (nil . never)
-                  (t . always)))
+(ert-deftest agent-shell--activity-group-initial-expanded-test ()
+  "The group expanded initial predicate."
+  (dolist (case '((nil . nil)
+                  (t . t)
+                  ;; `latest' groups are born expanded and folded once done.
+                  (latest . t)))
     (let ((agent-shell-activity-group-expand-by-default (car case)))
-      (should (eq (cdr case) (agent-shell--activity-group-expand-policy)))
-      ;; `when-active' groups are born expanded and folded once done.
-      (should (eq (not (eq (cdr case) 'never))
+      (should (eq (cdr case)
                   (agent-shell--activity-group-initial-expanded-p))))))
 
 (ert-deftest agent-shell--sync-activity-group-fold-test ()
-  "`when-active' keeps only the agent's current activity group expanded."
+  "`latest' keeps only the agent's current activity group expanded."
   (let ((collapsed '())
         (state (list (cons :activity-group-count 1)
                      (cons :request-count 3)
@@ -4592,7 +4588,7 @@ agent activity), while an `agent_message_chunk' starts a fresh group."
           (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
           (should-not collapsed)
           (should-not (map-elt state :expanded-activity-group))))
-      (let ((agent-shell-activity-group-expand-by-default 'when-active))
+      (let ((agent-shell-activity-group-expand-by-default 'latest))
         ;; The current run is recorded, with nothing to fold yet.
         (agent-shell--sync-activity-group-fold :state state :group-id "activity-1")
         (should-not collapsed)
@@ -4622,14 +4618,14 @@ agent activity), while an `agent_message_chunk' starts a fresh group."
         (agent-shell--collapse-expanded-activity-group state)
         (should-not collapsed)))))
 
-(ert-deftest agent-shell--activity-grouping-when-active-folds-previous-group-test ()
-  "Driving notifications under `when-active' folds each group as it is left.
+(ert-deftest agent-shell--activity-grouping-latest-folds-previous-group-test ()
+  "Driving notifications under `latest' folds each group as it is left.
 Groups are created expanded, and a group folds as soon as the agent starts
 answering rather than waiting for the next run to begin, so only the run
 in flight shows its members."
   (let ((collapsed '())
         (expanded '())
-        (agent-shell-activity-group-expand-by-default 'when-active)
+        (agent-shell-activity-group-expand-by-default 'latest)
         (state (list (cons :tool-calls nil)
                      (cons :last-entry-type nil)
                      (cons :last-agent-message-id nil)

--- a/tests/agent-shell-ui-tests.el
+++ b/tests/agent-shell-ui-tests.el
@@ -438,6 +438,44 @@ caller stamping ranges leaves it unmarked, stranding navigation there)."
       (should (get-text-property (body-start 0) 'invisible))
       (should-not (get-text-property (body-start 1) 'invisible)))))
 
+(ert-deftest agent-shell-ui-set-group-collapsed-by-id-test ()
+  "Setting a group's fold state by id is idempotent and leaves leaves alone."
+  (with-temp-buffer
+    (agent-shell-ui-mode 1)
+    (agent-shell-ui-update-fragment
+     (agent-shell-ui-make-fragment-model
+      :namespace-id "ns" :block-id "m1" :group-id "grp" :group-label "T"
+      :label-left "run" :label-right "a" :body "aa")
+     :navigation 'always)
+    ;; A leaf fragment, to guard that only group headers are targeted.
+    (agent-shell-ui-update-fragment
+     (agent-shell-ui-make-fragment-model
+      :namespace-id "ns" :block-id "leaf" :label-left "msg" :body "bb")
+     :expanded t :navigation 'always)
+    (cl-flet ((member-hidden-p ()
+                (get-text-property
+                 (map-elt (car (agent-shell-ui--group-children
+                                :group-qualified-id "ns-grp"))
+                          :start)
+                 'invisible)))
+      (should-not (member-hidden-p))
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id "ns" :block-id "grp" :collapsed t)
+      (should (member-hidden-p))
+      ;; Repeat calls are a no-op rather than a toggle.
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id "ns" :block-id "grp" :collapsed t)
+      (should (member-hidden-p))
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id "ns" :block-id "grp" :collapsed nil)
+      (should-not (member-hidden-p))
+      ;; Unknown ids and non-group fragments are left untouched.
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id "ns" :block-id "missing" :collapsed t)
+      (agent-shell-ui-set-group-collapsed-by-id
+       :namespace-id "ns" :block-id "leaf" :collapsed t)
+      (should-not (member-hidden-p)))))
+
 (ert-deftest agent-shell-ui-group-member-streams-body-stays-nested-test ()
   "A labels-only member that later gains a body stays nested and indented."
   (with-temp-buffer


### PR DESCRIPTION
I've been using `agent-shell-activity-group-expand-by-default t` for the new activity groups so that I can see progress while the agent is working.

Then I realised that I only care about activity in the currently active group. The others can close, keeping the session clean.

So this PR makes `agent-shell-activity-group-expand-by-default` a choice with the following options:

- `never`: backwards compatible with `nil`
- `always`: backwards compatible with `t`
- `when-active`: The group the agent is currently working in shows its members, and collapses once the agent moves on to a new group or the turn ends

I've been testing `when-active` in various sessions and it seems to work well - keeping me informed of the agent's current progress, but keeping the overall session clean.

<img width="802" height="705" alt="Screenshot 2026-07-30 at 16 35 12" src="https://github.com/user-attachments/assets/c867cb47-58e1-4b55-9930-8b8138bdb78d" />


## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
