### PR TITLE
Preserve "claimed" regions when rendering bold / italic / strikethrough

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -514,6 +514,42 @@ this returns `(((:watermark . 1200)))'."
                         nil))
     (nreverse results)))
 
+(defun agent-shell-markdown--emphasize-span (markup-start markup-end
+                                                          inner-start inner-end
+                                                          face)
+  "Strip emphasis delimiters around INNER-START..INNER-END and face the text.
+
+MARKUP-START..MARKUP-END spans the whole construct including its
+delimiters (e.g. `**X**'); INNER-START..INNER-END is the inner text
+\(`X').  Only the leading and trailing delimiters are deleted -- the
+inner text is left in place rather than deleted and re-inserted -- so
+any overlays, markers, or `agent-shell-markdown-frozen' regions an
+earlier pass or an external `agent-shell-markdown-render-functions'
+renderer placed inside survive.  (Deleting and re-inserting collapsed
+external markers to a zero-length span and dropped overlays, so a
+renderer that anchors an async result inside, say, a bold span -- e.g.
+math inside `**...**' -- lost it.)
+
+FACE is layered onto the remaining text with `add-face-text-property'
+\(so it composes with faces from earlier passes), and the original
+markdown is stashed on `agent-shell-markdown-source' (for
+`agent-shell-copy-as-markdown') unless the text already carries one.
+Point is left at the end of the faced text."
+  (let ((source (unless (get-text-property markup-start
+                                           'agent-shell-markdown-source)
+                  (agent-shell-markdown-reconstruct markup-start markup-end))))
+    ;; Delete the trailing delimiter first so INNER-START/INNER-END stay
+    ;; valid, then the leading one.  Removing only the delimiters keeps the
+    ;; inner text's characters (and anything anchored to them) intact.
+    (delete-region inner-end markup-end)
+    (delete-region markup-start inner-start)
+    (let ((end (+ markup-start (- inner-end inner-start))))
+      (add-face-text-property markup-start end face)
+      (when source
+        (put-text-property markup-start end
+                           'agent-shell-markdown-source source))
+      (goto-char end))))
+
 (cl-defun agent-shell-markdown--replace-bolds (&key avoid-ranges)
   "Replace `**X**' / `__X__' spans in current buffer with bold X.
 
@@ -540,22 +576,12 @@ world.\" with face `agent-shell-markdown-bold' on \"world\"."
                      markup-start markup-end avoid-ranges)))
         (if avoid
             (goto-char (cdr avoid))
-          (let ((text (buffer-substring
-                       (or (match-beginning 2) (match-beginning 3))
-                       (or (match-end 2) (match-end 3))))
-                (source (unless (get-text-property markup-start
-                                                   'agent-shell-markdown-source)
-                          (agent-shell-markdown-reconstruct
-                           markup-start markup-end))))
-            (delete-region markup-start markup-end)
-            (goto-char markup-start)
-            (insert text)
-            (let ((end (+ markup-start (length text))))
-              (add-face-text-property markup-start end 'agent-shell-markdown-bold)
-              (when source
-                (put-text-property markup-start end
-                                   'agent-shell-markdown-source source)))
-            (setq changed t)))))
+          (agent-shell-markdown--emphasize-span
+           markup-start markup-end
+           (or (match-beginning 2) (match-beginning 3))
+           (or (match-end 2) (match-end 3))
+           'agent-shell-markdown-bold)
+          (setq changed t))))
     changed))
 
 (cl-defun agent-shell-markdown--replace-italics (&key avoid-ranges)
@@ -588,22 +614,12 @@ world.\" with face `agent-shell-markdown-italic' on \"world\"."
                      markup-start markup-end avoid-ranges)))
         (if avoid
             (goto-char (cdr avoid))
-          (let ((text (buffer-substring
-                       (or (match-beginning 2) (match-beginning 4))
-                       (or (match-end 2) (match-end 4))))
-                (source (unless (get-text-property markup-start
-                                                   'agent-shell-markdown-source)
-                          (agent-shell-markdown-reconstruct
-                           markup-start markup-end))))
-            (delete-region markup-start markup-end)
-            (goto-char markup-start)
-            (insert text)
-            (let ((end (+ markup-start (length text))))
-              (add-face-text-property markup-start end 'agent-shell-markdown-italic)
-              (when source
-                (put-text-property markup-start end
-                                   'agent-shell-markdown-source source)))
-            (setq changed t)))))
+          (agent-shell-markdown--emphasize-span
+           markup-start markup-end
+           (or (match-beginning 2) (match-beginning 4))
+           (or (match-end 2) (match-end 4))
+           'agent-shell-markdown-italic)
+          (setq changed t))))
     changed))
 
 (cl-defun agent-shell-markdown--replace-strikethroughs (&key avoid-ranges)
@@ -628,21 +644,11 @@ For example, the buffer \"a ~~b~~ c\" becomes \"a b c\" with face
                      markup-start markup-end avoid-ranges)))
         (if avoid
             (goto-char (cdr avoid))
-          (let ((text (buffer-substring (match-beginning 1) (match-end 1)))
-                (source (unless (get-text-property markup-start
-                                                   'agent-shell-markdown-source)
-                          (agent-shell-markdown-reconstruct
-                           markup-start markup-end))))
-            (delete-region markup-start markup-end)
-            (goto-char markup-start)
-            (insert text)
-            (let ((end (+ markup-start (length text))))
-              (add-face-text-property markup-start end
-                                      'agent-shell-markdown-strikethrough)
-              (when source
-                (put-text-property markup-start end
-                                   'agent-shell-markdown-source source)))
-            (setq changed t)))))
+          (agent-shell-markdown--emphasize-span
+           markup-start markup-end
+           (match-beginning 1) (match-end 1)
+           'agent-shell-markdown-strikethrough)
+          (setq changed t))))
     changed))
 
 (cl-defun agent-shell-markdown--replace-headers (&key avoid-ranges)

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -28,6 +28,47 @@
                  '(("hello " nil)
                    ("world" (agent-shell-markdown-bold))))))
 
+(ert-deftest agent-shell-markdown-emphasis-preserves-frozen-region ()
+  ;; An emphasis pass that WRAPS an already-frozen region (e.g. one an
+  ;; external `agent-shell-markdown-render-functions' renderer claimed and
+  ;; anchored an async result inside) must strip only the delimiters and
+  ;; leave the inner text in place: deleting and re-inserting the whole
+  ;; span used to collapse markers pointing into it and drop overlays.
+  ;; Assert markers straddling the frozen text stay valid (still spanning
+  ;; it), an overlay on it survives, and the frozen property is intact.
+  (with-temp-buffer
+    (insert "a **b FROZEN c**\n")
+    (goto-char (point-min))
+    (search-forward "FROZEN")
+    (let* ((inner-start (match-beginning 0))
+           (inner-end (match-end 0))
+           (m-start (copy-marker inner-start))
+           (m-end (copy-marker inner-end))
+           (ov (make-overlay inner-start inner-end)))
+      (overlay-put ov 'display "IMG")
+      (put-text-property inner-start inner-end 'agent-shell-markdown-frozen t)
+      (agent-shell-markdown--replace-bolds :avoid-ranges nil)
+      ;; Delimiters gone, inner text kept.
+      (should (equal (buffer-substring-no-properties (point-min) (point-max))
+                     "a b FROZEN c\n"))
+      ;; Markers still bracket the same text (not collapsed).
+      (should (< (marker-position m-start) (marker-position m-end)))
+      (should (equal (buffer-substring-no-properties
+                      (marker-position m-start) (marker-position m-end))
+                     "FROZEN"))
+      ;; Overlay survived over the same text.
+      (should (overlay-buffer ov))
+      (should (equal (buffer-substring-no-properties
+                      (overlay-start ov) (overlay-end ov))
+                     "FROZEN"))
+      ;; Frozen property intact, bold applied to the surrounding text.
+      (should (get-text-property (marker-position m-start)
+                                 'agent-shell-markdown-frozen))
+      (should (memq 'agent-shell-markdown-bold
+                    (let ((f (get-text-property (marker-position m-start)
+                                                'face)))
+                      (if (listp f) f (list f))))))))
+
 (ert-deftest agent-shell-markdown-convert-italic ()
   (should (equal (agent-shell-markdown--deconstruct
                   (agent-shell-markdown-convert "hello *world*"))


### PR DESCRIPTION
## The PR in one paragraph

When an agent's message puts **bold** (or *italic*, or ~~strikethrough~~) around something a plugin like `agent-shell-math-renderer` has already rendered — for example a math formula inside `**...**` — that rendered content is currently lost; this PR fixes that, and along the way removes some duplicated code by refactoring it.

## The problem (in simple terms)

agent-shell lets other packages hook in and render their own content inside a message; an example is the LaTeX math renderer [agent-shell-math-renderer](https://github.com/alberti42/agent-shell-math-renderer) that turns `\(E=mc^2\)` into an actual typeset equation image.

To render this safely, such plugins "claim" the little stretch of text they are responsible for and mark it as off-limits, so agent-shell's own formatting steps leave it alone. In short, the contract is: *once a region is claimed, don't disturb it.*

There was a gap in that contract. agent-shell formats bold text by finding a `**...**` span, **deleting the whole thing, and retyping the inner text** without the `**` markers. That works fine for ordinary text. But if the bold happens to *wrap around* a region a plugin already claimed, the delete-and-retype throws that claimed content away:

- the plugin's "bookmark" pointing at the content is left pointing at nothing, and
- any image/overlay the plugin had placed there is dropped.

So a formula written as `**this matters: \(E=mc^2\)**` would simply fail to render — the surrounding text became bold, but the equation vanished. And because the region was still marked "already handled," agent-shell never tried again, so it stayed broken.

This is easy to trigger in practice: agents very often emphasize a sentence that contains an inline formula.

## Why it is worth fixing (beyond the refactor)

This isn't only about one math plugin. It's about **agent-shell keeping its promise** to any package that extends it. The whole point of the "claim a region and it won't be touched" mechanism is that plugins can rely on it. Today that promise quietly breaks in the common case where emphasis surrounds the claimed content.

Fixing it makes the extension mechanism something plugins can actually rely on.

## The fix

Bold, italic, and strikethrough all did the same delete-and-retype dance in three near-identical blocks of code. This PR:

1. **Pulls that shared logic into one small helper**, so the three passes no longer repeat themselves.
2. **Changes the approach** so it only removes the `**` (or `*` / `~~`) markers and **leaves the inner text exactly where it is**. Nothing inside the span is deleted, so anything a plugin anchored there survives untouched.

The visible result is unchanged for normal text — bold still looks bold — but a claimed region inside emphasis now keeps its bookmarks and its rendered image.

## How it was verified

- Reproduced the original failure (a formula inside `**...**` losing its anchor), then confirmed the fix keeps the anchor valid and the content in place.
- All existing markdown tests still pass.
- Added a focused regression test that wraps a claimed/frozen region in bold and checks that its bookmarks, its overlay, and its "off-limits" marker all survive.

## Risk

Low. The behavior for ordinary emphasized text is identical (same face, same copy-as-markdown output); the only difference is that the inner characters are kept rather than deleted and retyped. The change is confined to the three emphasis passes plus the new shared helper.
