### PR TITLE
Fix Dired DWIM context fallback

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -8423,7 +8423,18 @@ Buffer filename is OBVIOUS if its an image."
       (list (buffer-file-name))
     (or
      (agent-shell--dired-paths-in-region)
-     (dired-get-marked-files))))
+     (when (and obvious (equal major-mode 'dired-mode))
+       (agent-shell--dired-marked-files))
+     (unless obvious
+       (dired-get-marked-files)))))
+
+(defun agent-shell--dired-marked-files ()
+  "Return Dired marked files, or nil when no files are explicitly marked."
+  (when (equal major-mode 'dired-mode)
+    (let ((files (dired-get-marked-files nil nil nil t)))
+      (cond
+       ((eq (car-safe files) t) (cdr files))
+       ((cdr files) files)))))
 
 (defun agent-shell--dired-paths-in-region ()
   "If `dired' buffer, return region files.  nil otherwise."
@@ -9522,13 +9533,14 @@ Tries flymake first, then flycheck."
   "Get the current line as insertable text, ready for sending to agent.
 
 Uses AGENT-CWD to shorten file paths where necessary."
-  (save-excursion
-    (let ((start (line-beginning-position))
-          (end (line-end-position)))
-      (goto-char start)
-      (set-mark end)
-      (activate-mark)
-      (agent-shell--get-region-context :deactivate t :no-error t :agent-cwd agent-cwd))))
+  (unless (equal major-mode 'dired-mode)
+    (save-excursion
+      (let ((start (line-beginning-position))
+            (end (line-end-position)))
+        (goto-char start)
+        (set-mark end)
+        (activate-mark)
+        (agent-shell--get-region-context :deactivate t :no-error t :agent-cwd agent-cwd)))))
 
 (cl-defun agent-shell--context (&key shell-buffer)
   "Return context (if available).  Nil otherwise.

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -3619,6 +3619,62 @@ other unknown ones."
                                         (point-min) (point-max))))))
       (delete-directory temp-dir t))))
 
+(ert-deftest agent-shell--buffer-files-obvious-dired-ignores-current-line-test ()
+  "DWIM file context should not use Dired's current line by accident."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (file (expand-file-name "README.org" temp-dir))
+         dired-buffer)
+    (unwind-protect
+        (progn
+          (write-region "" nil file nil 'no-message)
+          (setq dired-buffer (dired-noselect temp-dir))
+          (with-current-buffer dired-buffer
+            (goto-char (point-min))
+            (search-forward "README.org")
+            (should-not (agent-shell--buffer-files :obvious t))
+            (should (equal (agent-shell--buffer-files)
+                           (list file)))))
+      (when (buffer-live-p dired-buffer)
+        (kill-buffer dired-buffer))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--buffer-files-obvious-dired-uses-marked-files-test ()
+  "DWIM file context should use explicitly marked Dired files."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (file (expand-file-name "README.org" temp-dir))
+         dired-buffer)
+    (unwind-protect
+        (progn
+          (write-region "" nil file nil 'no-message)
+          (setq dired-buffer (dired-noselect temp-dir))
+          (with-current-buffer dired-buffer
+            (goto-char (point-min))
+            (search-forward "README.org")
+            (dired-mark 1)
+            (should (equal (agent-shell--buffer-files :obvious t)
+                           (list file)))))
+      (when (buffer-live-p dired-buffer)
+        (kill-buffer dired-buffer))
+      (delete-directory temp-dir t))))
+
+(ert-deftest agent-shell--context-dired-ignores-current-line-test ()
+  "DWIM context should not insert raw Dired listing lines."
+  (let* ((temp-dir (make-temp-file "agent-shell-test" t))
+         (git-dir (expand-file-name ".git" temp-dir))
+         (agent-shell-context-sources '(files line))
+         dired-buffer)
+    (unwind-protect
+        (progn
+          (make-directory git-dir)
+          (setq dired-buffer (dired-noselect temp-dir "-la"))
+          (with-current-buffer dired-buffer
+            (goto-char (point-min))
+            (search-forward ".git")
+            (should-not (agent-shell--context))))
+      (when (buffer-live-p dired-buffer)
+        (kill-buffer dired-buffer))
+      (delete-directory temp-dir t))))
+
 (ert-deftest agent-shell--on-request-calls-permission-request-handler-test ()
   "Test `agent-shell--on-request' calls handler and :respond auto-approves."
   (with-temp-buffer


### PR DESCRIPTION
Dired's current-line fallback is useful for explicit file sending, but it should not count as obvious context when starting or reusing a shell.

Only use region-selected or explicitly marked Dired files for automatic file context, and skip current-line context in Dired so raw listing rows are not inserted into prompts.

Note: I am not really good at writing elisp code. This commit has been created with the assistance of an AI agent (OpenAI Codex). I do understand the code, but there might be better ways to improve the situation. It works for me - I am typically starting agent-shell sessions from dired buffers without selecting entries (files, directories, etc.).

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for ~a new feature~ the observed behavior: #788 
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
