### PR TITLE
Stop the live prompt flickering on every keystroke

### DIFF
--- a/agent-shell-chat-mode.el
+++ b/agent-shell-chat-mode.el
@@ -365,8 +365,8 @@ above, putting the first line of a multi-line input out of reach of
                               (1- pos)))
                ;; The live prompt's marker, shown before the input whether or
                ;; not text has been typed yet.  Keying this off `blank' would
-               ;; drop it the instant the user starts typing.  Carried as a
-               ;; `line-prefix', which occupies no buffer position.
+               ;; drop it the instant the user starts typing.  Carried as the
+               ;; covered prompt's `display', standing on its buffer positions.
                (marker (when (and live labeled)
                          (propertize (concat agent-shell-chat--body-indent
                                              agent-shell-chat--prompt)
@@ -409,15 +409,23 @@ above, putting the first line of a multi-line input out of reach of
             ;; span's start flips with `label-nl', and reuse has to survive
             ;; that flip rather than strand the overlay it should have moved.
             :anchor-beg pos :anchor-end run-end
-            ;; Hide the covered prompt with a `display' of \"\".
+            ;; Replace the covered prompt: with the live prompt's marker when
+            ;; there is one, otherwise with \"\" to hide it.
             ;;
-            ;; Where a newline above carries the label, nothing is shown at
-            ;; this position: a string here would keep `previous-line' from
-            ;; settling on the input's first line.  The prefixes do the rest,
-            ;; occupying no buffer position of their own.  They indent this
-            ;; line, which the input's first line shares with the covered
-            ;; prompt, and carry the live prompt's marker (indent included).
-            ;; They also drop any tinted gutter inherited from that text.
+            ;; Where a newline above carries the label, no *inserted* string
+            ;; stands at this position: a `before-string' here would keep
+            ;; `previous-line' from settling on the input's first line.  The
+            ;; marker is safe as a `display' because it stands on the covered
+            ;; prompt's own positions rather than adding any, so vertical
+            ;; motion behaves as it did with the prompt text visible.
+            ;;
+            ;; It must not be a `line-prefix': that belongs to the whole line,
+            ;; and the input's first line shares this one, so redisplay cannot
+            ;; take its cheap single-line path -- every edit re-lays the line
+            ;; out and the input visibly paints unindented before jumping
+            ;; right.  `line-prefix' is left to `input-indent' alone, which
+            ;; only ever applies to a submitted turn, and still drops any
+            ;; tinted gutter inherited from the covered text.
             ;;
             ;; With no newline above, the label renders here instead and each
             ;; of its blank lines becomes a row of this line.  The marker
@@ -426,8 +434,9 @@ above, putting the first line of a multi-line input out of reach of
             ;; with the input.
             :props (list (cons 'before-string
                                (if label-nl "" (concat before (or marker ""))))
-                         (cons 'display "")
-                         (cons 'line-prefix (if label-nl (or marker input-indent) ""))
+                         (cons 'display (if label-nl (or marker "") ""))
+                         (cons 'line-prefix
+                               (if (and label-nl (not marker)) input-indent ""))
                          (cons 'wrap-prefix (if label-nl input-indent ""))))
            kept)
           ;; Indent a submitted turn's input so it aligns with the response

--- a/tests/agent-shell-chat-mode-tests.el
+++ b/tests/agent-shell-chat-mode-tests.el
@@ -37,11 +37,12 @@ no newline above to carry it."
 
 (defun agent-shell-chat-mode-tests--marker-string (me)
   "Return the string carrying ME\='s prompt marker.
-It travels as a `line-prefix' (occupying no buffer position) where the
-label rides the newline above; with no newline to ride, the label renders
-on ME itself and the marker rejoins it there."
+It travels as the covered prompt's `display' (standing on its buffer
+positions, adding none) where the label rides the newline above; with no
+newline to ride, the label renders on ME itself and the marker rejoins it
+there."
   (or (seq-find (lambda (string) (string-match-p "❯" string))
-                (list (or (overlay-get me 'line-prefix) "")
+                (list (or (overlay-get me 'display) "")
                       (or (overlay-get me 'before-string) "")))
       ""))
 
@@ -323,6 +324,31 @@ the input reachable."
       ;; The label rides the newline that closes the line above the prompt.
       (should (string-match-p "Me" (agent-shell-chat-mode-tests--label-string me)))
       (should (eq ?\n (char-before (overlay-start me)))))))
+
+(ert-deftest agent-shell-chat-live-prompt-marker-not-line-prefix-test ()
+  "The live prompt's marker is a `display\=', never a `line-prefix\='.
+
+A `line-prefix\=' belongs to the whole line, and the input's first line
+shares its line with the covered prompt.  Redisplay then cannot take its
+cheap single-line path: every edit re-lays the line out, and the input
+visibly paints unindented before jumping right.
+
+Drawing the marker as the covered prompt's `display\=' costs nothing per
+edit, and still leaves the input's first line reachable by `previous-line\='
+because it stands on the prompt's own buffer positions rather than adding
+any (contrast a `before-string\=', which would not -- see #786)."
+  (agent-shell-chat-mode-tests--with-shell
+    (agent-shell-chat-mode-tests--prompt "Claude> ")
+    (insert "hello\n")
+    (agent-shell-chat-mode-tests--marker)
+    (insert "reply\n\n")
+    (agent-shell-chat-mode-tests--prompt "Claude> ")
+    (insert "typing here")
+    (let ((agent-shell-prompt-bar-mode nil))
+      (agent-shell-chat--relabel))
+    (let ((me (car (last (agent-shell-chat-mode-tests--me-overlays)))))
+      (should (string-match-p "❯" (or (overlay-get me 'display) "")))
+      (should-not (string-match-p "❯" (or (overlay-get me 'line-prefix) ""))))))
 
 (ert-deftest agent-shell-chat-decorates-prompt-region-test ()
   "A prompt read outside the shell is hidden behind the `Me' label.


### PR DESCRIPTION
## The problem

Typing into the shell flickers. Each character paints the input flush left for a frame, then jumps right under the ` ❯ ` marker — so a whole sentence visibly shifts sideways as it is typed. This causes a conspicuous flickering with each keystroke typed by the user.

## Cause

The marker is drawn as a `line-prefix` on the overlay covering the live comint prompt:

```elisp
(list (cons 'before-string (if label-nl "" before))
      (cons 'display "")
      (cons 'line-prefix (or marker ""))
      (cons 'wrap-prefix (or marker "")))
```

A `line-prefix` belongs to the whole line, and the live prompt shares its line with the input being typed. Emacs therefore cannot use its cheap single-line redisplay path: every `self-insert` re-lays the line out, and the unindented state is visible in between.

Measured — with counters on `agent-shell-chat--relabel`, `--label-prompts`, `--decorate-prompt-region` and friends, 25 keystrokes produced **zero** calls to any of them. No chat-mode code runs while typing, so this is redisplay, not a deferred relabel. Clearing `line-prefix` alone (leaving `wrap-prefix` in place) stops the flicker.

## Fix

Draw the marker as the covered prompt's `display`, which was already replacing that text with `""`:

```elisp
(cons 'display (or marker ""))
(cons 'line-prefix "")
```

`display` is a property of the covered text rather than of the line, so it costs nothing per keystroke. `wrap-prefix` is untouched — it applies only to wrapped continuation rows and is not implicated.

## This does not reintroduce #786

The comment at that call site explains why `line-prefix` was chosen: a string shown at the prompt position keeps `previous-line` from settling on the input's first line. That is true of an **inserted** string — a `before-string` holds point and cursor on the row above, which is #786.

A `display` string is different in kind: it stands on the positions of the text it covers, which are the prompt's own. Vertical motion therefore behaves exactly as it did when the prompt text was visible.

Verified by hand on a multi-line draft: from the last line, the up arrow walks onto the blank line, then onto the draft's **first** line, and only then up into the transcript above.

## Tests

The full suite passes — 384 tests across 12 files, 0 unexpected.

A new test, `agent-shell-chat-live-prompt-marker-not-line-prefix-test`, pins the mechanism; it fails against the previous implementation.

Two existing tests changed, both asserting the old mechanism rather than behaviour:

- `agent-shell-chat-mode-tests--marker-string` read the marker off `line-prefix`; it now reads `display`.
- `agent-shell-chat-label-is-before-string-test` asserted an empty `display` on every `Me` overlay, as a proxy for "the label is not drawn as a `display`".  It now asserts that directly, since the live prompt's `display` legitimately carries the marker. The label itself must still never be a `display` — that is what keeps the cursor off it — and the test still checks so.

`agent-shell-chat-nothing-shown-at-prompt-test` passes unchanged; only its docstring is updated, since it described the marker as travelling via `line-prefix`.