### PR TITLE
Strip copies in the substring filter, not via yank-handler

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -2096,9 +2096,13 @@ If DELETE is non-nil, delete the text between START and END.
 
 A paste elsewhere should give plain characters rather than agent-shell's
 implementation, so every text property is dropped: our faces, keymaps,
-cursor sensors, display overrides and internal markers all go.  The one
-kept is `yank-handler', which rewrites content on insertion rather than
-decorating it (see `agent-shell--block-quote').
+cursor sensors, display overrides and internal markers all go.  One
+\"> \" per line goes too, from text `agent-shell--block-quote' marked,
+so a quoted reply copies as the plain text it shows.
+
+Deciding this at copy time rather than on insertion keeps one copy
+meaning one thing: a `yank-handler' would rewrite for `yank' while the
+system clipboard and isearch kept the raw \"> \".
 
 `agent-shell-markdown-replace-markup' renders by rewriting markup in
 place, so the buffer already holds rendered text and there is nothing
@@ -2138,16 +2142,14 @@ mouse selection or a kill where mark > point) is normalized."
                             'indicator)
                     (replace-match "▼" t t)))
                 (buffer-string)))))
-    (let ((pos 0))
-      (while (< pos (length text))
-        (let ((next (or (next-single-property-change pos 'yank-handler text)
-                        (length text)))
-              (handler (get-text-property pos 'yank-handler text)))
-          (set-text-properties pos next
-                               (when handler (list 'yank-handler handler))
-                               text)
-          (setq pos next))))
-    text))
+    ;; One "> " per line, matching what the block quote inserted, so
+    ;; quoting already-quoted text keeps the inner level.
+    (substring-no-properties
+     (replace-regexp-in-string
+      (rx line-start "> ")
+      (lambda (match)
+        (if (get-text-property 0 'agent-shell-block-quote match) "" match))
+      text nil t))))
 
 (defvar-keymap agent-shell-mode-map
   :parent shell-maker-mode-map
@@ -9714,8 +9716,9 @@ When DEACTIVATE is non-nil, deactivate region/selection."
   "Return TEXT with each line prefixed by \"> \", displayed as a bar.
 
 Underlying text keeps the \"> \" so it remains valid markdown;
-the bar is a display-only override.  Yanks strip both the bar
-styling and the leading \"> \" so paste gives plain text."
+the bar is a display-only override.  The `agent-shell-block-quote'
+property tells `agent-shell--filter-buffer-substring' to drop the
+\"> \" from copies so paste gives plain text."
   (let* ((bar      (propertize "▌" 'face 'agent-shell-markdown-blockquote))
          (wrap     (propertize "▌ " 'face 'agent-shell-markdown-blockquote))
          (quoted   (concat "> " (replace-regexp-in-string
@@ -9726,12 +9729,7 @@ styling and the leading \"> \" so paste gives plain text."
      0 (length rendered)
      (list 'wrap-prefix wrap
            'face 'agent-shell-markdown-blockquote
-           'yank-handler
-           (list (lambda (s)
-                   (insert
-                    (replace-regexp-in-string
-                     (rx line-start "> ") ""
-                     (substring-no-properties s))))))
+           'agent-shell-block-quote t)
      rendered)
     (while (string-match (rx line-start ">") rendered pos)
       (put-text-property (match-beginning 0) (match-end 0)

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -4224,20 +4224,40 @@ markers."
         (should-not (text-properties-at pos copied))
         (setq pos (1+ pos))))))
 
-(ert-deftest agent-shell-filter-buffer-substring-keeps-yank-handler ()
-  "Copying keeps `yank-handler', which rewrites content rather than styling it.
-`agent-shell--block-quote' leans on it to drop the leading \"> \" on
-paste, so stripping it would silently paste the markdown prefix."
+(ert-deftest agent-shell-filter-buffer-substring-strips-block-quote-prefix ()
+  "Copying quoted text drops the \"> \" `agent-shell--block-quote' added."
   (with-temp-buffer
     (insert (agent-shell--block-quote "hello\nworld"))
+    (should (equal (agent-shell--filter-buffer-substring (point-min) (point-max))
+                   "hello\nworld"))))
+
+(ert-deftest agent-shell-filter-buffer-substring-strips-one-quote-level ()
+  "Quoting already-quoted text keeps the inner \"> \" on copy."
+  (with-temp-buffer
+    (insert (agent-shell--block-quote "> hello"))
+    (should (equal (agent-shell--filter-buffer-substring (point-min) (point-max))
+                   "> hello"))))
+
+(ert-deftest agent-shell-filter-buffer-substring-keeps-rendered-block-quote ()
+  "Markdown blockquotes copy with their \"> \" so the source round-trips."
+  (with-temp-buffer
+    (insert "> hello\n")
+    (agent-shell-markdown-replace-markup)
+    (should (equal (agent-shell--filter-buffer-substring (point-min) (point-max))
+                   "> hello\n"))))
+
+(ert-deftest agent-shell-filter-buffer-substring-block-quote-copies-alike ()
+  "A quoted reply copies the same whatever consumes it.
+The `yank-handler' this replaced rewrote text for `yank' only, so the
+system clipboard and isearch kept a \"> \" that `C-y' dropped."
+  (with-temp-buffer
+    (insert (agent-shell--block-quote "hello"))
     (let ((copied (agent-shell--filter-buffer-substring (point-min) (point-max))))
-      (should (equal copied "> hello\n> world"))
-      (should-not (get-text-property 0 'face copied))
-      (should (get-text-property 0 'yank-handler copied))
+      (should (equal copied "hello"))
       (should (equal (with-temp-buffer
                        (insert-for-yank copied)
                        (buffer-substring-no-properties (point-min) (point-max)))
-                     "hello\nworld")))))
+                     copied)))))
 
 (ert-deftest agent-shell-filter-buffer-substring-handles-reversed-range ()
   "A reversed range yields the same text as the forward one.


### PR DESCRIPTION
## Problem

Rendered output and block-quoted replies carry a `yank-handler` text property
whose lambda strips properties (and the leading `> `) at paste time. The
property rides on the characters, which has surprising reach:

- Once the text lands in any other buffer, copies from *there* still run
  agent-shell's lambda - for the rest of the session, in buffers unrelated to
  agent-shell.
- `insert-for-yank` is not just `C-y`: registers, rectangles, `cua`, xterm
  paste, and any third-party property-preserving insertion all hit the handler.
- The same `M-w` yields different content depending on destination: `C-y`
  gives `hello`, while the OS clipboard and isearch's `C-s C-y` keep the
  stored `> hello`. `yank-excluded-properties` is never consulted for handler
  text, so no setting affects any of this.

## Change

Delete both `yank-handler` puts and finish the job in
`agent-shell--filter-buffer-substring`, which shell and viewport buffers
already install as `filter-buffer-substring-function` - the hook Emacs
provides for deciding what a copy of a buffer yields. Copies now come out
property-free, and one `> ` per line is dropped from text tagged with a
private `agent-shell-block-quote` marker (set by `agent-shell--block-quote`
in place of the handler). The decision happens once, at copy time, in buffers
agent-shell owns; paste stays stock Emacs.

## Behaviour

`M-w`, `C-w`, mouse copy, and registers out of agent-shell buffers paste the
same as before. Markdown-rendered blockquotes still keep their `> ` on copy,
so the source round-trips. Two visible changes, both toward consistency:

- Copies of block-quoted replies are now identical everywhere. Previously the
  OS clipboard and isearch kept the `> ` that yank removed.
- Strings from the standalone `agent-shell-markdown-convert` API, killed from
  non-agent-shell buffers, now paste with stock Emacs semantics. No in-tree
  caller does this. Happy to gate it behind a keyword if you'd rather keep
  the old behaviour there.

## Context

Found while speech-enabling agent-shell with Emacspeak: its speech layer
inserts buffer text via `insert-for-yank` precisely to keep the text
properties it builds voices from, and the handler strips them. Any consumer
using `insert-for-yank` for property-preserving insertion hits the same wall,
and a buffer-local filter cannot break them.

Tests: the yank test is rewritten as filter tests - properties stripped,
`> ` dropped from quoted replies, one level per line for nested quotes,
markdown blockquotes keep theirs. Full suite passes.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature. (N/A - bug-ish cleanup, no new feature)
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss. (N/A - no visual changes)
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary. (docstrings updated)
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
