### PR TITLE
Label user and agent turns in `agent-shell-copy-as-markdown`

### DIFF
--- a/agent-shell-chat-mode.el
+++ b/agent-shell-chat-mode.el
@@ -47,8 +47,11 @@
 
 (declare-function agent-shell-subscribe-to "agent-shell")
 (declare-function agent-shell-unsubscribe "agent-shell")
+(declare-function agent-shell--agent-label "agent-shell")
+(declare-function agent-shell--prompt-face-p "agent-shell")
 
 (defvar agent-shell--state)
+(defvar agent-shell-user-label)
 ;; Soft reference: `agent-shell-prompt-bar-mode' may be unbound when the
 ;; prompt bar is not loaded.  Read it with `bound-and-true-p'.
 (defvar agent-shell-prompt-bar-mode)
@@ -116,27 +119,6 @@ FACE carries the box (see `agent-shell-chat-me-label').
 For example, (agent-shell-chat--label \"Me\" \\='agent-shell-chat-me-label)
 returns \" Me \" in that face."
   (propertize (format " %s " text) 'face face))
-
-(defun agent-shell-chat--agent-name ()
-  "Return the attached agent's display name for the response label.
-
-For example, with a mode-line name of \"Claude\" returns \"Claude\";
-with none available, returns \"Agent\"."
-  (or (map-nested-elt agent-shell--state '(:agent-config :mode-line-name))
-      "Agent"))
-
-(defun agent-shell-chat--prompt-face-p (value)
-  "Return non-nil when a `font-lock-face' VALUE marks a shell prompt.
-A live prompt carries `comint-highlight-prompt'; a restored or echoed
-prompt carries `agent-shell-prompt' (which inherits it).  Either may be
-repeated.
-
-For example, \\='comint-highlight-prompt, \\='agent-shell-prompt, and
-\\='(comint-highlight-prompt comint-highlight-prompt) all return non-nil,
-while \\='default returns nil."
-  (let ((faces (if (listp value) value (list value))))
-    (or (memq 'comint-highlight-prompt faces)
-        (memq 'agent-shell-prompt faces))))
 
 (defun agent-shell-chat--extends-bg-p (face)
   "Return non-nil when FACE paints an `:extend' background past end of line.
@@ -212,7 +194,7 @@ whitespace separates them."
       (while (< pos (point-max))
         (let ((run-end (or (next-single-property-change pos 'font-lock-face)
                            (point-max))))
-          (when (agent-shell-chat--prompt-face-p
+          (when (agent-shell--prompt-face-p
                  (get-text-property pos 'font-lock-face))
             (push (cons pos run-end) runs))
           (setq pos run-end)))
@@ -308,7 +290,7 @@ above, putting the first line of a multi-line input out of reach of
                                       (skip-chars-forward " \t\n")
                                       (point))))
                (me-label (agent-shell-chat--label
-                          "Me" 'agent-shell-chat-me-label))
+                          agent-shell-user-label 'agent-shell-chat-me-label))
                ;; Face the padding and marker `default' so they do not inherit
                ;; the covered text's face: a display string's unfaced chars
                ;; take the face of the text they replace, and after a code
@@ -447,7 +429,7 @@ newline would merge the input line into the response for line motion
   (save-excursion
     (goto-char (point-min))
     (let ((label (agent-shell-chat--label
-                  (agent-shell-chat--agent-name)
+                  (agent-shell--agent-label)
                   'agent-shell-chat-agent-label))
           (kept nil))
       (while (re-search-forward "<shell-maker-end-of-prompt>" nil t)
@@ -468,7 +450,7 @@ newline would merge the input line into the response for line motion
                       ;; (an empty response): it belongs to that prompt's
                       ;; spacing, and swallowing it would overlap the `Me'
                       ;; overlay.  Keep the label anchored at the marker.
-                      (if (agent-shell-chat--prompt-face-p
+                      (if (agent-shell--prompt-face-p
                            (get-text-property (point) 'font-lock-face))
                           mend
                         (point))))
@@ -500,7 +482,7 @@ newline would merge the input line into the response for line motion
                                  (goto-char mend)
                                  (skip-chars-forward " \t\n")
                                  (or (get-text-property (point) 'shell-maker--marker)
-                                     (agent-shell-chat--prompt-face-p
+                                     (agent-shell--prompt-face-p
                                       (get-text-property (point) 'font-lock-face))))))
           ;; A turn with no response is not labeled; its stale overlay, if
           ;; any, is dropped by the `--gc-overlays' sweep below.  Anchor the
@@ -570,7 +552,7 @@ replaced by the label, a blank line, and the marker the input follows:
     ;; Laid out as the shell lays out its own live prompt, without its
     ;; leading pad: nothing sits above this one to separate it from.
     (overlay-put overlay 'before-string
-                 (concat (agent-shell-chat--label "Me" 'agent-shell-chat-me-label)
+                 (concat (agent-shell-chat--label agent-shell-user-label 'agent-shell-chat-me-label)
                          (propertize "\n\n" 'face 'default)
                          (propertize (concat agent-shell-chat--body-indent
                                              agent-shell-chat--prompt)

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -1966,6 +1966,145 @@ associated viewport buffer exists, switch to that instead."
         (message "Copied session ID: %s" session-id))
     (user-error "No active session")))
 
+(defcustom agent-shell-user-label "Me"
+  "Name standing for you in this shell.
+
+Used wherever a turn needs attributing: `agent-shell-chat-mode' boxes it
+above each submitted prompt, and `agent-shell-copy-as-markdown' writes it
+into copied transcripts as `**Me:**'.  Set it empty to leave your turns
+unlabelled in copies.
+
+The agent's side is named by `agent-shell-agent-label'.  Change this to
+suit your language or taste, e.g. \"Ich\" or \"Moi\"."
+  :type 'string
+  :group 'agent-shell)
+
+(defcustom agent-shell-agent-label "%s"
+  "Name standing for the agent in this shell.
+
+Any `%s' is replaced with the agent's own name, taken from its
+configuration's mode-line name -- so the default labels a Claude shell
+\"Claude\" and a Pi shell \"Pi\", and \"%s (agent)\" gives \"Claude (agent)\".
+
+Leave `%s' out to use one fixed name for every agent, e.g. \"Agent\" or
+\"Assistant\".  Substitution is literal, so a `%' elsewhere in the string
+needs no escaping.
+
+Used wherever a turn needs attributing: `agent-shell-chat-mode' boxes it
+above each response, and `agent-shell-copy-as-markdown' writes it into
+copied transcripts as `**Claude:**'.  Set it empty to leave the agent's
+turns unlabelled in copies.  Your side of the conversation is named by
+`agent-shell-user-label'."
+  :type 'string
+  :group 'agent-shell)
+
+(defun agent-shell--agent-label ()
+  "Return the agent's name for labelling its turns.
+
+Applies `agent-shell-agent-label' to the attached agent's display name
+\(its configuration's mode-line name), falling back to \"Agent\" when no
+name is available, e.g. before a shell has attached."
+  (string-replace
+   "%s"
+   (or (map-nested-elt agent-shell--state '(:agent-config :mode-line-name))
+       "Agent")
+   agent-shell-agent-label))
+
+(defun agent-shell--prompt-face-p (value)
+  "Return non-nil when a `font-lock-face' VALUE marks a shell prompt.
+
+A live prompt carries `comint-highlight-prompt'; a restored or echoed
+prompt carries `agent-shell-prompt' (which inherits it).  Either may be
+repeated.
+
+For example, \\='comint-highlight-prompt, \\='agent-shell-prompt, and
+\\='(comint-highlight-prompt comint-highlight-prompt) all return non-nil,
+while \\='default returns nil."
+  (let ((faces (if (listp value) value (list value))))
+    (or (memq 'comint-highlight-prompt faces)
+        (memq 'agent-shell-prompt faces))))
+
+(defun agent-shell--copy-turn-label (name suffix-p)
+  "Return NAME as a copied-transcript turn label, or an empty string.
+
+Renders NAME in bold as `**NAME:**', with the blank line that separates
+it from the turn it introduces.  SUFFIX-P non-nil also prefixes a
+newline, for a label that must break out of the preceding line (the
+end-of-prompt marker sits at the end of the prompt's last line, whereas
+the shell prompt already starts one).
+
+An empty NAME returns the empty string, which stashes that chrome as
+\"vanishes from the copy\" -- so emptying `agent-shell-user-label' or
+`agent-shell-agent-label' leaves that side unlabelled."
+  (if (string-empty-p name)
+      ""
+    (let ((label (format "**%s:**" name)))
+      (if suffix-p
+          (concat "\n" label "\n")
+        (concat label "\n\n")))))
+
+(defun agent-shell--label-turn-chrome (beg end user-label agent-label)
+  "Stash USER-LABEL and AGENT-LABEL on the shell chrome between BEG and END.
+
+Puts `agent-shell-markdown-source' on the two spans that are shell chrome
+rather than markdown, so `agent-shell-markdown-reconstruct' substitutes a
+turn label for each:
+
+  - shell-maker's invisible `<shell-maker-end-of-prompt>' marker, tagged
+    `shell-maker--marker', becomes AGENT-LABEL.
+  - the shell prompt, recognized by `agent-shell--prompt-face-p', becomes
+    USER-LABEL.
+
+shell-maker's other markers (`<shell-maker-failed-command>',
+`<shell-maker-interrupted-command>') are chrome with no markdown meaning,
+so they are stashed empty and vanish from the copy.
+
+Intended to run on a scratch copy of the region (see
+`agent-shell--reconstruct-with-turn-labels'), never on the shell buffer
+itself."
+  (let ((pos beg))
+    (while (< pos end)
+      (let ((next (or (next-single-property-change
+                       pos 'shell-maker--marker nil end)
+                      end)))
+        (when (get-text-property pos 'shell-maker--marker)
+          (put-text-property
+           pos next 'agent-shell-markdown-source
+           (if (string-search "<shell-maker-end-of-prompt>"
+                              (buffer-substring-no-properties pos next))
+               agent-label
+             "")))
+        (setq pos next))))
+  (let ((pos beg))
+    (while (< pos end)
+      (let ((next (or (next-single-property-change
+                       pos 'font-lock-face nil end)
+                      end)))
+        (when (agent-shell--prompt-face-p
+               (get-text-property pos 'font-lock-face))
+          (put-text-property pos next 'agent-shell-markdown-source user-label))
+        (setq pos next)))))
+
+(defun agent-shell--reconstruct-with-turn-labels (beg end)
+  "Reconstruct markdown for BEG..END with shell chrome shown as turn labels.
+
+Works on a scratch copy of the region so the shell buffer is never
+modified: `buffer-substring' carries the text properties
+`agent-shell-markdown-reconstruct' reads, and the labels are stashed
+there.
+
+Both labels are resolved before the copy, since `agent-shell-agent-label'
+reads buffer-local state that the scratch buffer does not have."
+  (let ((text (buffer-substring beg end))
+        (user-label (agent-shell--copy-turn-label agent-shell-user-label nil))
+        (agent-label (agent-shell--copy-turn-label (agent-shell--agent-label) t)))
+    (with-temp-buffer
+      (insert text)
+      (agent-shell--label-turn-chrome
+       (point-min) (point-max) user-label agent-label)
+      (agent-shell-markdown-reconstruct (point-min) (point-max)))))
+
+
 (defun agent-shell-copy-as-markdown (beg end)
   "Copy the region between BEG and END to the kill ring as markdown.
 
@@ -1978,9 +2117,14 @@ fenced code blocks with their ```language fences, and tables.  A
 construct only partially selected (for example a single line of a
 code block) is copied verbatim as shown.
 
+Shell chrome is turned into markdown too: the prompt and shell-maker's
+invisible end-of-prompt marker are replaced by turn labels naming
+`agent-shell-user-label' and `agent-shell-agent-label', so a copied
+transcript shows where each turn begins.
+
 Interactively, operates on the active region."
   (interactive "r")
-  (kill-new (agent-shell-markdown-reconstruct beg end))
+  (kill-new (agent-shell--reconstruct-with-turn-labels beg end))
   (setq deactivate-mark t)
   (message "Copied as markdown"))
 

--- a/tests/agent-shell-chat-mode-tests.el
+++ b/tests/agent-shell-chat-mode-tests.el
@@ -72,21 +72,6 @@ Carries `shell-maker--marker', as shell-maker's real marker does."
                  agent-shell-chat--labeled t)
      ,@body))
 
-(ert-deftest agent-shell-chat-prompt-face-p-test ()
-  "Prompt runs are recognized whether the face is a symbol or a list."
-  (should (agent-shell-chat--prompt-face-p 'comint-highlight-prompt))
-  (should (agent-shell-chat--prompt-face-p '(comint-highlight-prompt comint-highlight-prompt)))
-  (should-not (agent-shell-chat--prompt-face-p 'default))
-  (should-not (agent-shell-chat--prompt-face-p nil)))
-
-(ert-deftest agent-shell-chat-agent-name-test ()
-  "The agent label uses `:mode-line-name', falling back to \"Agent\"."
-  (agent-shell-chat-mode-tests--with-shell
-    (should (equal "Claude" (agent-shell-chat--agent-name))))
-  (with-temp-buffer
-    (setq-local agent-shell--state nil)
-    (should (equal "Agent" (agent-shell-chat--agent-name)))))
-
 (ert-deftest agent-shell-chat-labels-submitted-turn-test ()
   "A submitted turn boxes the prompt as `Me' and the response as the agent."
   (agent-shell-chat-mode-tests--with-shell

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -5937,5 +5937,128 @@ Then [after](https://after.com/y)
     (agent-shell-previous-item)
     (should (eq (char-after) ?A))))
 
+;;; Turn labels (chat mode's boxes and copy-as-markdown's headings).
+
+(defmacro agent-shell-tests--with-agent-name (name &rest body)
+  "Run BODY in a buffer whose shell state reports mode-line name NAME."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (setq-local agent-shell--state
+                 (list (cons :agent-config (list (cons :mode-line-name ,name)))))
+     ,@body))
+
+(defun agent-shell-tests--prompt (text)
+  "Insert a live shell prompt run displaying TEXT, as shell-maker fontifies it."
+  (insert (propertize text 'font-lock-face
+                      '(comint-highlight-prompt comint-highlight-prompt))))
+
+(defun agent-shell-tests--marker (&optional text)
+  "Insert shell-maker's invisible end-of-prompt marker, or TEXT as a marker."
+  (insert (propertize (or text "<shell-maker-end-of-prompt>")
+                      'invisible t 'shell-maker--marker t)))
+
+(ert-deftest agent-shell--prompt-face-p-test ()
+  "Prompt runs are recognized whether the face is a symbol or a list.
+`agent-shell-prompt' counts too: restored and echoed prompts carry it
+rather than `comint-highlight-prompt'."
+  (should (agent-shell--prompt-face-p 'comint-highlight-prompt))
+  (should (agent-shell--prompt-face-p
+           '(comint-highlight-prompt comint-highlight-prompt)))
+  (should (agent-shell--prompt-face-p 'agent-shell-prompt))
+  (should (agent-shell--prompt-face-p '(agent-shell-prompt)))
+  (should-not (agent-shell--prompt-face-p 'default))
+  (should-not (agent-shell--prompt-face-p nil)))
+
+(ert-deftest agent-shell--agent-label-test ()
+  "The agent label substitutes `:mode-line-name', falling back to \"Agent\"."
+  (agent-shell-tests--with-agent-name "Claude"
+    (should (equal "Claude" (agent-shell--agent-label))))
+  (with-temp-buffer
+    (setq-local agent-shell--state nil)
+    (should (equal "Agent" (agent-shell--agent-label)))))
+
+(ert-deftest agent-shell--agent-label-shapes-test ()
+  "`agent-shell-agent-label' shapes the name: `%s', fixed, or decorated."
+  (agent-shell-tests--with-agent-name "Claude"
+    (let ((agent-shell-agent-label "%s (agent)"))
+      (should (equal "Claude (agent)" (agent-shell--agent-label))))
+    ;; No `%s': one fixed name for every agent.
+    (let ((agent-shell-agent-label "Agent"))
+      (should (equal "Agent" (agent-shell--agent-label))))
+    ;; Substitution is literal, so a stray `%' needs no escaping.
+    (let ((agent-shell-agent-label "%s 100%"))
+      (should (equal "Claude 100%" (agent-shell--agent-label))))
+    (let ((agent-shell-agent-label ""))
+      (should (equal "" (agent-shell--agent-label))))))
+
+(ert-deftest agent-shell--copy-turn-label-test ()
+  "A turn label is bold, followed by a blank line; a suffix label breaks first.
+An empty name yields the empty string, which makes that chrome vanish
+from a copy rather than labelling it."
+  (should (equal "**Me:**\n\n" (agent-shell--copy-turn-label "Me" nil)))
+  (should (equal "\n**Claude:**\n" (agent-shell--copy-turn-label "Claude" t)))
+  (should (equal "" (agent-shell--copy-turn-label "" nil)))
+  (should (equal "" (agent-shell--copy-turn-label "" t))))
+
+(ert-deftest agent-shell--copy-as-markdown-labels-turns-test ()
+  "A copied transcript names each turn instead of showing shell chrome.
+The prompt becomes the user label and the invisible end-of-prompt marker
+becomes the agent label, so the two turns stay separated."
+  (agent-shell-tests--with-agent-name "Claude"
+    (agent-shell-tests--prompt "Claude> ")
+    (insert "hello\n")
+    (agent-shell-tests--marker)
+    (insert "world\n")
+    (should (equal (agent-shell--reconstruct-with-turn-labels
+                    (point-min) (point-max))
+                   "**Me:**\n\nhello\n\n**Claude:**\nworld\n"))))
+
+(ert-deftest agent-shell--copy-as-markdown-labels-restored-prompt-test ()
+  "A restored prompt is labelled too: it carries `agent-shell-prompt'.
+`comint-highlight-prompt' alone would miss it."
+  (agent-shell-tests--with-agent-name "Claude"
+    (insert (propertize "Claude> " 'font-lock-face 'agent-shell-prompt))
+    (insert "hello\n")
+    (should (equal (agent-shell--reconstruct-with-turn-labels
+                    (point-min) (point-max))
+                   "**Me:**\n\nhello\n"))))
+
+(ert-deftest agent-shell--copy-as-markdown-empty-label-drops-chrome-test ()
+  "Emptying a label leaves that side unlabelled, but still drops its chrome."
+  (agent-shell-tests--with-agent-name "Claude"
+    (agent-shell-tests--prompt "Claude> ")
+    (insert "hello\n")
+    (agent-shell-tests--marker)
+    (insert "world\n")
+    (let ((agent-shell-user-label "")
+          (agent-shell-agent-label ""))
+      (should (equal (agent-shell--reconstruct-with-turn-labels
+                      (point-min) (point-max))
+                     "hello\nworld\n")))))
+
+(ert-deftest agent-shell--copy-as-markdown-drops-other-markers-test ()
+  "shell-maker's other markers are chrome with no markdown meaning: they vanish."
+  (agent-shell-tests--with-agent-name "Claude"
+    (insert "output\n")
+    (agent-shell-tests--marker "<shell-maker-failed-command>")
+    (should (equal (agent-shell--reconstruct-with-turn-labels
+                    (point-min) (point-max))
+                   "output\n"))))
+
+(ert-deftest agent-shell--copy-as-markdown-leaves-buffer-unmodified-test ()
+  "Labelling happens on a scratch copy, so a copy never touches the shell."
+  (agent-shell-tests--with-agent-name "Claude"
+    (agent-shell-tests--prompt "Claude> ")
+    (insert "hello\n")
+    (agent-shell-tests--marker)
+    (insert "world\n")
+    (let ((before (buffer-string)))
+      (set-buffer-modified-p nil)
+      (agent-shell--reconstruct-with-turn-labels (point-min) (point-max))
+      (should (equal before (buffer-string)))
+      (should-not (buffer-modified-p))
+      ;; The label is stashed on the scratch copy only, never here.
+      (should-not (get-text-property (point-min) 'agent-shell-markdown-source)))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
## The problem

Copying a transcript region with `agent-shell-copy-as-markdown` puts terminal chrome on the kill ring:

````
Pi> Let's make a new test. Print verbatim

```math
E=mc^2
```
<shell-maker-end-of-prompt>
```math
E=mc^2
```
````

`<shell-maker-end-of-prompt>` is `invisible t` — it is not visible in the buffer and it is not markdown, so it has no business in a copy at all. `Pi> ` is visible, but a bare terminal prompt is not how a markdown transcript marks a turn.

Everything else already round-trips correctly; this is only about the chrome around the turns.

## Why not just strip them

The marker is the *only* boundary between a submitted prompt and its response. Removing it leaves the two running together with nothing in between — worse than the status quo for anyone pasting a transcript into a document, an issue, or another LLM.

So this renders the chrome as markdown rather than stripping it.

## After

````
**Me:**

Let's make a test. Print verbatim

```math
E=mc^2
```

**Pi:**

```math
E=mc^2
```
````

## How it works

No new machinery. `agent-shell-markdown-reconstruct` already substitutes a span's `agent-shell-markdown-source` into the copy — the empty string being the documented "inserted chrome vanishes" case. The chrome simply was never stamped. **`agent-shell-markdown-reconstruct` is unchanged.**

Both spans are inserted by shell-maker, not agent-shell: it calls `shell-maker-insert-end-of-prompt-marker` itself on submit (shell-maker.el:2299) and emits the prompt through its own output filter. So stamping happens at **copy time**, not insertion time, which keeps the change inside agent-shell — **no shell-maker change is required**.

- `agent-shell--label-turn-chrome` stamps the two spans, found by properties they already carry: `shell-maker--marker` for the marker, and a prompt face for the prompt.
- `agent-shell--reconstruct-with-turn-labels` does this on a **scratch copy** of the region (`buffer-substring` carries the text properties reconstruct reads), so the shell buffer is never modified by a copy.

shell-maker's other markers (`<shell-maker-failed-command>`, `<shell-maker-interrupted-command>`) are stashed empty and vanish — they were being copied verbatim too.

## Shared naming with `agent-shell-chat-mode` (second commit)

`agent-shell-chat-mode` already labels these same two anchors on screen — it boxes each user turn `Me` and each response with the agent's name. But it draws them with **overlays**, and reconstruct reads **text properties**, so a copy cannot see them: with chat-mode on, the buffer reads as a clean chat while a copy still yields `Pi> ` and the raw marker.

Rather than inventing a second set of names, who is speaking is named once and used by both. Two private chat-mode helpers move to `agent-shell.el` (the copy path cannot require chat-mode, since `agent-shell.el` requires *it*):

```
agent-shell-chat--agent-name    -> agent-shell--agent-label
agent-shell-chat--prompt-face-p -> agent-shell--prompt-face-p
```

chat-mode's on-screen output is unchanged, but its user label — previously the hardcoded string `"Me"` — becomes customizable on the way, which seems worth having on its own: it is the one name a user is most likely to want in their own language.

## New options

| Option | Default | Effect |
|---|---|---|
| `agent-shell-user-label` | `"Me"` | Your name — chat-mode's box and copies |
| `agent-shell-agent-label` | `"%s"` | Agent's name; `%s` is its mode-line name, omit it for a fixed name such as `"Agent"` |

Two options, not three: a copy renders either name as `**Name:**`, which did not seem worth making configurable. Emptying a name leaves that side unlabelled while still dropping its chrome, so "no labels at all" needs no option of its own.

Substitution in `agent-shell-agent-label` is literal, so a `%` elsewhere in the string needs no escaping. The blank lines around a label are added in code, not configured, so no setting can produce lopsided spacing.

## Fixed along the way

Taking the prompt predicate from chat-mode also fixes prompt detection: `comint-highlight-prompt` alone misses restored and echoed prompts, which carry `agent-shell-prompt`. Those would have gone unlabelled.

## Possible extension (not in this PR)

`agent-shell-agent-label` could accept a function as well as a string (`:type '(choice string function)`), letting a user compose a label from richer per-turn metadata — which model answered, when.

That is deliberately left out, because agent-shell does not currently record it. The model is session-level (`:model-id`), so switching models mid-session would retroactively relabel every earlier turn, and there is no per-turn timestamp at all — only `:last-activity-time`, which a copy would render as "now". Recording per-turn model and time is a much larger change, plausibly belonging in shell-maker.

Adding the function option later would not break anything: the option would simply accept a function as well as a string, so any label already configured as a string keeps working.

## Testing

Select across a prompt and its response in a shell buffer and run `M-x agent-shell-copy-as-markdown`. Checked manually against a live shell, and in batch for: label substitution and spacing, the shell buffer being unmodified by a copy, the `%s`/fixed/`"%s (agent)"` label shapes, an empty name dropping that side's label and chrome, `<shell-maker-failed-command>` vanishing, and restored-prompt faces being labelled. Both files byte-compile clean.
