### PR TITLE
Ask about killing the shell only when that is what was asked for

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -79,6 +79,8 @@
 (declare-function agent-shell-completion-mode "agent-shell-completion")
 (declare-function agent-shell-yank-dwim "agent-shell")
 
+(defvar-local agent-shell-viewport--clean-up t)
+
 (defvar agent-shell-header-style)
 (defvar agent-shell-prefer-viewport-interaction)
 (defvar agent-shell-viewport-dismiss-on-send)
@@ -1488,8 +1490,6 @@ on current major mode."
                                                                  (:mode . ,mode-binding)
                                                                  (:thought-level . ,thought-level-binding))))))
       (setq-local header-line-format header))))
-
-(defvar-local agent-shell-viewport--clean-up t)
 
 (cl-defun agent-shell-viewport--shell-buffer (&optional viewport-buffer)
   "Get the shell buffer associated with VIEWPORT-BUFFER.


### PR DESCRIPTION
Sending a composed prompt with C-c C-c asked "Kill shell session too?" whenever the viewport had been opened by anything other than `agent-shell-prompt-compose' -- which is the only path that sets `agent-shell-viewport-dismiss-on-send' buffer-locally, and so the only one that dismisses rather than kills.

`agent-shell-viewport-compose-send-and-kill' already binds `agent-shell-viewport--clean-up' to nil around the kill, with a comment saying exactly why the question should not be asked.  The binding never took effect: the variable is declared at the foot of the file, well after this use, so at compile time the symbol was not yet special and under lexical binding the `let' produced a dead lexical variable.  The dynamic value stayed t and `kill-buffer-hook' asked anyway.  The compiler said so in two warnings:

  Unused lexical variable 'agent-shell-viewport--clean-up'
  Variable 'agent-shell-viewport--clean-up' declared after its first use

Moving the declaration above its first use makes the existing binding dynamic, which is what it was written to be.  Both warnings go, and sending no longer offers to kill the session it just sent to.

Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
