### PR TITLE
Guard group member walk against non-advancing block range #751

### DIFF
--- a/agent-shell-ui.el
+++ b/agent-shell-ui.el
@@ -605,12 +605,19 @@ equal to GROUP-QUALIFIED-ID; the run stops at the first non-member."
             (let ((state (get-text-property (point) 'agent-shell-ui-state)))
               (unless (and state (equal (map-elt state :group-id) group-qualified-id))
                 (throw 'done nil))
-              (let ((block (agent-shell-ui--block-range :position (point))))
+              (let* ((block (agent-shell-ui--block-range :position (point)))
+                     (end (map-elt block :end)))
+                ;; POS advances only to END, with nothing requiring END to move
+                ;; forward.  A range ending at or behind POS re-examines the
+                ;; same member forever (consing on every pass), and a nil BLOCK
+                ;; reaches `goto-char' as nil.  Stop instead.
+                (unless (and end (> end pos))
+                  (throw 'done nil))
                 (push (list (cons :qualified-id (map-elt state :qualified-id))
                             (cons :start (map-elt block :start))
-                            (cons :end (map-elt block :end)))
+                            (cons :end end))
                       children)
-                (setq pos (map-elt block :end))))))
+                (setq pos end)))))
         (nreverse children)))))
 
 (cl-defun agent-shell-ui--group-child-region (&key group-qualified-id)

--- a/tests/agent-shell-ui-tests.el
+++ b/tests/agent-shell-ui-tests.el
@@ -583,6 +583,43 @@ separators stayed hidden, collapsing members onto the folded header line."
     (should (agent-shell-ui--group-header-range "ns-grp"))
     (should (equal '("ns-m2") (agent-shell-ui-tests--group-child-ids "ns-grp")))))
 
+(ert-deftest agent-shell-ui-group-children-stops-when-block-range-stalls-test ()
+  "Member enumeration stops when a block range fails to advance.
+The member walk moves to each block's `:end', with nothing requiring that
+end to move forward.  A range ending at or behind the walk position, or a
+nil range, used to re-examine the same member forever and cons on every
+pass until Emacs stopped responding."
+  (with-temp-buffer
+    (agent-shell-ui-mode 1)
+    (dolist (id '("t1" "t2"))
+      (agent-shell-ui-update-fragment
+       (agent-shell-ui-make-fragment-model
+        :namespace-id "ns" :block-id id :group-id "grp" :group-label "Tools"
+        :label-left "run" :label-right id)
+       :navigation 'always))
+    (should (equal '("ns-t1" "ns-t2")
+                   (agent-shell-ui-tests--group-child-ids "ns-grp")))
+    (let ((block-range (symbol-function 'agent-shell-ui--block-range)))
+      ;; Members report a stalled range; the header keeps its real one so the
+      ;; walk still starts.
+      (cl-letf (((symbol-function 'agent-shell-ui--block-range)
+                 (lambda (&rest args)
+                   (if (eq 'group (map-elt (get-text-property
+                                            (plist-get args :position)
+                                            'agent-shell-ui-state)
+                                           :kind))
+                       (apply block-range args)
+                     '((:start . 1) (:end . 1))))))
+        (should-not (agent-shell-ui-tests--group-child-ids "ns-grp")))
+      (cl-letf (((symbol-function 'agent-shell-ui--block-range)
+                 (lambda (&rest args)
+                   (when (eq 'group (map-elt (get-text-property
+                                              (plist-get args :position)
+                                              'agent-shell-ui-state)
+                                             :kind))
+                     (apply block-range args)))))
+        (should-not (agent-shell-ui-tests--group-child-ids "ns-grp"))))))
+
 ;;; backward-block
 
 (defun agent-shell-ui-tests--fragment-start (qualified-id)


### PR DESCRIPTION
Fixes the non-terminating loop reported in #751.

`agent-shell-ui--group-children` walks group members by jumping to each member's `:end`, and nothing requires that end to move forward:

```elisp
(let ((block (agent-shell-ui--block-range :position (point))))
  (push (list ...) children)
  (setq pos (map-elt block :end)))   ; only progress signal
```

A block range ending at or behind `pos` re-examines the same member forever, consing on every pass. #751 has a `sample`(1) profile of that state: ~65% of the time in `garbage_collect`, heap climbing until Emacs is unresponsive. A `nil` `block` is also unguarded and reaches `goto-char` as `nil` on the next iteration.

This adds a strict forward-progress requirement, so a stalled range ends the walk instead of spinning. That covers both callers, since `--group-child-region` and `--group-insertion-point` share `--group-children`.

I have not identified what produces the non-advancing range. I tried the duplicate-`:qualified-id` theory from #751 — planting an earlier run with a member's id — and it did **not** reproduce: `--block-range` resolved correctly and the walk terminated. So this is a defensive invariant on the loop, not a fix for the underlying range calculation, and the real trigger is still open in #751.

Trade-off worth naming: when a range does stall, enumeration now stops early rather than looping, so a folded group could leave a trailing member visible and `--group-insertion-point` could return a slightly early position. Both seem clearly preferable to the hang, but it is a behaviour change in that degenerate case.

### Test

`agent-shell-ui-group-children-stops-when-block-range-stalls-test` stubs `--block-range` to report a stalled range for members while letting the header resolve normally. Verified it fails without the production change (returns `("ns-t1")`, i.e. the walk accepts the stalled member) and passes with it. It asserts the guard rather than reproducing the hang, so it fails fast instead of stalling CI.

Full suite: 426 tests, 0 unexpected (1 pre-existing skip). `byte-compile-file` diffed against baseline — no new warnings. `checkdoc` clean on both changed files.

## Checklist

- [ ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [ ] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

---

Disclosure on the first two boxes, deliberately left unchecked: this description and the code were drafted with AI assistance (Claude Code), so I cannot honestly tick them as written. I'm reviewing the diff myself and will follow up in my own words to confirm I vouch for it. Flagging rather than quietly ticking, since CONTRIBUTING.org is explicit about this. Happy to close if you'd rather just take the patch from #751 directly.
