### PR TITLE
Refresh viewport header even with nil agent-shell-prefer-viewport-interaction

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3713,8 +3713,7 @@ variable (see makunbound)"))
                                                          :cache-enabled (eq status 'busy))))
                                                     ;; 'ended is the final tick; render even
                                                     ;; if off-screen to ensure animation is hidden.
-                                                    (when-let* ((using-viewports agent-shell-prefer-viewport-interaction)
-                                                                (viewport-buffer (agent-shell-viewport--buffer
+                                                    (when-let* ((viewport-buffer (agent-shell-viewport--buffer
                                                                                   :shell-buffer shell-buffer
                                                                                   :existing-only t))
                                                                 ;; 'ended is the final tick; render even


### PR DESCRIPTION
agent-shell-prompt-compose creates a viewport buffer without requiring agent-shell-prefer-viewport-interaction to be non-nil.  We should update the header of that buffer even so.

## Checklist

- [X] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [X] *I've reviewed all code in PR myself and will vouch for its quality*.
- [X] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [X] I've added tests where applicable.
- [X] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
