### PR TITLE
Prevent syntax highlighting from delaying other buffers' mode hooks

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -3240,10 +3240,10 @@ unchanged."
             ((fboundp mode)))
       (with-temp-buffer
         (insert code)
-        (let ((inhibit-message t)
-              (delay-mode-hooks t))
-          (funcall mode)
-          (font-lock-ensure))
+        (let ((inhibit-message t))
+          (delay-mode-hooks
+            (funcall mode)
+            (font-lock-ensure)))
         (buffer-string))
     code))
 

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -756,6 +756,32 @@ print(\"hi\")
 
 " (agent-shell-markdown-source-block))))))
 
+(ert-deftest agent-shell-markdown-highlight-code-delays-mode-hooks-locally ()
+  "Highlighting code should not delay mode hooks in another buffer."
+  (with-temp-buffer
+    (let ((delay-mode-hooks nil)
+          (observer (current-buffer))
+          highlighted-mode-hook-ran
+          observer-hook-ran)
+      (add-hook 'agent-shell-markdown-tests-observer-hook
+                (lambda () (setq observer-hook-ran t)) nil t)
+      (cl-letf (((symbol-function 'agent-shell-markdown-tests-mode)
+                 (lambda ()
+                   (kill-all-local-variables)
+                   (add-hook 'agent-shell-markdown-tests-mode-hook
+                             (lambda ()
+                               (setq highlighted-mode-hook-ran t))
+                             nil t)
+                   (with-current-buffer observer
+                     (run-mode-hooks
+                      'agent-shell-markdown-tests-observer-hook))
+                   (run-mode-hooks
+                    'agent-shell-markdown-tests-mode-hook))))
+        (agent-shell-markdown--highlight-code
+         "" "agent-shell-markdown-tests"))
+      (should-not highlighted-mode-hook-ran)
+      (should observer-hook-ran))))
+
 (ert-deftest agent-shell-markdown-convert-source-block-body-tagged ()
   ;; Body chars carry `agent-shell-markdown-frozen t' so subsequent calls
   ;; treat them as an avoid-range (streaming-safe).  Rendered output


### PR DESCRIPTION
## Problem

`agent-shell-markdown--highlight-code` manually binds `delay-mode-hooks` while activating a language major mode in a temporary buffer. Because `delay-mode-hooks` was not first made buffer-local, that dynamic binding temporarily makes its default value non-nil. 

As a result, another buffer without its own buffer-local value can see mode-hook delays intended only for the syntax-highlighting buffer. When that buffer calls `run-mode-hooks`, Emacs queues its mode hooks instead of running them. The buffer's mode initialization may then remain incomplete until `run-mode-hooks` is called there again. In particular, this can happen while [`agent-shell-desktop.el`](https://github.com/timfel/agent-shell-desktop.el) is restoring shells and one of their large transcripts is being rendered.

## Changes

- Use Emacs's built-in `delay-mode-hooks` macro, which makes the variable buffer-local before binding it and preserves the intended suppression across the major mode's `kill-all-local-variables` call.
- Add a regression test that verifies hooks remain delayed in the syntax-highlighting buffer while hooks in another buffer run normally.

## Verification

- Confirmed the regression test fails before the fix because the observer buffer sees the dynamically bound default of `delay-mode-hooks` as non-nil and queues its hook instead of running it.
- Confirmed the regression test passes after the fix.
- Ran the full test suite

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.