### PR TITLE
docs: add agent-shell-queue link

### DIFF
--- a/README.org
+++ b/README.org
@@ -98,6 +98,7 @@ We now have a handful of additional packages to extend the =agent-shell= experie
 - [[https://github.com/wandersoncferreira/agent-shell-dashboard][agent-shell-dashboard]]: A landing page for =agent-shell=.
 - [[https://github.com/SreenivasVRao/agent-shell-hq][agent-shell-hq]]: A heads-up display and peek interface for managing multiple =agent-shell= sessions, organized by project.
 - [[https://github.com/Jamie-Cui/agent-shell-permission-transient][agent-shell-permission-transient]]: A compact Transient interface for responding to queued agent-shell permission requests.
+- [[https://github.com/tychoish/agent-shell-queue][agent-shell-queue]]: A flexible prompt/shell queue for =agent-shell= sessions.
 
 * Articles
 - 20Y: [[https://20y.hu/~slink/journal/agent-shell/index.html][Agentic development workflow in Emacs]]


### PR DESCRIPTION
I've been working on this for (months) and it works pretty well (and I use it every day,) but I've been avoiding making a patch to add this because I was stuck in a loop of letting the perfect be the enemy of the good. For reasons unknown, I've decided to get over myself, and submit this. But if you want me to take a different appraoch, or wait a while, I'm happy to.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- I've filed a feature request/discussion for a new feature.

  Doesn't feel like it's big enough, and a ticket feels like it would create more noise/work. If you want I definitely can.

- I'm making visual changes, so I'm including screenshots so you can view and discuss.
- I've added tests where applicable.
- [x] I've updated documentation where necessary.
- I've run `M-x checkdoc` and `M-x byte-compile-file`.
