### PR TITLE
Fix viewport prompt font-lock face precedence

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -383,7 +383,8 @@ Optionally set its PROMPT and RESPONSE."
                        'agent-shell-viewport-prompt t
                        'line-prefix "  "
                        'wrap-prefix "  "
-                       'face 'agent-shell-viewport-prompt)
+                       'face 'agent-shell-viewport-prompt
+                       'font-lock-face 'agent-shell-viewport-prompt)
          prompt)))
     (when response
       (insert response))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -4599,6 +4599,28 @@ interaction (e.g. \"1/2\" after switching to the latest interaction)."
       (kill-buffer viewport-buffer)
       (kill-buffer shell-buffer))))
 
+(ert-deftest agent-shell-viewport--initialize-overrides-prompt-font-lock-face-test ()
+  "The echoed viewport prompt must override copied input font-lock faces."
+  (let ((agent-shell-header-style 'text)
+        (agent-shell-file-completion-enabled nil)
+        (prompt (propertize "Claude> inspect"
+                            'font-lock-face 'comint-highlight-input)))
+    (with-temp-buffer
+      (let ((viewport-buffer (current-buffer)))
+        (cl-letf (((symbol-function 'agent-shell-viewport--position)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'agent-shell-viewport--shell-buffer)
+                   (lambda (&rest _) viewport-buffer))
+                  ((symbol-function 'agent-shell-viewport--update-header)
+                   (lambda (&rest _))))
+          (agent-shell-viewport-view-mode)
+          (agent-shell-viewport--initialize :prompt prompt)
+          (let ((prompt-start (agent-shell-viewport--prompt-start)))
+            (should (eq (get-text-property prompt-start 'face)
+                        'agent-shell-viewport-prompt))
+            (should (eq (get-text-property prompt-start 'font-lock-face)
+                        'agent-shell-viewport-prompt))))))))
+
 (ert-deftest agent-shell--refresh-session-title-skips-when-list-unsupported ()
   "Test `agent-shell--refresh-session-title' sends no request without `list'.
 


### PR DESCRIPTION
Thank you for contributing to agent-shell!

This fixes viewport prompt styling when copied prompt text already carries
`font-lock-face` from comint.

## Summary

`agent-shell-viewport--initialize` now sets both `face` and `font-lock-face`
to `agent-shell-viewport-prompt`. A regression test covers a copied prompt
carrying `comint-highlight-input`.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
