### PR TITLE
Render raw tool output

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3012,10 +3012,8 @@ Clears STATE's `:expanded-activity-group'."
            (let* ((diffs (map-nested-elt state `(:tool-calls ,(map-nested-elt acp-notification '(params update toolCallId)) :diffs)))
                   (output (concat
                            "\n\n"
-                           (mapconcat #'agent-shell--content-block-to-markdown
-                                      (seq-keep (lambda (item) (map-elt item 'content))
-                                                (map-nested-elt acp-notification '(params update content)))
-                                      "\n\n")
+                           (agent-shell--tool-call-update-output-markdown
+                            (map-nested-elt acp-notification '(params update)))
                            "\n\n"))
                   (diff-text (agent-shell--format-diffs-as-text diffs))
                   (body-text (if diff-text
@@ -7526,6 +7524,14 @@ Example:
                            (_ (string-remove-prefix "image/" mime-type))))
               ((seq-contains-p image-file-name-extensions extension)))
     (agent-shell--data-to-cache-file data extension)))
+
+(defun agent-shell--tool-call-update-output-markdown (acp-update)
+  "Return markdown output for an ACP tool call update ACP-UPDATE."
+  (or (map-nested-elt acp-update '(rawOutput formatted_output))
+      (mapconcat #'agent-shell--content-block-to-markdown
+                 (seq-keep (lambda (item) (map-elt item 'content))
+                           (map-elt acp-update 'content))
+                 "\n\n")))
 
 (defun agent-shell--content-block-to-markdown (acp-content-block)
   "Return markdown for a `session/update' ACP-CONTENT-BLOCK.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -503,6 +503,24 @@ image-rendering path as `![alt](uri)'."
                     (data . "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGP4DwQACfsD/fteaysAAAAASUVORK5CYII=")))
                  "\n\n![image](file:///tmp/shot.png)\n\n")))
 
+(ert-deftest agent-shell--tool-call-update-output-markdown-test ()
+  "Test tool call output extraction from ACP updates."
+  (should (equal
+           (agent-shell--tool-call-update-output-markdown
+            '((rawOutput . ((formatted_output . "stdout\nstderr\n")))
+              (content . [((type . "content")
+                           (content . ((type . "text")
+                                       (text . "legacy content"))))])))
+           "stdout\nstderr\n"))
+  (should (equal
+           (agent-shell--tool-call-update-output-markdown
+            '((content . [((type . "content")
+                           (content . ((type . "text") (text . "first"))))
+                          ((type . "content")
+                           (content . ((type . "text") (text . "second"))))])))
+           "first\n\nsecond"))
+  (should (equal (agent-shell--tool-call-update-output-markdown nil) "")))
+
 (ert-deftest agent-shell--image-data-to-file-test ()
   "Test `agent-shell--image-data-to-file'.
 


### PR DESCRIPTION
## Summary

- render tool call output from rawOutput.formatted_output when present
- keep the existing content block rendering as the fallback
- add focused regression coverage for both paths

## Validation

- emacs -Q --batch -L /home/marek/.emacs.d/straight/repos/acp.el -L /home/marek/.emacs.d/straight/repos/shell-maker -L . -l tests/agent-shell-tests.el -f ert-run-tests-batch-and-exit