### PR TITLE
Expose the fragment `:ui-section` to markdown render functions

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -263,6 +263,18 @@ CONTEXT keys:
                   delimiters that fall inside a verbatim span (e.g. a
                   literal `\\(x\\)' the agent meant as code, not math).
 
+  :ui-section  The `agent-shell-ui-section' text-property value at the
+                  start of the narrowed region, or nil.  Agent Shell
+                  renders each fragment section (`label-left', `body',
+                  `label-right', ...) in its own narrowed pass and tags
+                  the whole section with this property, so a renderer
+                  can skip UI chrome — e.g. a tool-command label in
+                  `label-right' whose `\\(...\\)' is shell grouping, not
+                  math.  nil when the narrowed region carries no section
+                  property (e.g. a static `agent-shell-markdown-convert'
+                  string), in which case a renderer should treat it as
+                  ordinary body content.
+
 Each function returns an alist (nil for no-op).  Recognised keys:
 
   :watermark  Buffer position the streaming frontier must not pass,
@@ -476,14 +488,17 @@ Builds the same CONTEXT alist that
 the buffer is narrowed to right now:
 
   ((:source-blocks . SOURCE-BLOCKS)
-   (:inline-code-ranges . INLINE-CODE-RANGES))
+   (:inline-code-ranges . INLINE-CODE-RANGES)
+   (:ui-section . UI-SECTION))
 
 SOURCE-BLOCKS are the fenced-block descriptors from
 `agent-shell-markdown--source-blocks'.  INLINE-CODE-RANGES are
 marker ranges covering inline `code' span bodies, computed with the
 fenced blocks as avoid-ranges so backticks inside a fenced block are
-not mistaken for an inline span.  See
-`agent-shell-markdown-render-functions' for the meaning of each key.
+not mistaken for an inline span.  UI-SECTION is the
+`agent-shell-ui-section' property value at the start of the narrowed
+region (or nil).  See `agent-shell-markdown-render-functions' for the
+meaning of each key.
 
 `agent-shell-markdown-replace-markup' builds its context through
 this function too, so code that renders a static (non-streamed)
@@ -496,7 +511,13 @@ path."
                          (agent-shell-markdown--inline-code-ranges
                           :avoid-ranges source-ranges))))
     (list (cons :source-blocks source-blocks)
-          (cons :inline-code-ranges inline-ranges))))
+          (cons :inline-code-ranges inline-ranges)
+          ;; The narrowed region is a single Agent Shell fragment section,
+          ;; tagged uniformly with `agent-shell-ui-section', so its value at
+          ;; `point-min' identifies the section (e.g. `label-right' for a
+          ;; tool-command label).  nil for a section-less region.
+          (cons :ui-section (get-text-property (point-min)
+                                               'agent-shell-ui-section)))))
 
 (defun agent-shell-markdown--run-render-functions (context)
   "Run `agent-shell-markdown-render-functions' with CONTEXT.

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -2351,6 +2351,43 @@ exercised by the editing in the -all-math-cases test.)"
                     (:body . "\\frac{a}{b}")
                     (:complete . t))))))
 
+(defun agent-shell-markdown-tests--ui-section (markdown &optional section)
+  "Return the `:ui-section' a renderer sees for MARKDOWN.
+When SECTION is non-nil, tag the whole inserted text with
+`agent-shell-ui-section' SECTION first, mimicking Agent Shell rendering
+a fragment section in its own narrowed pass."
+  (let (seen)
+    (with-temp-buffer
+      (let ((agent-shell-markdown-render-functions
+             (list (lambda (context)
+                     (setq seen (map-elt context :ui-section))
+                     nil))))
+        (insert markdown)
+        (when section
+          (put-text-property (point-min) (point-max)
+                             'agent-shell-ui-section section))
+        (agent-shell-markdown-replace-markup)))
+    seen))
+
+(ert-deftest agent-shell-markdown-render-functions-receives-ui-section ()
+  ;; Agent Shell tags each narrowed fragment section with
+  ;; `agent-shell-ui-section'; a renderer is handed that value as
+  ;; `:ui-section' so it can skip UI chrome (e.g. shell grouping in a
+  ;; `label-right' tool-command label) without touching body equations.
+  (should (eq (agent-shell-markdown-tests--ui-section
+               "find . \\( -name '*.nix' \\)" 'label-right)
+              'label-right))
+  (should (eq (agent-shell-markdown-tests--ui-section
+               "Result: \\(x^2\\)." 'body)
+              'body)))
+
+(ert-deftest agent-shell-markdown-render-functions-ui-section-nil-when-absent ()
+  ;; A section-less region (e.g. a static `agent-shell-markdown-convert'
+  ;; string) carries no property, so `:ui-section' is nil and a renderer
+  ;; treats it as ordinary body content.
+  (should (eq (agent-shell-markdown-tests--ui-section "plain \\(x\\) math")
+              nil)))
+
 (ert-deftest agent-shell-markdown-render-functions-source-blocks-incomplete ()
   ;; A still-streaming fence is reported with `:complete' nil and no
   ;; `:body', so a renderer knows the language but not to claim it yet.


### PR DESCRIPTION
## What this does

When agent-shell draws a message, it splits each entry into named sections — a left label, a body, and a right label — and renders each one as Markdown in its own pass. External packages can hook into that Markdown rendering through `agent-shell-markdown-render-functions` to claim and render regions of their own (for example, a LaTeX-math renderer that turns `\(x^2\)` into a real equation image).

Today those render functions are told *what* text they are looking at (fenced code blocks, inline-code spans) but **not which section they are in**. This PR adds one new piece of information to the context they receive: `:ui-section` — the name of the section currently being rendered (`label-left`, `body`, `label-right`, …), or `nil` when there is no section (e.g. a plain string passed to `agent-shell-markdown-convert`).

That's the whole change: one extra key in the context alist, plus docs and tests. It changes nothing about how agent-shell itself renders — it only hands a fact agent-shell already knows to the render functions that ask for it.

## Why it's needed (the concrete problem)

This came up in a real bug in the **agent-shell-math-renderer** add-on. The bug was reported in [agent-shell-math-renderer#5](https://github.com/alberti42/agent-shell-math-renderer/pull/5). In essence, a tool call's command is shown in the **right-hand label**.  A perfectly ordinary shell command such as

```sh
find . \( -name 'Makefile' -o -name '*.nix' \)
```

uses `\(` and `\)` as shell grouping. But `\(…\)` is *also* the standard delimiter for inline LaTeX math. So the math renderer, running over that label, mistakes the shell grouping for an equation and shipped the command off to LaTeX — producing a spurious compiler warning on every such command (and wasted work). The command was never math; it was just a label.

The renderer had no clean way to know "this is a UI command label, don't treat it as prose." The only signal available was to reach directly into an agent-shell **internal text property** (`agent-shell-ui-section`) that the render-function contract never promised — brittle, and exactly the kind of private-detail dependency an add-on should avoid. If that property is ever renamed or moved, the add-on silently breaks again.

Exposing `:ui-section` as a **documented** key closes that gap the same way `:inline-code-ranges` and `:source-blocks` already do: it lets a render function say "skip the right-hand command labels, but keep rendering equations in the message body" using nothing but the public contract.

## How it works

The context that render functions receive is built in one place, `agent-shell-markdown-context`, which already runs with the buffer narrowed to exactly the section being rendered. Since agent-shell tags each section uniformly with the `agent-shell-ui-section` property, reading that property at the start of the narrowed region tells us the section name. So, this name is added to the returned alist as `:ui-section`. Because every path (streaming *and* the static `agent-shell-markdown-convert`) builds its context through that same function, they all get the key with no chance of drifting apart.

A render function can then guard itself on the section, e.g. "only render in the message body (or a section-less region such as a static string), never in the status/command labels":

```elisp
(let ((section (map-elt context :ui-section)))
  (when (or (null section) (eq section 'body))
    ;; … render math …
    ))
```

This guard is all what is needed to fix the math renderer, while avoiding reading any internal (private) property. I verified it end-to-end against both a build **with** this change and one **without** it: with the key, the shell command above is correctly left alone while `\(x^2\)` in a message body still renders; without the key, the command is wrongly sent to LaTeX.

## Tests

Added to `tests/agent-shell-markdown-tests.el`:

- a render function receives `:ui-section` as `label-right` / `body` when the narrowed region is tagged with that section, and
- `:ui-section` is `nil` for a section-less region (e.g. a static `agent-shell-markdown-convert` string).