### PR TITLE
Preserve point during table rendering

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -2756,13 +2756,16 @@ is safe to call on display and on resize."
         (let ((inhibit-read-only t)
               (buffer-undo-list t)
               (modified (buffer-modified-p)))
-          (dolist (region (nreverse regions))
-            (agent-shell-markdown--render-table
-             (list (cons :source (nth 2 region))
-                   (cons :start (marker-position (nth 0 region)))
-                   (cons :end (marker-position (nth 1 region)))))
-            (set-marker (nth 0 region) nil)
-            (set-marker (nth 1 region) nil))
+          ;; Preserve point (`agent-shell-markdown--render-table' moves point
+          ;; and can be triggered at arbitrary times).
+          (save-excursion
+            (dolist (region (nreverse regions))
+              (agent-shell-markdown--render-table
+               (list (cons :source (nth 2 region))
+                     (cons :start (marker-position (nth 0 region)))
+                     (cons :end (marker-position (nth 1 region)))))
+              (set-marker (nth 0 region) nil)
+              (set-marker (nth 1 region) nil)))
           (restore-buffer-modified-p modified))))))
 
 (defun agent-shell-markdown--carry-properties (pos)


### PR DESCRIPTION
I have been trying to use `embark-act` on items in the agent-shell session buffer (for example, when the agent refers to a file, jump to that text and `C-. RET` to open the file). I've found that if the session contains markdown tables, when I return to the agent shell buffer (e.g. by exiting out of the embark menu), point is no longer where I activated embark from - it's at the end of the last markdown table in the buffer. 

I got an agent to inspect the problem, and it's assessment is that a window resize hook is fired when the embark menu window opens, which causes `agent-shell-markdown-rerender-tables` to call `agent-shell-markdown--render-table` on the tables - this latter function deletes and inserts the table (which moves point), but there's no `save-excursion` protecting the original point. This PR adds the `save-excursion` which fixes the issue for me.

While I first noticed it when using embark, there are probably other ways to trigger this (e.g. if one were to make link clicking open in a new window, as requested in #755, that would likely also trigger a window resize)

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
