### PR TITLE
Allow setting "defaults" for Pi

### DIFF
--- a/README.org
+++ b/README.org
@@ -966,6 +966,8 @@ always go to Evil modes if you need to with ~C-z~).
 | agent-shell-path-resolver-function            | Function for resolving remote paths on the local file-system, and vice versa.   |
 | agent-shell-permission-icon                   | Icon displayed when shell commands require permission to execute.               |
 | agent-shell-pi-acp-command                    | Command and parameters for the Pi ACP client.                                   |
+| agent-shell-pi-default-model-id               | Default Pi model ID.                                                            |
+| agent-shell-pi-default-session-mode-id        | Default Pi session mode ID.                                                     |
 | agent-shell-pi-environment                    | Environment variables for the Pi client.                                        |
 | agent-shell-prefer-viewport-interaction       | Non-nil makes ‘agent-shell’ prefer viewport interaction over shell interaction. |
 | agent-shell-preferred-agent-config            | Default agent to use for all new shells.                                        |

--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -67,6 +67,26 @@ Example usage to set custom environment variables:
   :type '(repeat string)
   :group 'agent-shell)
 
+(defcustom agent-shell-pi-default-model-id
+  nil
+  "Default Pi model ID.
+
+Must be one of the model ID's displayed under \"Available models\"
+when starting a new shell.
+
+Can be set to either a string or a function that returns a string."
+  :type '(choice (const nil) string function)
+  :group 'agent-shell)
+
+(defcustom agent-shell-pi-default-session-mode-id
+  nil
+  "Default Pi session mode ID.
+
+Must be one of the mode ID's displayed under \"Available modes\"
+when starting a new shell."
+  :type '(choice (const nil) string)
+  :group 'agent-shell)
+
 (defun agent-shell-pi-make-agent-config ()
   "Create a Pi coding agent configuration.
 
@@ -81,6 +101,10 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-pi--welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-pi-make-client :buffer buffer))
+   :default-model-id (lambda () (if (functionp agent-shell-pi-default-model-id)
+                                    (funcall agent-shell-pi-default-model-id)
+                                  agent-shell-pi-default-model-id))
+   :default-session-mode-id (lambda () agent-shell-pi-default-session-mode-id)
    :install-instructions "See https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent for Pi installation.
 Requires pi-acp adapter for ACP integration."))
 

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2296,8 +2296,20 @@ COMMAND, when present, may be a shell command string or an argv vector."
         (t (error "Unexpected tool-call command type: %S" (type-of command)))))
 
 (defun agent-shell--active-requests-p (state)
-  "Return non-nil if STATE has in-flight requests awaiting responses."
-  (map-elt state :active-requests))
+  "Return non-nil if STATE has an in-flight request running a prompt turn.
+
+Only turn-running requests count. Non-turn requests
+like `session/set_model' must not mark the shell as in-turn:
+notifications arriving while they are in flight (e.g. an agent
+greeting) render above the live prompt, not after it."
+  (seq-find (lambda (request)
+              (member (map-elt request :method)
+                      (append '("session/prompt"
+                                "session/load"
+                                "session/resume"
+                                "session/fork")
+                              (agent-shell-experimental--methods))))
+            (map-elt state :active-requests)))
 
 (defun agent-shell--make-out-of-session-turn-notification-body (state acp-notification)
   "Build a fragment body for ACP-NOTIFICATION arriving out of turn using STATE."


### PR DESCRIPTION
Simple change making Pi work like the others. It's nice to be able to pick your default model/session.

Thank you for contributing to agent-shell!

## Checklist

- [ ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [ ] *I've reviewed all code in PR myself and will vouch for its quality*.
- [ ] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
