### PR TITLE
Link the file references agents cite in prose

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -425,6 +425,10 @@ body un-fontified."
         ;; After the markup passes, so a URL already consumed as a
         ;; `[title](url)' destination or an image's is not seen again.
         (agent-shell-markdown--linkify-urls :avoid-ranges avoid-ranges)
+        ;; Fenced blocks alone, not AVOID-RANGES: a citation is nearly
+        ;; always inside an inline `code' span, which those would skip.
+        (agent-shell-markdown--linkify-file-references
+         :avoid-ranges source-ranges)
         (agent-shell-markdown--style-dividers :avoid-ranges avoid-ranges)
         (agent-shell-markdown--style-blockquotes :avoid-ranges avoid-ranges)
         (agent-shell-markdown--style-lists :avoid-ranges avoid-ranges)
@@ -1064,6 +1068,69 @@ there opens it in the browser."
     (agent-shell-markdown--apply-link-properties
      :start start :end end
      :url (buffer-substring-no-properties start end))))
+
+(defconst agent-shell-markdown--file-reference-regexp
+  (rx (one-or-more (any alnum "_./+~-"))
+      ":" (one-or-more digit)
+      (optional "-" (optional "L") (one-or-more digit)))
+  "Regexp matching a file reference as an agent cites one in prose.
+
+A path followed by a line, optionally a line range: \"foo.el:12\" or
+\"foo.el:12-20\".  A cited column is left out of the match, so
+\"foo.el:12:5\" links its line and leaves \":5\" as text.  Deliberately loose
+about what a path looks like -- what makes a match a reference is that
+it resolves to a file that exists, which
+`agent-shell-markdown--linkify-file-reference' checks.")
+
+(cl-defun agent-shell-markdown--linkify-file-references (&key avoid-ranges)
+  "Face the file references in prose as links, openable from the buffer.
+
+Agents cite their sources as `docs/audit.md:500' rather than as
+markdown links, so the citation renders as plain text and there is no
+way to reach the file it names.  Each one gains what any rendered link
+carries (see `agent-shell-markdown--apply-link-properties'), including
+a target `agent-shell-markdown--open-local-link' resolves, so RET opens
+the file on that line and item navigation stops there.
+
+References inside any of AVOID-RANGES are left alone, which callers
+pass as the fenced blocks alone: a path inside one is sample content or
+command output rather than a citation.  Inline `code' spans are
+deliberately not avoided -- backticks are how agents write these
+references, so skipping them would skip nearly every reference there
+is.
+
+For example, the buffer \"see `foo.el:12` now\" keeps its text, with
+\"foo.el:12\" faced and openable."
+  (let ((case-fold-search nil))
+    (goto-char (point-min))
+    (while (re-search-forward agent-shell-markdown--file-reference-regexp nil t)
+      (let ((start (match-beginning 0))
+            (end (match-end 0)))
+        (if-let* ((avoid (agent-shell-markdown-in-avoid-range-p
+                          start end avoid-ranges)))
+            (goto-char (cdr avoid))
+          (agent-shell-markdown--linkify-file-reference start end))))))
+
+(defun agent-shell-markdown--linkify-file-reference (start end)
+  "Give the reference on [START, END) the properties a rendered link carries.
+
+A no-op when the text already carries a link\='s target, which is where
+an earlier pass rendered a `[title](foo.el:12)' destination, or when
+the path names no file that exists.
+
+The body of an inline `code' span is tagged
+`agent-shell-markdown-frozen', and a reference is usually inside one.
+That tag keeps later passes from re-parsing text whose markup has
+already been resolved; adding properties re-parses nothing, so it
+doesn\='t apply here.
+
+For example, over the reference in \"see foo.el:12 now\", RET opens
+`foo.el' on line 12."
+  (let ((reference (buffer-substring-no-properties start end)))
+    (when (and (not (get-text-property start 'agent-shell-markdown-url))
+               (agent-shell-markdown--parse-local-link reference))
+      (agent-shell-markdown--apply-link-properties
+       :start start :end end :url reference))))
 
 (defun agent-shell-markdown--image-attributes-pending-p (pos)
   "Return non-nil when an image ending at POS may still gain `{...}' attributes.

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -4278,3 +4278,67 @@ for a fully-selected buffer."
 (provide 'agent-shell-markdown-tests)
 
 ;;; agent-shell-markdown-tests.el ends here
+
+(ert-deftest agent-shell-markdown-linkify-file-reference-in-inline-code-test ()
+  "Test a cited `FILE:LINE' is linked, inside backticks or in prose.
+
+Agents nearly always wrap a citation in backticks, and an inline `code'
+body is tagged `agent-shell-markdown-frozen', so a pass honouring that
+tag would leave almost every reference plain."
+  (let* ((directory (make-temp-file "agent-shell-refs" t))
+         (default-directory directory)
+         (file (expand-file-name "foo.el" directory)))
+    (unwind-protect
+        (progn
+          (with-temp-file file (insert "one\ntwo\nthree\n"))
+          (with-temp-buffer
+            (insert "see `foo.el:2` and foo.el:3 here\n")
+            (agent-shell-markdown-replace-markup :force t :complete t)
+            (goto-char (point-min))
+            (search-forward "foo.el:2")
+            (should (equal "foo.el:2"
+                           (get-text-property (match-beginning 0)
+                                              'agent-shell-markdown-url)))
+            (search-forward "foo.el:3")
+            (should (equal "foo.el:3"
+                           (get-text-property (match-beginning 0)
+                                              'agent-shell-markdown-url)))))
+      (delete-directory directory t))))
+
+(ert-deftest agent-shell-markdown-linkify-file-reference-needs-a-file-test ()
+  "Test prose that merely reads like a citation stays prose.
+
+The path is what decides: matching the shape is not enough, since
+ordinary text and version numbers land on it too."
+  (let* ((directory (make-temp-file "agent-shell-refs" t))
+         (default-directory directory))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "absent.el:2 and `nope/missing.txt:10-20` stay text\n")
+          (agent-shell-markdown-replace-markup :force t :complete t)
+          (should-not (text-property-not-all (point-min) (point-max)
+                                             'agent-shell-markdown-url nil)))
+      (delete-directory directory t))))
+
+(ert-deftest agent-shell-markdown-linkify-file-reference-skips-fenced-blocks-test ()
+  "Test a path inside a fenced block is left alone.
+
+There it is sample content or command output rather than a citation,
+while the same path in prose alongside it is linked."
+  (let* ((directory (make-temp-file "agent-shell-refs" t))
+         (default-directory directory)
+         (file (expand-file-name "foo.el" directory)))
+    (unwind-protect
+        (progn
+          (with-temp-file file (insert "one\ntwo\nthree\n"))
+          (with-temp-buffer
+            (insert "cited foo.el:2 here\n\n```console\nfoo.el:3: matched\n```\n")
+            (agent-shell-markdown-replace-markup :force t :complete t)
+            (goto-char (point-min))
+            (search-forward "foo.el:2")
+            (should (get-text-property (match-beginning 0)
+                                       'agent-shell-markdown-url))
+            (search-forward "foo.el:3")
+            (should-not (get-text-property (match-beginning 0)
+                                           'agent-shell-markdown-url))))
+      (delete-directory directory t))))


### PR DESCRIPTION
## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature. (#781)
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

---

Draft for #781, to get a feel for things as you asked. Rewrote my advice config into a patch against agent-shell.

On the [skill](https://github.com/xenodium/emacs-skills/blob/main/skills/file-links/SKILL.md): That one is elegant! I still think the two compose rather than compete. A link your skill
produces is already handled, and this pass leaves it alone — it skips text
that already carries a link target. This is for the agents that don't emit
links - e.g.  a session where the skill isn't installed. It also
doesn't depend on the agent complying every time, which is the part I can't
verify by reading the output.

Everything needed to *follow* one of these was already there.
`--parse-local-link` reads `path:LINE` and `path:LINE-LINE`, and
`agent-shell-markdown-visit-file` opens the file, lands on the line and pushes
the origin onto xref's marker stack. What was missing was detection —
`--linkify-urls` scans `browse-url-button-regexp`, which no bare relative path
matches, so a citation never reached the code that would have handled it.

One thing worth your eye:

**Inline code.** The new pass takes the fenced blocks alone as its
avoid-ranges rather than the merged set. Nearly every citation arrives inside
backticks, so avoiding inline spans skips nearly everything. Those bodies are
tagged `agent-shell-markdown-frozen`; my reading is that the tag exists to stop
later passes re-parsing markup that's already resolved, and adding properties
re-parses nothing — but you'd know if that's a stretch. A path inside a fenced
block does stay text, on the grounds that it's sample content or command output
rather than a citation.

Asked Opus to measure the cost. Here is what we got:

Costs, on a 35k buffer with `:force t` (streaming renders narrow to the new
chunk, so this is the pessimistic case):

| | without | with |
|---|---|---|
| no references | 2.3 ms | 3.3 ms |
| 20 references | 2.5 ms | 3.8 ms |
| 400 references | 2.4 ms | 8.2 ms |

So ~1 ms per 35k is the regexp scan, and each reference on top costs ~11 µs —
about half resolving the path (`file-exists-p` and `expand-file-name`), about
half applying the link properties, which any link pays anyway.

Only the resolving half is avoidable, and only by caching. Keyed on the path
that would save about three quarters of the checks in my own buffers (656
references, 165 distinct paths); keyed on the whole reference, only a quarter.
I left it out, since the 400-reference row is a reference every 88 characters
and my real sessions run one per ~2300 — call it 0.2 ms a render. Happy to add
it if you disagree.
