### PR TITLE
Preserve properties on escaped Markdown punctuation

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -579,8 +579,10 @@ on `agent-shell-markdown-source'.  The placeholder is not a markup
 character, so the styling passes treat an escaped delimiter (like the
 `*' in `**let\\***') as ordinary content rather than markup, and
 `agent-shell-markdown--decode-escapes' restores the bare char after
-they run.  Escapes inside AVOID-RANGES (fenced or inline code, where a
-backslash is literal) are left untouched.  Returns non-nil on a change.
+they run.  Caller-owned properties on the escaped character are carried
+onto the placeholder.  Escapes inside AVOID-RANGES (fenced or inline
+code, where a backslash is literal) are left untouched.  Returns
+non-nil on a change.
 
 For example the buffer `**let vs let\\***' becomes `**let vs letP**'
 \(P the placeholder tagged `*'), so the bold pass matches and the span
@@ -595,7 +597,9 @@ still round-trips to `**let vs let\\***' on copy."
         (if avoid
             (goto-char (cdr avoid))
           (let ((ch (char-after (match-beginning 1)))
-                (source (agent-shell-markdown-reconstruct start end)))
+                (source (agent-shell-markdown-reconstruct start end))
+                (carried (agent-shell-markdown--carry-properties
+                          (match-beginning 1))))
             (delete-region start end)
             (insert (propertize
                      (char-to-string agent-shell-markdown--escape-placeholder)
@@ -605,6 +609,8 @@ still round-trips to `**let vs let\\***' on copy."
                      'rear-nonsticky '(agent-shell-markdown-escaped
                                        agent-shell-markdown-frozen
                                        agent-shell-markdown-source)))
+            (when carried
+              (add-text-properties start (point) carried))
             (setq changed t)))))
     changed))
 

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -43,6 +43,23 @@
                   (agent-shell-markdown-convert "a \\_b\\_ c and \\* star"))
                  "a _b_ c and * star")))
 
+(ert-deftest agent-shell-markdown-escaped-punctuation-preserves-properties ()
+  "Escaped punctuation retains caller-owned text properties."
+  (with-temp-buffer
+    (insert "den\\.")
+    (add-text-properties (1- (point-max)) (point-max)
+                         '(agent-shell-ui-state sentinel
+                           agent-shell-ui-section label-right
+                           read-only t))
+    (let ((inhibit-read-only t))
+      (agent-shell-markdown-replace-markup :render-images nil))
+    (let ((period (1- (point-max))))
+      (should (equal (buffer-substring-no-properties (point-min) (point-max))
+                     "den."))
+      (should (eq (get-text-property period 'agent-shell-ui-state) 'sentinel))
+      (should (eq (get-text-property period 'agent-shell-ui-section) 'label-right))
+      (should (eq (get-text-property period 'read-only) t)))))
+
 (ert-deftest agent-shell-markdown-escaped-punctuation-round-trips ()
   ;; The escaped markdown is stashed, so copy-as-markdown restores the
   ;; backslashes verbatim.


### PR DESCRIPTION
## Problem

Rendering backslash-escaped Markdown punctuation replaces the escaped pair with a placeholder. The placeholder drops caller-owned text properties. Consequently, when escaped punctuation terminates a fragment label, the rendered character falls outside the fragment's state, section, and read-only ranges.

## Change

Carry caller-owned properties from the escaped character onto the placeholder using the renderer's existing property filter. Renderer-owned properties remain controlled by the renderer.

## Verification

- Added a regression test that renders `den\.` with UI properties on the period. Before this change the rendered period loses `agent-shell-ui-state`; after this change it retains the state, section, and read-only properties.
- Ran the full ERT suite
## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.