### PR TITLE
Mark restored prompts with comint-highlight-prompt

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -3008,7 +3008,7 @@ Clears STATE's `:expanded-activity-group'."
                           (concat (propertize
                                    (map-nested-elt
                                     state '(:agent-config :shell-prompt))
-                                   'font-lock-face 'agent-shell-prompt
+                                   'font-lock-face '(agent-shell-prompt comint-highlight-prompt)
                                    'field 'output)
                                   (propertize content-text
                                               'font-lock-face 'agent-shell-input))


### PR DESCRIPTION
Thank you for contributing to agent-shell!

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

## The bug

After restoring a session, `C-c C-o` on a restored interaction silently
shows the *previous* one in the viewport. No error, nothing in
`*Messages*`.

## Why

`agent-shell.el:3011` renders the prompt prefix for a `user_message_chunk`
replayed during `session/load`. Its own comment says it means to match the
field/face shape comint emits for a live prompt, but it applies
`agent-shell-prompt` alone.

That face *inherits* `comint-highlight-prompt`, so the prompt looks
correct. But `shell-maker--re-search-forward-prompt` matches with
`(memq 'comint-highlight-prompt (ensure-list ...))`, and inheritance
doesn't satisfy `memq`. The restored interaction never enters
`shell-maker--extract-history`, so `agent-shell-interaction-at-point`
returns nil — and `agent-shell-viewport-refresh` guards its entire body on
that value, so it does nothing at all.

Same applies to `session/push`, which goes through the same branch.

## The fix

Append the face rather than substitute it.

`agent-shell-prompt` stays first for precedence and remains customizable,
and downstream packages matching on it with `memq` (there are tsome) keep working.

## Verified

Against `shell-maker--re-search-forward-prompt` on the rendered prompt
text:

```
agent-shell-prompt                             -> not found
(agent-shell-prompt comint-highlight-prompt)   -> found
```

No tests added since I think the change is trivial, but happy to add one. The existing suite
passes.
