### PR TITLE
docs: add OrcaRouter as a named provider example for Qwen Code

### DIFF
--- a/README.org
+++ b/README.org
@@ -582,7 +582,7 @@ For OAuth login-based authentication:
       (agent-shell-qwen-make-authentication :login t))
 #+end_src
 
-For an OpenAI-compatible provider (for example OpenRouter), pass the API key and set the base URL and model via =agent-shell-qwen-environment=:
+For an OpenAI-compatible provider (for example OpenRouter or OrcaRouter), pass the API key and set the base URL and model via =agent-shell-qwen-environment=:
 
 #+begin_src emacs-lisp
 ;; With string
@@ -598,6 +598,24 @@ For an OpenAI-compatible provider (for example OpenRouter), pass the API key and
       (agent-shell-make-environment-variables
        "OPENAI_BASE_URL" "https://openrouter.ai/api/v1"
        "OPENAI_MODEL" "x-ai/grok-4.3"))
+#+end_src
+
+For [[https://www.orcarouter.ai][OrcaRouter]], an OpenAI-compatible AI gateway, pass the API key and set the base URL and model via =agent-shell-qwen-environment=:
+
+#+begin_src emacs-lisp
+;; With string
+(setq agent-shell-qwen-authentication
+      (agent-shell-qwen-make-authentication :openai-api-key "your-orcarouter-api-key-here"))
+
+;; With function
+(setq agent-shell-qwen-authentication
+      (agent-shell-qwen-make-authentication
+       :openai-api-key (lambda () (auth-source-pass-get 'secret "orcarouter-api-key"))))
+
+(setq agent-shell-qwen-environment
+      (agent-shell-make-environment-variables
+       "OPENAI_BASE_URL" "https://api.orcarouter.ai/v1"
+       "OPENAI_MODEL" "orcarouter/auto"))
 #+end_src
 
 *** Cursor


### PR DESCRIPTION
Add a named OrcaRouter example to the Qwen Code section, alongside the existing OpenRouter block.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means agent-shell users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verification:
- `curl https://api.orcarouter.ai/v1/models` with the API key → HTTP 200, lists `orcarouter/auto`.
- Live chat completion via `https://api.orcarouter.ai/v1` with `orcarouter/auto` → HTTP 200.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
I'm an engineer on the OrcaRouter team.

- [ ] I agree to communicate (PR description and comments) with the author myself (not AI-generated).
- [x] I've reviewed all code in PR myself and will vouch for its quality.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
