### PR TITLE
Fix executable-find on remote host

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -4213,7 +4213,7 @@ variable (see makunbound)"))
         (kill-buffer shell-buffer)
         (error "No way to create a new client"))
       (let ((command (map-elt (funcall (map-elt config :client-maker) (current-buffer)) :command)))
-        (unless (executable-find command)
+        (unless (executable-find command t)
           (kill-buffer shell-buffer)
           (error "%s" (agent-shell--make-missing-executable-error
                        :executable command


### PR DESCRIPTION
This change will not impact the behavior of local agent-shell at all, but it will fix a lingering issue where agent-shell tramp will not work if you don't have the same executable on both the remote host and the local host. Enabling the remote flag means it will find the executable on the host you are currently working on instead of only the local host.

See junyi-hou/agent-shell-tramp#5

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
