### PR TITLE
Steer prompts into the running turn instead of queueing them

### DIFF
--- a/README.org
+++ b/README.org
@@ -672,6 +672,14 @@ In view mode, use =r= to compose a reply, =R= to quote the response in a reply, 
 Do not invoke =agent-shell-viewport-edit-mode= or =agent-shell-viewport-view-mode= directly in an agent shell buffer.  They are major modes installed by the entry points above on the separate viewport buffer, not commands for converting the shell buffer.
 #+end_quote
 
+*** Steering a running turn
+
+A prompt sent while the agent is working is queued and submitted once the turn ends.  Agents that support steering can take it into the turn already running instead, so a wrong direction can be corrected without waiting for it to finish.  Steering is an ACP extension (=_session/steering=) rather than part of the spec, advertised by the agent at initialization: the Claude and Codex packages implement it, other agents keep queueing.
+
+Sending from a busy shell steers automatically when the agent supports it.  Use a prefix argument (=C-u=) to queue that one prompt instead, or set =agent-shell-steer-when-busy= to nil to always queue.  =M-x agent-shell-steer= steers explicitly, and errors when there is no running turn to steer or the agent cannot steer.  A steer that the agent does not accept falls back to queueing, so the prompt is never lost.
+
+What the agent does with the steered prompt is up to the agent: Claude interrupts what it is generating and responds to it, while Codex finishes the message in flight first.
+
 *** Specific Agent Commands
 
 Start a specific agent shell session directly:
@@ -982,6 +990,7 @@ always go to Evil modes if you need to with ~C-z~).
 | agent-shell-show-context-usage-indicator      | Non-nil to show the context usage indicator in the header and mode line.        |
 | agent-shell-show-usage-at-turn-end            | Whether to display usage information when agent turn ends.                      |
 | agent-shell-show-welcome-message              | Non-nil to show welcome message.                                                |
+| agent-shell-steer-when-busy                   | Whether a prompt sent mid-turn steers the agent instead of queueing.            |
 | agent-shell-text-file-capabilities            | Whether agents are initialized with read/write text file capabilities.          |
 | agent-shell-thought-process-expand-by-default | Whether thought process sections should be expanded by default.                 |
 | agent-shell-thought-process-icon              | Icon displayed during the AI’s thought process.                                 |
@@ -1067,7 +1076,7 @@ always go to Evil modes if you need to with ~C-z~).
 | p or <backtab>  | agent-shell-previous-item                               | Go to previous item.                                                          |
 |                 | agent-shell-previous-permission-button                  | Jump to the previous button.                                                  |
 |                 | agent-shell-prompt-compose                              | Compose an `agent-shell' prompt in a dedicated buffer.                        |
-|                 | agent-shell-prompt-queue                                | Queue or immediately send a prompt depending on shell busy state.             |
+|                 | agent-shell-prompt-queue                                | Steer, queue, or immediately send a prompt depending on shell state.          |
 |                 | agent-shell-prompt-queue-remove                         | Remove all pending prompts or a specific prompt by REMOVE-INDEX.              |
 |                 | agent-shell-prompt-queue-resume                         | Resume processing pending prompts in the queue.                               |
 | r               | agent-shell-quote-region                                | Quote the active region into the shell's latest prompt.                       |
@@ -1084,6 +1093,7 @@ always go to Evil modes if you need to with ~C-z~).
 |                 | agent-shell-send-screenshot                             | Capture a screenshot and insert it into `agent-shell'.                        |
 | C-c RET         | agent-shell-set-session-mode                            | Set session mode (if any available).                                          |
 | C-c C-v         | agent-shell-set-session-model                           | Set session model.                                                            |
+|                 | agent-shell-steer                                       | Steer PROMPT into the turn the agent is currently running.                    |
 | RET             | agent-shell-submit                                      | Submit current input.                                                         |
 |                 | agent-shell-toggle                                      | Toggle agent shell display.                                                   |
 |                 | agent-shell-toggle-logging                              | Toggle logging.                                                               |

--- a/agent-shell-experimental.el
+++ b/agent-shell-experimental.el
@@ -28,6 +28,13 @@
 ;; a request to the client, followed by session/update notifications,
 ;; concluded by an session_push_end notification.  The client
 ;; then responds to the original request.
+;;
+;; _session/steering: Steer a prompt into the turn already running,
+;; instead of queueing it until the turn ends.  The client sends the
+;; request; the agent answers whether the prompt joined the running
+;; turn, or why it could not.  The steered prompt's own output arrives
+;; as ordinary session/update notifications on the turn already in
+;; flight, so nothing else changes.
 
 ;;; Code:
 
@@ -37,6 +44,9 @@
 
 (declare-function acp-send-response "acp")
 (declare-function acp-make-error "acp")
+(declare-function agent-shell--build-content-blocks "agent-shell")
+(declare-function agent-shell--expand-truncated-regions "agent-shell")
+(declare-function agent-shell--send-request "agent-shell")
 (declare-function agent-shell-heartbeat-start "agent-shell-heartbeat")
 (declare-function agent-shell-heartbeat-stop "agent-shell-heartbeat")
 (declare-function shell-maker-insert-end-of-prompt-marker "shell-maker")
@@ -135,6 +145,109 @@ ERROR is an optional error object if the push prompt was rejected."
 (defun agent-shell-experimental--methods ()
   "Return the list of experimental methods that replay session notifications."
   '("session/push"))
+
+(defconst agent-shell-experimental--steering-method "_session/steering"
+  "Request method that steers a prompt into the turn already running.
+
+Not part of the ACP spec -- the leading underscore marks it as an
+extension -- but implemented under this name by the Claude and Codex
+adapters, which advertise it as `_meta.steering.supported' in their
+`initialize' response.  The ACP proposal that would standardise this is
+`session/inject' (RFD 1261), still unmerged and targeting v2.")
+
+(cl-defun agent-shell-experimental--make-session-steering-request (&key session-id prompt)
+  "Instantiate a steering request for SESSION-ID carrying PROMPT.
+
+PROMPT is a vector of content blocks, the same shape `session/prompt'
+takes.
+
+The `idleBehavior' opt-in asks the agent to do nothing and say so when
+no turn is running, rather than starting a detached turn out of our
+sight.  Only the Claude adapter honours it; Codex's parameter parser
+passes unknown keys through and ignores them, so a steer that races the
+end of a turn can still come back `startedNewTurn' there.
+
+For example:
+
+  (agent-shell-experimental--make-session-steering-request
+   :session-id \"sess-1\"
+   :prompt [((type . \"text\") (text . \"just the filenames\"))])
+
+  => ((:method . \"_session/steering\")
+      (:params . ((sessionId . \"sess-1\")
+                  (prompt . [((type . \"text\")
+                              (text . \"just the filenames\"))])
+                  (_meta . ((steering
+                             . ((idleBehavior . \"promptRequired\"))))))))"
+  (unless session-id
+    (error ":session-id is required"))
+  (unless prompt
+    (error ":prompt is required"))
+  `((:method . ,agent-shell-experimental--steering-method)
+    (:params . ((sessionId . ,session-id)
+                (prompt . ,(vconcat prompt))
+                (_meta . ((steering . ((idleBehavior . "promptRequired")))))))))
+
+(defun agent-shell-experimental--steering-outcome (acp-response)
+  "Return ACP-RESPONSE's steering outcome as a symbol.
+
+One of:
+
+  `injected'         - the prompt joined the turn that was running.
+  `prompt-required'  - no turn was running and the agent left the
+                       prompt with us to submit normally.
+  `started-new-turn' - no turn was running and the agent started one
+                       of its own, which we did not ask for and cannot
+                       track.
+  `failed'           - the agent could not apply the steer.
+
+An unrecognised outcome maps to `failed' so a future agent's new answer
+falls back to queueing rather than being mistaken for success.
+
+For example:
+
+  (agent-shell-experimental--steering-outcome \\='((outcome . \"injected\")))
+  => injected
+
+  (agent-shell-experimental--steering-outcome \\='((outcome . \"whatever\")))
+  => failed"
+  (pcase (map-elt acp-response 'outcome)
+    ("injected" 'injected)
+    ("promptRequired" 'prompt-required)
+    ("startedNewTurn" 'started-new-turn)
+    (_ 'failed)))
+
+(cl-defun agent-shell-experimental--send-steering (&key state prompt on-outcome)
+  "Steer PROMPT into the turn STATE's session is currently running.
+
+Must be called from the shell buffer: PROMPT is converted with
+`agent-shell--build-content-blocks', which reads the buffer's prompt
+capabilities.
+
+ON-OUTCOME is called with (OUTCOME MESSAGE): OUTCOME as per
+`agent-shell-experimental--steering-outcome', and MESSAGE the agent's
+error text when the request itself failed, nil otherwise.  A failed
+request reports `failed' rather than propagating the error, so callers
+have one code path for \"this did not get steered\" and can fall back to
+queueing without losing the prompt."
+  (let* ((expanded (agent-shell--expand-truncated-regions prompt))
+         (content-blocks (condition-case nil
+                             (agent-shell--build-content-blocks expanded)
+                           (error `[((type . "text")
+                                     (text . ,(substring-no-properties expanded)))]))))
+    (agent-shell--send-request
+     :state state
+     :client (map-elt state :client)
+     :request (agent-shell-experimental--make-session-steering-request
+               :session-id (map-nested-elt state '(:session :id))
+               :prompt content-blocks)
+     :buffer (current-buffer)
+     :on-success (lambda (acp-response)
+                   (funcall on-outcome
+                            (agent-shell-experimental--steering-outcome acp-response)
+                            nil))
+     :on-failure (lambda (acp-error _raw-message)
+                   (funcall on-outcome 'failed (map-elt acp-error 'message))))))
 
 (defun agent-shell-experimental--normalize-request (request)
   "Normalize REQUEST from JSON symbol keys to keyword keys.

--- a/agent-shell-prompt-queue.el
+++ b/agent-shell-prompt-queue.el
@@ -39,10 +39,34 @@
 (declare-function agent-shell--shell-buffer "agent-shell")
 (declare-function agent-shell--state "agent-shell")
 (declare-function agent-shell--echo "agent-shell")
+(declare-function agent-shell--active-requests-p "agent-shell")
+(declare-function agent-shell--emit-event "agent-shell")
+(declare-function agent-shell--render-steered-prompt "agent-shell")
+(declare-function agent-shell-status "agent-shell")
+(declare-function agent-shell-steering-supported-p "agent-shell")
+(declare-function agent-shell-experimental--send-steering "agent-shell-experimental")
+(declare-function agent-shell-completion--setup-minibuffer "agent-shell-completion")
 (declare-function shell-maker-busy "shell-maker")
 
 (defvar agent-shell--state)
 (defvar comint-input-ring)
+
+(defcustom agent-shell-steer-when-busy t
+  "Whether a prompt sent mid-turn steers the agent instead of queueing.
+
+Steering hands the prompt to the agent while it is still working, so it
+can change course.  Queueing holds the prompt until the turn ends and
+then sends it as a new one.
+
+Only agents that advertise steering can be steered; the rest queue
+regardless.  A prefix argument to `agent-shell-prompt-queue' forces
+queueing for one prompt without changing this.
+
+Note that steering may cut the agent off mid-answer: whether the
+in-flight response is interrupted or the prompt waits for a safe
+break-point is the agent's choice, not ours."
+  :type 'boolean
+  :group 'agent-shell)
 
 ;; The queueing commands were renamed to the `agent-shell-prompt-queue'
 ;; namespace.  A package upgrade reloads this file into a running session
@@ -205,14 +229,115 @@ agent commands when the agent has reported them."
       (read-string (or (map-nested-elt (agent-shell--state) '(:agent-config :shell-prompt))
                        "Enqueue prompt: ")))))
 
-(defun agent-shell-prompt-queue (prompt)
-  "Queue or immediately send a prompt depending on shell busy state.
+(defun agent-shell--prompt-queue-steer-p ()
+  "Return non-nil when a prompt sent now should steer the running turn.
+
+Requires `agent-shell-steer-when-busy', an agent that advertises
+steering, and a turn that is running but not `blocked'.  A blocked shell
+is waiting on a permission answer: what an agent does with a message
+injected while a tool sits on that question is left undefined by every
+implementation, so those prompts keep queueing."
+  (and agent-shell-steer-when-busy
+       (agent-shell-steering-supported-p)
+       (eq (agent-shell-status) 'busy)))
+
+(cl-defun agent-shell--prompt-queue-steer (&key prompt)
+  "Steer PROMPT into the running turn, queueing it if that fails.
+
+Dispatches on the agent's answer:
+
+  `injected'         renders PROMPT as a user prompt in the running turn.
+  `prompt-required'  the turn had ended and the agent left PROMPT with
+                     us, so submit it as an ordinary prompt.
+  `started-new-turn' the turn had ended and the agent started one we did
+                     not ask for; its output arrives with no request in
+                     flight, so say so rather than let it appear as an
+                     unexplained out-of-turn message.
+  `failed'           queue PROMPT unchanged.
+
+Every path keeps PROMPT: a steer that does not land must not cost the
+user their text."
+  (let ((state (agent-shell--state)))
+    (agent-shell-experimental--send-steering
+     :state state
+     :prompt prompt
+     :on-outcome
+     (lambda (outcome message)
+       (pcase outcome
+         ('injected
+          (agent-shell--render-steered-prompt :state state :prompt prompt))
+         ('prompt-required
+          ;; The agent saw no turn, but this shell may not have processed
+          ;; its own `session/prompt' response yet, and submitting into a
+          ;; still-busy shell errors and drops the text.  Queueing is
+          ;; correct either way: the queue drains as soon as the turn
+          ;; settles.
+          (if (shell-maker-busy)
+              (agent-shell--prompt-queue-enqueue :prompt prompt)
+            (agent-shell--insert-to-shell-buffer :text prompt :submit t :no-focus t)))
+         ('started-new-turn
+          (agent-shell--update-fragment
+           :state state
+           :block-id (format "%s-steer-detached-turn"
+                             (map-elt state :request-count))
+           :label-left (propertize "Steered prompt started a new turn"
+                                   'font-lock-face 'agent-shell-section-heading)
+           :body (format "The turn ended before this prompt reached the agent, so
+the agent started one of its own for it:
+
+  %s
+
+Its output arrives out of turn, and the shell does not show as
+busy while it runs." prompt)
+           :create-new t
+           :above-last-prompt (not (agent-shell--active-requests-p state))))
+         (_
+          (agent-shell--prompt-queue-enqueue :prompt prompt)
+          (when message
+            (agent-shell--echo "Steering failed (%s); prompt queued" message))))
+       (agent-shell--emit-event :event 'prompt-steered
+                                :data (list (cons :prompt prompt)
+                                            (cons :outcome outcome)))))))
+
+(defun agent-shell-prompt-queue (prompt &optional queue-only)
+  "Steer, queue, or immediately send a prompt depending on shell state.
 
 Read PROMPT from the minibuffer and act on the current project's shell,
 resolving it via `agent-shell--shell-buffer' so this works even when
-invoked outside a shell buffer.  If the shell is busy, add PROMPT to the
-pending prompts queue.  Otherwise, submit it immediately.  Queued prompts
-will be automatically sent when the current prompt completes.
+invoked outside a shell buffer.
+
+When the shell is idle, submit PROMPT immediately.  When a turn is
+running, steer PROMPT into it if the agent supports that (see
+`agent-shell--prompt-queue-steer-p'), so the agent can change course
+rather than finish first.  Otherwise add PROMPT to the pending prompts
+queue, which is sent automatically when the current turn completes.
+
+With a prefix argument, or with QUEUE-ONLY non-nil, always queue rather
+than steer -- for when the agent should finish what it is doing before
+reading the next thing.
+
+While reading, @ completes project files and / completes available agent
+commands when the agent has reported them."
+  (interactive
+   (list (with-current-buffer (agent-shell--shell-buffer :no-create t)
+           (agent-shell--prompt-queue-read))
+         current-prefix-arg))
+  (with-current-buffer (agent-shell--shell-buffer :no-create t)
+    (cond
+     ((not (shell-maker-busy))
+      (agent-shell--insert-to-shell-buffer :text prompt :submit t :no-focus t))
+     ((and (not queue-only) (agent-shell--prompt-queue-steer-p))
+      (agent-shell--prompt-queue-steer :prompt prompt))
+     (t
+      (agent-shell--prompt-queue-enqueue :prompt prompt)))))
+
+(defun agent-shell-steer (prompt)
+  "Steer PROMPT into the turn the agent is currently running.
+
+Unlike queueing, the prompt reaches the agent while it works, so it can
+change course instead of finishing first.  Signals a `user-error' when
+the agent does not support steering or no turn is running -- use
+`agent-shell-prompt-queue' for those.
 
 While reading, @ completes project files and / completes available agent
 commands when the agent has reported them."
@@ -220,9 +345,13 @@ commands when the agent has reported them."
    (list (with-current-buffer (agent-shell--shell-buffer :no-create t)
            (agent-shell--prompt-queue-read))))
   (with-current-buffer (agent-shell--shell-buffer :no-create t)
-    (if (shell-maker-busy)
-        (agent-shell--prompt-queue-enqueue :prompt prompt)
-      (agent-shell--insert-to-shell-buffer :text prompt :submit t :no-focus t))))
+    (unless (shell-maker-busy)
+      (user-error "No turn to steer; the agent is idle"))
+    (unless (agent-shell-steering-supported-p)
+      (user-error "This agent does not support steering"))
+    (when (eq (agent-shell-status) 'blocked)
+      (user-error "Answer the pending permission request first"))
+    (agent-shell--prompt-queue-steer :prompt prompt)))
 
 (defun agent-shell-prompt-queue-resume ()
   "Resume processing pending prompts in the queue.

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1209,6 +1209,7 @@ OUTGOING-REQUEST-DECORATOR (passed through to `acp-make-client')."
         (cons :supports-session-load nil)
         (cons :supports-session-resume nil)
         (cons :supports-session-fork nil)
+        (cons :supports-steering nil)
         (cons :resume-session-id nil)
         (cons :fork-session-id nil)
         (cons :pending-restore nil)
@@ -2035,6 +2036,16 @@ Returns one of:
       (if (shell-maker-busy)
           'busy
         'ready)))))
+
+(cl-defun agent-shell-steering-supported-p (&key shell-buffer)
+  "Return non-nil when the agent accepts a prompt steered into a running turn.
+When SHELL-BUFFER is non-nil, check that buffer instead of the current one.
+
+Steering is an ACP extension rather than part of the spec, so the agent
+advertises it in the `initialize' response's top-level `_meta' as
+`steering.supported'.  See `agent-shell-experimental--send-steering'."
+  (with-current-buffer (or shell-buffer (current-buffer))
+    (map-elt agent-shell--state :supports-steering)))
 
 (defun agent-shell-interrupt (&optional force)
   "Interrupt in-progress request and reject all pending permissions.
@@ -6099,6 +6110,12 @@ Session events:
   `input-submitted'       - User submitted input to the agent
     :data contains :prompt (the text sent to the agent, with any
     truncated regions expanded)
+  `prompt-steered'        - User steered a prompt into the running turn
+    :data contains :prompt and :outcome.  :outcome is `injected' when
+    the prompt joined the running turn, `prompt-required' or
+    `started-new-turn' when the turn had already ended, or `failed'
+    when the steer could not be applied and the prompt was queued
+    instead.  See `agent-shell-experimental--steering-outcome'.
   `idle'                  - Agent idle for variable `agent-shell-idle-timeout'
     seconds :data contains :idle-event and :buffer
 
@@ -6406,6 +6423,11 @@ Must provide ON-INITIATED (lambda ())."
                                                               (:name . ,(map-elt mode 'name))
                                                               (:description . ,(map-elt mode 'description))))
                                                           (map-elt modes 'availableModes))))))
+                   ;; Steering is an extension, so it is advertised in the
+                   ;; response's top-level `_meta' rather than in
+                   ;; `agentCapabilities'.  See `agent-shell-steering-supported-p'.
+                   (map-put! agent-shell--state :supports-steering
+                             (eq (map-nested-elt acp-response '(_meta steering supported)) t))
                    (when-let* ((agent-capabilities (map-elt acp-response 'agentCapabilities)))
                      (map-put! agent-shell--state :supports-session-load
                                (eq (map-elt agent-capabilities 'loadSession) t))
@@ -6413,7 +6435,13 @@ Must provide ON-INITIATED (lambda ())."
                       :state agent-shell--state
                       :block-id "agent_capabilities"
                       :label-left (propertize "Agent capabilities" 'font-lock-face 'agent-shell-section-heading)
-                      :body (agent-shell--format-agent-capabilities agent-capabilities)))
+                      ;; Listed alongside the spec capabilities because that is
+                      ;; what it is to a reader of this block, even though the
+                      ;; wire carries it elsewhere.
+                      :body (agent-shell--format-agent-capabilities
+                             (if (map-elt agent-shell--state :supports-steering)
+                                 (append agent-capabilities '((steering . t)))
+                               agent-capabilities))))
                    (agent-shell--emit-event :event 'init-handshake))
                  (funcall on-initiated))
    :on-failure (agent-shell--make-error-handler
@@ -7953,6 +7981,51 @@ Each marked span is replaced by its `agent-shell-region-text' value."
           (goto-char beg)
           (insert full-text))))
     (buffer-string)))
+
+(defconst agent-shell--steered-entry-type "steered_user_message"
+  "`:last-entry-type' left by a steered prompt.
+
+Deliberately not \"user_message_chunk\": that value asks the replay
+path to insert the end-of-prompt marker on the next notification, and
+`agent-shell--render-steered-prompt' has already inserted its own.")
+
+(cl-defun agent-shell--render-steered-prompt (&key state prompt)
+  "Render PROMPT into STATE's shell as the user prompt it is.
+
+A steered prompt is never echoed back: neither the Claude nor the Codex
+adapter forwards it as a `user_message_chunk' while the turn runs, so
+the client renders it or it does not appear at all.
+
+Uses the field/face shape comint gives a live prompt, so
+`comint-next-prompt', `agent-shell-next-item', copying and screen-reader
+prompt navigation treat it as a user prompt rather than as a new kind of
+entry.  `shell-maker-insert-end-of-prompt-marker' then closes it, which
+is what bounds the prompt for anything measuring it by searching forward
+for the marker; without it such a search runs to the next submission and
+takes the rest of the turn's output as this prompt's body.
+
+The `[steered]' prefix carries the one thing this shape would otherwise
+lose -- that the prompt was injected into a running turn rather than
+typed before one."
+  (map-put! state :chunked-group-count (1+ (map-elt state :chunked-group-count)))
+  (agent-shell--append-transcript
+   :text (format "## User (steered) (%s)\n\n%s\n\n"
+                 (format-time-string "%F %T")
+                 (agent-shell--indent-markdown-headers prompt))
+   :file-path agent-shell--transcript-file)
+  (agent-shell--update-text
+   :state state
+   :block-id (format "%s-steered-user_message_chunk"
+                     (map-elt state :chunked-group-count))
+   :text (concat (propertize (map-nested-elt state '(:agent-config :shell-prompt))
+                             'font-lock-face '(agent-shell-prompt comint-highlight-prompt)
+                             'field 'output)
+                 (propertize (concat "[steered] " (substring-no-properties prompt))
+                             'font-lock-face 'agent-shell-input))
+   :create-new t)
+  (with-current-buffer (map-elt state :buffer)
+    (shell-maker-insert-end-of-prompt-marker))
+  (map-put! state :last-entry-type agent-shell--steered-entry-type))
 
 (cl-defun agent-shell--send-command (&key prompt shell-buffer)
   "Send PROMPT to agent using SHELL-BUFFER."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -5750,6 +5750,156 @@ shell is left working in a directory that was just deleted."
         (kill-buffer new-shell-buffer))
       (when (file-directory-p temp-dir)
         (delete-directory temp-dir t)))))
+(ert-deftest agent-shell-experimental--make-session-steering-request-test ()
+  "Test `agent-shell-experimental--make-session-steering-request'."
+  (let ((request (agent-shell-experimental--make-session-steering-request
+                  :session-id "sess-1"
+                  :prompt '(((type . "text") (text . "actually, just the filenames"))))))
+    (should (equal (map-elt request :method) "_session/steering"))
+    (should (equal (map-nested-elt request '(:params sessionId)) "sess-1"))
+    ;; Sent as a vector so it serializes to a JSON array, like session/prompt.
+    (should (vectorp (map-nested-elt request '(:params prompt))))
+    (should (equal (map-nested-elt request '(:params prompt))
+                   [((type . "text") (text . "actually, just the filenames"))]))
+    ;; Opts out of the agent starting a turn of its own when none is running.
+    (should (equal (map-nested-elt request '(:params _meta steering idleBehavior))
+                   "promptRequired")))
+  (should-error (agent-shell-experimental--make-session-steering-request
+                 :prompt '(((type . "text") (text . "hi")))))
+  (should-error (agent-shell-experimental--make-session-steering-request
+                 :session-id "sess-1")))
+
+(ert-deftest agent-shell-experimental--steering-outcome-test ()
+  "Test `agent-shell-experimental--steering-outcome'."
+  (should (eq (agent-shell-experimental--steering-outcome '((outcome . "injected")))
+              'injected))
+  (should (eq (agent-shell-experimental--steering-outcome
+               '((outcome . "promptRequired") (reason . "noRunningTurn")))
+              'prompt-required))
+  (should (eq (agent-shell-experimental--steering-outcome '((outcome . "startedNewTurn")))
+              'started-new-turn))
+  (should (eq (agent-shell-experimental--steering-outcome '((outcome . "failed")))
+              'failed))
+  ;; An outcome we don't know, or none at all, must read as failure so the
+  ;; caller queues the prompt rather than treating it as delivered.
+  (should (eq (agent-shell-experimental--steering-outcome '((outcome . "somethingNew")))
+              'failed))
+  (should (eq (agent-shell-experimental--steering-outcome '()) 'failed)))
+
+(ert-deftest agent-shell--prompt-queue-steer-p-test ()
+  "Test `agent-shell--prompt-queue-steer-p' decides when to steer."
+  (cl-letf* ((status 'busy)
+             (supported t)
+             ((symbol-function 'agent-shell-status) (lambda (&rest _) status))
+             ((symbol-function 'agent-shell-steering-supported-p) (lambda (&rest _) supported)))
+    (let ((agent-shell-steer-when-busy t))
+      (should (agent-shell--prompt-queue-steer-p))
+      ;; A pending permission answer is a question, not a turn to redirect.
+      (setq status 'blocked)
+      (should-not (agent-shell--prompt-queue-steer-p))
+      (setq status 'ready)
+      (should-not (agent-shell--prompt-queue-steer-p))
+      ;; An agent that never advertised steering is only ever queued to.
+      (setq status 'busy
+            supported nil)
+      (should-not (agent-shell--prompt-queue-steer-p)))
+    ;; Reset the stubs' own bindings, not fresh shadowing ones: the stubs
+    ;; close over these, so a `let' here would leave them reading the values
+    ;; set above and pass for the wrong reason.
+    (setq status 'busy
+          supported t)
+    (let ((agent-shell-steer-when-busy nil))
+      (should-not (agent-shell--prompt-queue-steer-p)))))
+
+(cl-defun agent-shell-tests--steer-outcome (&key outcome busy)
+  "Steer a prompt, answer with OUTCOME, and return where the prompt landed.
+
+BUSY is what `shell-maker-busy' reports while the outcome is handled: a
+shell that has not yet processed its own `session/prompt' response is
+still busy even though the agent says the turn ended.
+
+Returns `rendered' (shown as a user prompt in the running turn),
+`submitted' (sent as an ordinary prompt), `queued' (added to the pending
+queue) or `reported' (rendered as a fragment explaining a turn we did
+not ask for)."
+  (let ((landed))
+    (cl-letf (((symbol-function 'agent-shell--state)
+               (lambda (&rest _) (list (cons :buffer (current-buffer)))))
+              ((symbol-function 'shell-maker-busy) (lambda (&rest _) busy))
+              ((symbol-function 'agent-shell-experimental--send-steering)
+               (lambda (&rest args)
+                 (funcall (plist-get args :on-outcome) outcome "agent said no")))
+              ((symbol-function 'agent-shell--render-steered-prompt)
+               (lambda (&rest _) (setq landed 'rendered)))
+              ((symbol-function 'agent-shell--insert-to-shell-buffer)
+               (lambda (&rest _) (setq landed 'submitted)))
+              ((symbol-function 'agent-shell--prompt-queue-enqueue)
+               (lambda (&rest _) (setq landed 'queued)))
+              ((symbol-function 'agent-shell--update-fragment)
+               (lambda (&rest _) (setq landed 'reported)))
+              ((symbol-function 'agent-shell--echo) #'ignore)
+              ((symbol-function 'agent-shell--emit-event) #'ignore))
+      (agent-shell--prompt-queue-steer :prompt "actually, just the filenames"))
+    landed))
+
+(ert-deftest agent-shell--prompt-queue-steer-test ()
+  "Test `agent-shell--prompt-queue-steer' keeps the prompt on every outcome."
+  (should (eq (agent-shell-tests--steer-outcome :outcome 'injected) 'rendered))
+  ;; The turn had ended and the agent handed the prompt back, so send it
+  ;; as an ordinary one -- unless this shell is still busy, where
+  ;; submitting would error and drop the text.  The queue drains as soon
+  ;; as the turn settles.
+  (should (eq (agent-shell-tests--steer-outcome :outcome 'prompt-required) 'submitted))
+  (should (eq (agent-shell-tests--steer-outcome :outcome 'prompt-required :busy t) 'queued))
+  (should (eq (agent-shell-tests--steer-outcome :outcome 'started-new-turn) 'reported))
+  ;; A steer that did not land must not cost the user their text.
+  (should (eq (agent-shell-tests--steer-outcome :outcome 'failed) 'queued)))
+
+(defun agent-shell-tests--render-steered-prompt (prompt)
+  "Render PROMPT into a bare shell buffer mid-turn.
+
+Returns an alist of the resulting buffer text and the `:last-entry-type'
+left behind."
+  (let* ((buffer (generate-new-buffer " *agent-shell-steer-render-test*"))
+         (fake-process (start-process "fake-agent" buffer "cat")))
+    (set-process-query-on-exit-flag fake-process nil)
+    (unwind-protect
+        (with-current-buffer buffer
+          (comint-mode)
+          (setq-local comint-prompt-regexp "^Claude> ")
+          (let ((state (list (cons :buffer (current-buffer))
+                             (cons :chunked-group-count 0)
+                             (cons :last-entry-type "agent_message_chunk")
+                             (cons :agent-config '((:shell-prompt . "Claude> "))))))
+            (cl-letf (((symbol-function 'shell-maker--process) (lambda () fake-process)))
+              ;; The turn so far: a prompt the user submitted and the
+              ;; agent's answer streaming under it.
+              (shell-maker--output-filter fake-process "Claude> ")
+              (let ((inhibit-read-only t))
+                (goto-char (point-max))
+                (insert "list the files<shell-maker-end-of-prompt>\nListing "))
+              (agent-shell--render-steered-prompt :state state :prompt prompt)
+              (list (cons :text (buffer-substring-no-properties (point-min) (point-max)))
+                    (cons :last-entry-type (map-elt state :last-entry-type))))))
+      (when (process-live-p fake-process)
+        (delete-process fake-process))
+      (kill-buffer buffer))))
+
+(ert-deftest agent-shell--render-steered-prompt-test ()
+  "Test a steered prompt renders as a closed user prompt.
+Neither adapter echoes a steered prompt back, so it is rendered here or
+it is nowhere.  The end-of-prompt marker closes it: chat mode reads the
+last prompt with no marker after it as the live one, and the prompt bar
+hides that."
+  (let ((rendered (agent-shell-tests--render-steered-prompt "just the filenames")))
+    (should (equal (map-elt rendered :text)
+                   (concat "Claude> list the files<shell-maker-end-of-prompt>\n"
+                           "Listing \n\n"
+                           "Claude> [steered] just the filenames"
+                           "<shell-maker-end-of-prompt>")))
+    ;; Not "user_message_chunk": that asks the notification dispatch to
+    ;; insert an end-of-prompt marker of its own on the next update.
+    (should-not (equal (map-elt rendered :last-entry-type) "user_message_chunk"))))
 
 (defmacro agent-shell-tests--with-rendered-shell (markdown &rest body)
   "Render MARKDOWN in a temporary shell buffer and run BODY with point at start.


### PR DESCRIPTION
Implements the steering proposal from #773.

When the agent advertises steering and a turn is running, a prompt sent from the
shell is injected into that turn instead of being queued until it ends. Agents
that don't advertise it queue exactly as before.

The method is `_session/steering` — an ACP extension rather than spec (hence the
leading underscore), advertised in the `initialize` response's top-level `_meta`
as `steering.supported`, a sibling of `agentCapabilities`. Verified against
`@agentclientprotocol/claude-agent-acp` 0.66.0 and `@agentclientprotocol/codex-acp`
1.2.0. The standards-track equivalent, `session/inject`
(agentclientprotocol/agent-client-protocol#1261), is unmerged and targets ACP v2,
so the extension is what's usable today.

**Queueing stays the fallback and nothing is lost.** A steer is attempted only
when the agent advertises it, `agent-shell-steer-when-busy` is on, and a turn is
running that isn't blocked on a permission answer. Every other outcome — the turn
had ended, the agent refused, the request failed — either submits the prompt
normally or puts it back on the queue. A shell waiting on a permission answer
keeps queueing deliberately: what an agent does with a message injected while a
tool sits on that question isn't defined by any implementation I could find.

Entry points:

- Sending from a busy shell steers automatically.
- `C-u M-x agent-shell-prompt-queue` queues that one prompt instead.
- `M-x agent-shell-steer` steers explicitly and errors when it can't.
- `agent-shell-steer-when-busy` (the one new defcustom, since #773 asked for
  opt-out) turns the automatic behaviour off entirely.

Neither adapter echoes a steered prompt back while the turn runs, so it's rendered
client-side, reusing the field/face shape already used for replayed user messages
and closed with shell-maker's end-of-prompt marker — without that, chat mode reads
it as the live prompt and the prompt bar hides it. Also adds a `prompt-steered`
session event.

**On automating cancel-and-resend instead** (your comment in the issue): I don't
think they're equivalent. Interrupting drops the work in flight and leaves a
cancellation in the transcript, while a steer keeps the turn and what it has
already done. They compose, though — `agent-shell-steer` could fall back to
interrupt-and-continue for agents that don't advertise steering, which is what
@liaowang11 suggested. Happy to do that as a follow-up if you'd like it.

Behaviour differs per agent, worth knowing before trying it: Claude interrupts
what it's generating and answers in a couple of seconds; Codex accepts the steer
but finishes the message in flight first.

Testing: five tests covering the request shape, outcome mapping, the decision to
steer, the four-way fallback (including that a failed steer keeps the prompt), and
the rendered prompt. Full suite passes at 568.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
