### PR TITLE
Handle ACP session/list pagination

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -7371,6 +7371,58 @@ SESSION-TITLE is an optional display title for the resumed session."
    :on-failure (agent-shell--make-error-handler
                 :state (agent-shell--state) :shell-buffer shell-buffer)))
 
+(cl-defun agent-shell--make-session-list-request (&key cwd cursor)
+  "Return an ACP session/list request for CWD and optional CURSOR.
+
+CURSOR is an opaque token returned as `nextCursor' by a previous
+session/list response.
+
+  (agent-shell--make-session-list-request :cwd \"/tmp\" :cursor \"next\")
+  ;; => ((:method . \"session/list\")
+  ;;     (:params (cursor . \"next\") (cwd . \"/tmp\")))"
+  (let ((request (acp-make-session-list-request :cwd cwd)))
+    (when cursor
+      (map-put! request :params
+                (map-insert (map-elt request :params) 'cursor cursor)))
+    request))
+
+(cl-defun agent-shell--list-sessions (&key state cwd buffer cursor seen-cursors
+                                           sessions on-success on-failure)
+  "Fetch all session/list pages for CWD using STATE and BUFFER.
+
+CURSOR, SEEN-CURSORS, and SESSIONS carry pagination state between
+requests.  Call ON-SUCCESS with all sessions when the agent omits
+`nextCursor'.  Call ON-FAILURE with the ACP error and raw message when a
+request fails or the agent repeats a cursor."
+  (agent-shell--send-request
+   :state state
+   :client (map-elt state :client)
+   :request (agent-shell--make-session-list-request :cwd cwd :cursor cursor)
+   :buffer buffer
+   :on-success
+   (lambda (acp-response)
+     (let ((all-sessions (append sessions
+                                 (append (or (map-elt acp-response 'sessions) '()) nil)))
+           (next-cursor (map-elt acp-response 'nextCursor)))
+       (cond
+        ((not next-cursor)
+         (funcall on-success all-sessions))
+        ((seq-contains-p seen-cursors next-cursor #'equal)
+         (funcall on-failure
+                  '((message . "Agent repeated a session/list cursor"))
+                  nil))
+        (t
+         (agent-shell--list-sessions
+          :state state
+          :cwd cwd
+          :buffer buffer
+          :cursor next-cursor
+          :seen-cursors (cons next-cursor seen-cursors)
+          :sessions all-sessions
+          :on-success on-success
+          :on-failure on-failure)))))
+   :on-failure on-failure))
+
 (cl-defun agent-shell--initiate-session-list-and-load (&key shell-buffer on-session-init)
   "Try loading latest existing session with SHELL-BUFFER and ON-SESSION-INIT."
   (with-current-buffer (map-elt (agent-shell--state) :buffer)
@@ -7380,15 +7432,12 @@ SESSION-TITLE is an optional display title for the resumed session."
      :body "\n\nLooking for existing sessions..."
      :append t))
   (agent-shell--emit-event :event 'session-list)
-  (agent-shell--send-request
+  (agent-shell--list-sessions
    :state (agent-shell--state)
-   :client (map-elt (agent-shell--state) :client)
-   :request (acp-make-session-list-request
-             :cwd (agent-shell--resolve-path (agent-shell-cwd)))
+   :cwd (agent-shell--resolve-path (agent-shell-cwd))
    :buffer (current-buffer)
-   :on-success (lambda (acp-response)
-                 (let ((acp-sessions (agent-shell--sort-sessions-by-recency
-                                      (append (or (map-elt acp-response 'sessions) '()) nil))))
+   :on-success (lambda (acp-sessions)
+                 (let ((acp-sessions (agent-shell--sort-sessions-by-recency acp-sessions)))
                    (condition-case nil
                        (let* ((acp-session
                                (pcase agent-shell-session-strategy

--- a/agent-shell.el
+++ b/agent-shell.el
@@ -953,6 +953,34 @@ Available values:
          (set-default sym value))
   :group 'agent-shell)
 
+(defun agent-shell--validate-session-list-page-limit (value)
+  "Signal a user error unless VALUE is nil or a positive integer."
+  (unless (or (null value)
+              (and (integerp value) (> value 0)))
+    (user-error
+     "`agent-shell-session-list-page-limit' must be nil or a positive integer, got: %S"
+     value)))
+
+(defcustom agent-shell-session-list-page-limit nil
+  "Maximum number of pages to request when listing sessions.
+
+When nil, retrieve all pages by following continuation cursors until the
+agent returns no next cursor.
+
+When a positive integer, retrieve at most that many pages, including the
+initial page.  If the final retrieved page contains a continuation cursor,
+remaining sessions are silently omitted.  Empty pages count toward the
+limit.
+
+A finite value may cause session selection and the `latest' session
+strategy to operate on only a subset of the agent's sessions."
+  :type '(choice (const :tag "Retrieve all pages" nil)
+                 (integer :tag "Maximum pages"))
+  :set (lambda (symbol value)
+         (agent-shell--validate-session-list-page-limit value)
+         (set-default symbol value))
+  :group 'agent-shell)
+
 (defcustom agent-shell-session-choices-function nil
   "Function to transform the choices offered when starting a shell.
 
@@ -7387,13 +7415,18 @@ session/list response.
     request))
 
 (cl-defun agent-shell--list-sessions (&key state cwd buffer cursor seen-cursors
-                                           sessions on-success on-failure)
+                                           sessions (page 1)
+                                           (page-limit agent-shell-session-list-page-limit)
+                                           on-success on-failure)
   "Fetch all session/list pages for CWD using STATE and BUFFER.
 
-CURSOR, SEEN-CURSORS, and SESSIONS carry pagination state between
-requests.  Call ON-SUCCESS with all sessions when the agent omits
-`nextCursor'.  Call ON-FAILURE with the ACP error and raw message when a
-request fails or the agent repeats a cursor."
+CURSOR, SEEN-CURSORS, SESSIONS, and PAGE carry pagination state between
+requests.  PAGE-LIMIT is nil to fetch all pages, or a positive integer
+limiting the number of requests.  Call ON-SUCCESS with the fetched
+sessions when the agent omits `nextCursor' or PAGE-LIMIT is reached.
+Call ON-FAILURE with the ACP error and raw message when a request fails
+or the agent repeats a cursor."
+  (agent-shell--validate-session-list-page-limit page-limit)
   (agent-shell--send-request
    :state state
    :client (map-elt state :client)
@@ -7405,7 +7438,8 @@ request fails or the agent repeats a cursor."
                                  (append (or (map-elt acp-response 'sessions) '()) nil)))
            (next-cursor (map-elt acp-response 'nextCursor)))
        (cond
-        ((not next-cursor)
+        ((or (not next-cursor)
+             (and page-limit (>= page page-limit)))
          (funcall on-success all-sessions))
         ((seq-contains-p seen-cursors next-cursor #'equal)
          (funcall on-failure
@@ -7419,6 +7453,8 @@ request fails or the agent repeats a cursor."
           :cursor next-cursor
           :seen-cursors (cons next-cursor seen-cursors)
           :sessions all-sessions
+          :page (1+ page)
+          :page-limit page-limit
           :on-success on-success
           :on-failure on-failure)))))
    :on-failure on-failure))

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2811,7 +2811,10 @@ so the command must not append a second time."
 
 (ert-deftest agent-shell--list-sessions-fetches-all-pages-test ()
   "Test `agent-shell--list-sessions' follows cursors through empty pages."
-  (let (failure requests sessions)
+  (let ((agent-shell-session-list-page-limit nil)
+        failure
+        requests
+        sessions)
     (cl-letf (((symbol-function 'agent-shell--send-request)
                (lambda (&rest args)
                  (let* ((request (plist-get args :request))
@@ -2847,6 +2850,56 @@ so the command must not append a second time."
                              (map-elt session 'sessionId))
                            sessions)
                    '("session-1" "session-2")))))
+
+(ert-deftest agent-shell--list-sessions-respects-page-limit-test ()
+  "Test `agent-shell--list-sessions' stops silently at the page limit."
+  (let ((agent-shell-session-list-page-limit 2)
+        failure
+        requests
+        sessions)
+    (cl-letf (((symbol-function 'agent-shell--send-request)
+               (lambda (&rest args)
+                 (let* ((request (plist-get args :request))
+                        (cursor (map-nested-elt request '(:params cursor))))
+                   (push request requests)
+                   (funcall
+                    (plist-get args :on-success)
+                    (if cursor
+                        '((sessions . []) (nextCursor . "page-3"))
+                      '((sessions . [((sessionId . "session-1"))])
+                        (nextCursor . "page-2"))))))))
+      (agent-shell--list-sessions
+       :state '((:client . test-client))
+       :cwd "/tmp"
+       :buffer (current-buffer)
+       :on-success (lambda (result) (setq sessions result))
+       :on-failure (lambda (&rest args) (setq failure args))))
+    (should-not failure)
+    (should (equal (mapcar (lambda (request)
+                             (map-nested-elt request '(:params cursor)))
+                           (nreverse requests))
+                   '(nil "page-2")))
+    (should (equal (mapcar (lambda (session)
+                             (map-elt session 'sessionId))
+                           sessions)
+                   '("session-1")))))
+
+(ert-deftest agent-shell--list-sessions-rejects-invalid-page-limit-test ()
+  "Test `agent-shell--list-sessions' rejects invalid page limits."
+  (dolist (page-limit '(0 -1 1.5 "2"))
+    (let ((agent-shell-session-list-page-limit page-limit)
+          request-sent)
+      (cl-letf (((symbol-function 'agent-shell--send-request)
+                 (lambda (&rest _args) (setq request-sent t))))
+        (should-error
+         (agent-shell--list-sessions
+          :state '((:client . test-client))
+          :cwd "/tmp"
+          :buffer (current-buffer)
+          :on-success #'ignore
+          :on-failure #'ignore)
+         :type 'user-error))
+      (should-not request-sent))))
 
 (ert-deftest agent-shell--list-sessions-rejects-repeated-cursor-test ()
   "Test `agent-shell--list-sessions' stops when an agent repeats a cursor."

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -2798,6 +2798,77 @@ so the command must not append a second time."
       (when (and test-buffer (buffer-live-p test-buffer))
         (kill-buffer test-buffer)))))
 
+(ert-deftest agent-shell--make-session-list-request-test ()
+  "Test `agent-shell--make-session-list-request' adds an optional cursor."
+  (let ((first-page (agent-shell--make-session-list-request :cwd "/tmp/"))
+        (next-page (agent-shell--make-session-list-request
+                    :cwd "/tmp/"
+                    :cursor "next-page")))
+    (should (equal (map-nested-elt first-page '(:params cwd)) "/tmp"))
+    (should-not (map-nested-elt first-page '(:params cursor)))
+    (should (equal (map-nested-elt next-page '(:params cwd)) "/tmp"))
+    (should (equal (map-nested-elt next-page '(:params cursor)) "next-page"))))
+
+(ert-deftest agent-shell--list-sessions-fetches-all-pages-test ()
+  "Test `agent-shell--list-sessions' follows cursors through empty pages."
+  (let (failure requests sessions)
+    (cl-letf (((symbol-function 'agent-shell--send-request)
+               (lambda (&rest args)
+                 (let* ((request (plist-get args :request))
+                        (cursor (map-nested-elt request '(:params cursor))))
+                   (push request requests)
+                   (funcall
+                    (plist-get args :on-success)
+                    (cond
+                     ((not cursor)
+                      '((sessions . []) (nextCursor . "page-2")))
+                     ((equal cursor "page-2")
+                      '((sessions . [((sessionId . "session-1"))])
+                        (nextCursor . "page-3")))
+                     ((equal cursor "page-3")
+                      '((sessions . [((sessionId . "session-2"))])))
+                     (t (error "Unexpected cursor: %s" cursor))))))))
+      (agent-shell--list-sessions
+       :state '((:client . test-client))
+       :cwd "/tmp"
+       :buffer (current-buffer)
+       :on-success (lambda (result) (setq sessions result))
+       :on-failure (lambda (&rest args) (setq failure args))))
+    (setq requests (nreverse requests))
+    (should-not failure)
+    (should (equal (mapcar (lambda (request)
+                             (map-nested-elt request '(:params cursor)))
+                           requests)
+                   '(nil "page-2" "page-3")))
+    (should (seq-every-p (lambda (request)
+                           (equal (map-nested-elt request '(:params cwd)) "/tmp"))
+                         requests))
+    (should (equal (mapcar (lambda (session)
+                             (map-elt session 'sessionId))
+                           sessions)
+                   '("session-1" "session-2")))))
+
+(ert-deftest agent-shell--list-sessions-rejects-repeated-cursor-test ()
+  "Test `agent-shell--list-sessions' stops when an agent repeats a cursor."
+  (let ((request-count 0)
+        failure
+        sessions)
+    (cl-letf (((symbol-function 'agent-shell--send-request)
+               (lambda (&rest args)
+                 (setq request-count (1+ request-count))
+                 (funcall (plist-get args :on-success)
+                          '((sessions . []) (nextCursor . "same-cursor"))))))
+      (agent-shell--list-sessions
+       :state '((:client . test-client))
+       :cwd "/tmp"
+       :buffer (current-buffer)
+       :on-success (lambda (result) (setq sessions result))
+       :on-failure (lambda (&rest args) (setq failure args))))
+    (should (= request-count 2))
+    (should-not sessions)
+    (should (equal (map-nested-elt (car failure) '(message))
+                   "Agent repeated a session/list cursor"))))
+
 (ert-deftest agent-shell--initiate-session-prefers-list-and-load-when-supported ()
   "Test `agent-shell--initiate-session' prefers session/list + session/load."
   (with-temp-buffer
@@ -2841,10 +2912,13 @@ so the command must not append a second time."
                           (method (map-elt request :method)))
                      (pcase method
                        ("session/list"
-                        (funcall (plist-get args :on-success)
-                                 '((sessions . [((sessionId . "session-123")
-                                                 (cwd . "/tmp")
-                                                 (title . "Recent session"))]))))
+                        (funcall
+                         (plist-get args :on-success)
+                         (if (map-nested-elt request '(:params cursor))
+                             '((sessions . [((sessionId . "session-123")
+                                             (cwd . "/tmp")
+                                             (title . "Recent session"))]))
+                           '((sessions . []) (nextCursor . "next-page")))))
                        ("session/load"
                         (funcall (plist-get args :on-success)
                                  '((modes (currentModeId . "default")
@@ -2864,8 +2938,13 @@ so the command must not append a second time."
           (should (equal (mapcar (lambda (req)
                                    (map-elt (plist-get req :request) :method))
                                  ordered-requests)
-                         '("session/list" "session/load")))
-          (let* ((load-request (plist-get (nth 1 ordered-requests) :request))
+                         '("session/list" "session/list" "session/load")))
+          (should-not (map-nested-elt (plist-get (nth 0 ordered-requests) :request)
+                                      '(:params cursor)))
+          (should (equal (map-nested-elt (plist-get (nth 1 ordered-requests) :request)
+                                         '(:params cursor))
+                         "next-page"))
+          (let* ((load-request (plist-get (nth 2 ordered-requests) :request))
                  (load-params (map-elt load-request :params)))
             (should (equal (map-elt load-params 'sessionId) "session-123"))
             (should (equal (map-elt load-params 'cwd) "/tmp"))))


### PR DESCRIPTION
This PR fixes the issue for some providers, like Codex and Qwen, where not all sessions are listed because pagination was not handled. Other providers, like Claude, currently return all sessions on the first page, so their behavior remains unchanged.

I also added an optional page limit for session listing requests. This limits the number of pages/requests followed during pagination, not the number of sessions, and it defaults to `nil`, meaning all pages are fetched. The option therefore does not impose a default cap, a finite limit is explicitly opt-in and may silently truncate the result.

I'm aware of the "Avoid premature customization" guidance in CONTRIBUTING, but it still seems better to have this option because without it agent-shell may follow a provider-determined number of pages, while ACP does not expose a portable page-size/session-count parameter. However, if you think this customization is redundant, no problem-just say the word and I will remove it.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.

Only after opening the PR did I realize that I should have created an issue first. Sorry about that. I'm happy to treat this PR as the discussion and adjust or reduce its scope based on your feedback.