### PR TITLE
Fix chat prompt indentation

### DIFF
--- a/agent-shell-chat-mode.el
+++ b/agent-shell-chat-mode.el
@@ -161,7 +161,7 @@ so a label following it needs a full pad rather than a single newline."
     (or (= beg (point-min))
         (eq (char-before beg) ?\n))))
 
-(cl-defun agent-shell-chat--ensure-overlay (&key tag beg end props
+(cl-defun agent-shell-chat--ensure-overlay (&key tag beg end props rear-advance
                                                  (anchor-beg beg)
                                                  (anchor-end end))
   "Ensure a TAG overlay spans BEG..END carrying PROPS.
@@ -180,13 +180,19 @@ changed, leaves an unchanged buffer untouched: relabeling runs on every
 agent event, and each overlay write dirties its span for redisplay.
 
 ANCHOR-BEG..ANCHOR-END default to the span, and are widened only where
-an overlay is expected to sit somewhere its span no longer covers."
+an overlay is expected to sit somewhere its span no longer covers.
+
+With REAR-ADVANCE non-nil the overlay takes in text inserted at its end
+and is not `evaporate'd while empty, so it can hold properties over an
+input still being typed: relabeling is event-driven, so an overlay that
+stopped at the caret would never grow to cover what follows it."
   (let ((overlay (or (seq-find (lambda (overlay)
                                  (eq (overlay-get overlay 'agent-shell-chat--tag) tag))
                                (overlays-in anchor-beg (max anchor-end (1+ anchor-beg))))
-                     (let ((created (make-overlay beg end)))
+                     (let ((created (make-overlay beg end nil nil rear-advance)))
                        (overlay-put created 'agent-shell-chat--tag tag)
-                       (overlay-put created 'evaporate t)
+                       (unless rear-advance
+                         (overlay-put created 'evaporate t))
                        created))))
     (unless (and (= (overlay-start overlay) beg) (= (overlay-end overlay) end))
       (move-overlay overlay beg end))
@@ -195,6 +201,35 @@ an overlay is expected to sit somewhere its span no longer covers."
                 (overlay-put overlay property value)))
             props)
     overlay))
+
+(defun agent-shell-chat--draft-tail-indent (beg end)
+  "Return the indent a draft spanning BEG..END needs on its last line.
+
+A `line-prefix' hangs off the character a display row starts from, and a
+draft ending in a newline has none there: that row starts at end of
+buffer.  The caret would sit flush left until the first character landed
+to carry the prefix.  A string standing at that position indents the row
+instead, and gives way (to \"\") the moment there is a character for the
+prefix itself.
+
+For example, over a draft of \"one\\n\" returns the body indent, and over
+\"one\" returns \"\"."
+  (if (and (> end beg) (eq (char-before end) ?\n))
+      agent-shell-chat--body-indent
+    ""))
+
+(defun agent-shell-chat--draft-changed (draft after &rest _)
+  "Re-indent DRAFT's last line once a change to it has landed.
+
+Runs from DRAFT's own modification hooks, AFTER being non-nil once the
+change is in.  Kept off the relabel path: relabeling is event-driven and
+coalesced, so none runs between the newline that empties the last line
+and the character that fills it."
+  (when after
+    (let ((indent (agent-shell-chat--draft-tail-indent
+                   (overlay-start draft) (overlay-end draft))))
+      (unless (equal (overlay-get draft 'after-string) indent)
+        (overlay-put draft 'after-string indent)))))
 
 (defun agent-shell-chat--gc-overlays (tags kept)
   "Delete label overlays of TAGS not in KEPT (a list of overlays).
@@ -439,6 +474,32 @@ above, putting the first line of a multi-line input out of reach of
                                (if (and label-nl (not marker)) input-indent ""))
                          (cons 'wrap-prefix (if label-nl input-indent ""))))
            kept)
+          ;; Indent the live prompt's draft below its first line, which the
+          ;; marker indents.  The overlay above covers the prompt text alone,
+          ;; so no row starting past it -- a wrapped one, or one a typed
+          ;; newline began -- ever sees a prefix of its own.  Rear-advancing
+          ;; and anchored at the input's start: it has to be in place, and
+          ;; grow, as characters arrive, since no relabel runs while typing.
+          (when (and live labeled)
+            (push
+             (agent-shell-chat--ensure-overlay
+              :tag 'me-draft :beg run-end :end (point-max)
+              :rear-advance t
+              :props (list (cons 'line-prefix agent-shell-chat--body-indent)
+                           (cons 'wrap-prefix agent-shell-chat--body-indent)
+                           ;; Indents a last line left empty by a newline,
+                           ;; which the prefix cannot reach.  The hooks keep
+                           ;; it in step with what is typed.
+                           (cons 'after-string
+                                 (agent-shell-chat--draft-tail-indent
+                                  run-end (point-max)))
+                           (cons 'modification-hooks
+                                 (list #'agent-shell-chat--draft-changed))
+                           (cons 'insert-in-front-hooks
+                                 (list #'agent-shell-chat--draft-changed))
+                           (cons 'insert-behind-hooks
+                                 (list #'agent-shell-chat--draft-changed))))
+             kept))
           ;; Indent a submitted turn's input so it aligns with the response
           ;; body.  The live prompt (input flows after the marker) and empty
           ;; prompts have no input to indent.
@@ -462,7 +523,7 @@ above, putting the first line of a multi-line input out of reach of
           (setq runs (cdr runs))))
       ;; Drop stale labels whose prompt run was deleted (e.g. a live prompt a
       ;; `session/push' removed) and which no label above reached.
-      (agent-shell-chat--gc-overlays '(me me-label me-surplus me-input)
+      (agent-shell-chat--gc-overlays '(me me-label me-surplus me-input me-draft)
                                      kept)
       ;; Labels from before chat overlays stopped using `category': an upgrade
       ;; reloads this file into a running session (see
@@ -665,7 +726,7 @@ too."
     (agent-shell-unsubscribe :subscription agent-shell-chat--subscription))
   (when (timerp agent-shell-chat--relabel-timer)
     (cancel-timer agent-shell-chat--relabel-timer))
-  (dolist (tag '(me me-label me-surplus me-input agent))
+  (dolist (tag '(me me-label me-surplus me-input me-draft agent))
     (remove-overlays (point-min) (point-max) 'agent-shell-chat--tag tag))
   ;; Labels from before chat overlays stopped using `category'.
   ;; TODO: Remove after 2026-09-28 (see `agent-shell-chat--label-prompts').

--- a/tests/agent-shell-chat-mode-tests.el
+++ b/tests/agent-shell-chat-mode-tests.el
@@ -53,6 +53,12 @@ there."
                     (overlays-in (point-min) (point-max)))
         (lambda (a b) (< (overlay-start a) (overlay-start b)))))
 
+(defun agent-shell-chat-mode-tests--draft-overlay ()
+  "Return the overlay indenting the live prompt's draft, or nil."
+  (seq-find (lambda (overlay)
+              (eq (overlay-get overlay 'agent-shell-chat--tag) 'me-draft))
+            (overlays-in (point-min) (point-max))))
+
 (defun agent-shell-chat-mode-tests--agent-overlays ()
   "Return the agent label overlays in the current buffer."
   (seq-filter (lambda (overlay)
@@ -559,10 +565,67 @@ of a line, and that is where the covered prompt sits."
                                (eq (overlay-get overlay 'agent-shell-chat--tag)
                                    'me-input))
                              (overlays-in (point-min) (point-max)))))
-      ;; Only the submitted turn gets an indent overlay; the live prompt does not.
+      ;; Only the submitted turn gets an indent overlay; the live prompt's
+      ;; draft is covered by its own.
       (should (= 1 (length input)))
       (should (equal agent-shell-chat--body-indent
                      (overlay-get (car input) 'line-prefix))))))
+
+(ert-deftest agent-shell-chat-live-draft-indented-test ()
+  "The live prompt's draft carries the body indent below its first line.
+The marker indents the first line; this indents the lines under it, which
+the overlay covering the prompt text cannot reach.  It is in place before
+anything is typed and takes in what follows, since no relabel runs per
+keystroke."
+  (agent-shell-chat-mode-tests--with-shell
+    (agent-shell-chat-mode-tests--prompt "Claude> ")
+    (let ((agent-shell-prompt-bar-mode nil))
+      (agent-shell-chat--relabel))
+    (let ((draft (agent-shell-chat-mode-tests--draft-overlay)))
+      (should draft)
+      (should (equal agent-shell-chat--body-indent
+                     (overlay-get draft 'line-prefix)))
+      (should (equal agent-shell-chat--body-indent
+                     (overlay-get draft 'wrap-prefix)))
+      ;; Empty while nothing is typed, and grows with what is.
+      (should (= (overlay-start draft) (overlay-end draft)))
+      (goto-char (point-max))
+      (insert "first line\nsecond line")
+      (should (= (overlay-end draft) (point-max))))))
+
+(ert-deftest agent-shell-chat-draft-empty-last-line-indented-test ()
+  "A newline in the draft leaves its empty last line indented too.
+That line starts at end of buffer, where there is no character to carry
+the draft's `line-prefix', so the caret would sit flush left until the
+next one arrived.  A string standing there indents it meanwhile, and
+steps aside once a character can carry the prefix.  The draft's own
+modification hooks keep this in step, since no relabel runs while a
+prompt is being typed."
+  (agent-shell-chat-mode-tests--with-shell
+    (agent-shell-chat-mode-tests--prompt "Claude> ")
+    (let ((agent-shell-prompt-bar-mode nil))
+      (agent-shell-chat--relabel))
+    (let ((draft (agent-shell-chat-mode-tests--draft-overlay)))
+      (should draft)
+      (goto-char (point-max))
+      (should (equal "" (overlay-get draft 'after-string)))
+      (insert "one")
+      (should (equal "" (overlay-get draft 'after-string)))
+      (insert "\n")
+      (should (equal agent-shell-chat--body-indent
+                     (overlay-get draft 'after-string)))
+      ;; The first character of the new line takes over.
+      (insert "t")
+      (should (equal "" (overlay-get draft 'after-string)))
+      ;; Deleting back to the empty line brings it back.
+      (delete-char -1)
+      (should (equal agent-shell-chat--body-indent
+                     (overlay-get draft 'after-string)))
+      ;; A relabel mid-draft leaves it alone.
+      (let ((agent-shell-prompt-bar-mode nil))
+        (agent-shell-chat--relabel))
+      (should (equal agent-shell-chat--body-indent
+                     (overlay-get draft 'after-string))))))
 
 (ert-deftest agent-shell-chat-empty-submission-hidden-test ()
   "An empty submission (a prompt with another below it) is not labeled.


### PR DESCRIPTION
Fixes chat prompt alignment after the first line. 

- Subsequent lines are now indented to column 2
- This matches the submitted prompt indentation

Before:

<img width="284" height="179" alt="Screenshot 2026-08-31 at 15 52 24" src="https://github.com/user-attachments/assets/c58900a1-d0e1-4b4b-a9b5-688241bec705" />

After:

<img width="289" height="176" alt="Screenshot 2026-08-31 at 15 53 31" src="https://github.com/user-attachments/assets/d9982851-8bb9-48ca-8cb4-aa80a2c486b2" />

<img width="499" height="271" alt="Screenshot 2026-08-31 at 15 55 34" src="https://github.com/user-attachments/assets/ebed8277-7a05-4dd4-8cb2-8a3e71c410a0" />

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
