### PR TITLE
Slash command completion at prompt start

### DIFF
--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -26,8 +26,10 @@
 
 ;;; Code:
 
+(require 'comint)
 (require 'map)
 (require 'seq)
+(require 'subr-x)
 (require 'agent-shell-project)
 
 (declare-function agent-shell--shell-buffer "agent-shell")
@@ -52,6 +54,33 @@ the word, nil otherwise."
                 ((or (= start (1+ (line-beginning-position)))
                      (memq (char-before (1- start)) '(?\s ?\t ?\n)))))
       `((:start . ,start) (:end . ,end)))))
+
+(defun agent-shell-completion--input-start ()
+  "Return the position where the prompt input being composed begins.
+Handles the shell's comint prompt, the viewport's compose buffer and the
+minibuffer reading a queued prompt.  Falls back to `point-min'."
+  (cond
+   ((minibufferp)
+    (minibuffer-prompt-end))
+   ((derived-mode-p 'agent-shell-viewport-edit-mode)
+    (point-min))
+   ((and (derived-mode-p 'comint-mode)
+         comint-last-prompt
+         (>= (point) (cdr comint-last-prompt)))
+    (marker-position (cdr comint-last-prompt)))
+   (t
+    (point-min))))
+
+(defun agent-shell-completion--command-start-p (position)
+  "Non-nil when POSITION is where a slash command can start.
+Agents only recognize a slash command as the first thing in a message,
+so only whitespace may precede POSITION in the input being composed.
+
+With input \"summarize \" typed at the prompt, POSITION right after the
+space is nil, while POSITION right after the prompt is non-nil."
+  (string-blank-p (buffer-substring-no-properties
+                   (min (agent-shell-completion--input-start) position)
+                   position)))
 
 (defun agent-shell--capf-exit-with-space (_string _status)
   "Insert space after completion."
@@ -102,6 +131,8 @@ buffer.  Returns nil if the override is set but its buffer is dead."
 (defun agent-shell--command-completion-at-point ()
   "Complete available commands after /."
   (when-let* ((bounds (agent-shell--completion-bounds "[:alnum:]_-" ?/))
+              ;; Bounds start after /, so the / itself sits one char back.
+              ((agent-shell-completion--command-start-p (1- (map-elt bounds :start))))
               (source (or (and (buffer-live-p agent-shell-completion--shell-buffer)
                                agent-shell-completion--shell-buffer)
                           (agent-shell--shell-buffer :no-error t :no-create t)))
@@ -124,7 +155,9 @@ buffer.  Returns nil if the override is set but its buffer is dead."
 (defun agent-shell--trigger-completion-at-point ()
   "Trigger completion when @ or / is typed at a word boundary.
 Only triggers when the character is at line start or after whitespace,
-preventing spurious completions mid-word or in paths."
+preventing spurious completions mid-word or in paths.  / additionally
+requires being at the start of the input, where agents recognize
+commands."
   (when (and (memq (char-before) '(?@ ?/))
              (or (= (point) (1+ (line-beginning-position)))
                  (memq (char-before (1- (point))) '(?\s ?\t ?\n))))

--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -61,9 +61,9 @@ Handles the shell's live comint prompt, the viewport's compose buffer
 and the minibuffer reading a queued prompt.  Falls back to `point-min',
 which includes a stale prompt with agent output streaming below it.
 
-With the shell buffer ending in `Claude> summarize', where the prompt
-`Claude> ' ends at position 30 and the typed `summarize' occupies 30 to
-39, returns 30."
+With the shell buffer ending in `Claude> hello', where the prompt
+`Claude> ' ends at position 30 and the typed `hello' occupies 30 to 35,
+returns 30."
   (cond
    ((minibufferp)
     (minibuffer-prompt-end))
@@ -83,10 +83,10 @@ Agents only recognize a slash command as the very first character of a
 message, so nothing at all may precede POSITION in the input being
 composed.
 
-With the shell buffer ending in `Claude> summarize ', where the typed
-input occupies 30 to 40: a / typed right after the prompt (POSITION 30)
-returns non-nil, while one typed after `summarize ' (POSITION 40)
-returns nil."
+With the shell buffer ending in `Claude> hello ', where the typed input
+occupies 30 to 36: a / typed right after the prompt (POSITION 30)
+returns non-nil, while one typed after `hello ' (POSITION 36) returns
+nil."
   (= position (agent-shell-completion--input-start)))
 
 (defun agent-shell--capf-exit-with-space (_string _status)

--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -29,9 +29,9 @@
 (require 'comint)
 (require 'map)
 (require 'seq)
-(require 'subr-x)
 (require 'agent-shell-project)
 
+(declare-function agent-shell--live-input-prompt-p "agent-shell")
 (declare-function agent-shell--shell-buffer "agent-shell")
 (declare-function agent-shell--project-files "agent-shell-project")
 
@@ -57,8 +57,9 @@ the word, nil otherwise."
 
 (defun agent-shell-completion--input-start ()
   "Return the position where the prompt input being composed begins.
-Handles the shell's comint prompt, the viewport's compose buffer and the
-minibuffer reading a queued prompt.  Falls back to `point-min'.
+Handles the shell's live comint prompt, the viewport's compose buffer
+and the minibuffer reading a queued prompt.  Falls back to `point-min',
+which includes a stale prompt with agent output streaming below it.
 
 With `Claude> summarize' ending the shell buffer and `summarize'
 spanning 30 to 39, returns 30."
@@ -69,6 +70,7 @@ spanning 30 to 39, returns 30."
     (point-min))
    ((and (derived-mode-p 'comint-mode)
          comint-last-prompt
+         (agent-shell--live-input-prompt-p comint-last-prompt)
          (>= (point) (cdr comint-last-prompt)))
     (marker-position (cdr comint-last-prompt)))
    (t
@@ -76,14 +78,13 @@ spanning 30 to 39, returns 30."
 
 (defun agent-shell-completion--command-start-p (position)
   "Non-nil when POSITION is where a slash command can start.
-Agents only recognize a slash command as the first thing in a message,
-so only whitespace may precede POSITION in the input being composed.
+Agents only recognize a slash command as the very first character of a
+message, so nothing at all may precede POSITION in the input being
+composed.
 
 With `Claude> summarize ' ending the shell buffer and the input spanning
-30 to 40, returns nil for POSITION 40 and non-nil for POSITION 30."
-  (string-blank-p (buffer-substring-no-properties
-                   (min (agent-shell-completion--input-start) position)
-                   position)))
+30 to 40, returns non-nil for POSITION 30 and nil for POSITION 40."
+  (= position (agent-shell-completion--input-start)))
 
 (defun agent-shell--capf-exit-with-space (_string _status)
   "Insert space after completion."

--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -58,7 +58,10 @@ the word, nil otherwise."
 (defun agent-shell-completion--input-start ()
   "Return the position where the prompt input being composed begins.
 Handles the shell's comint prompt, the viewport's compose buffer and the
-minibuffer reading a queued prompt.  Falls back to `point-min'."
+minibuffer reading a queued prompt.  Falls back to `point-min'.
+
+With `Claude> summarize' ending the shell buffer and `summarize'
+spanning 30 to 39, returns 30."
   (cond
    ((minibufferp)
     (minibuffer-prompt-end))
@@ -76,8 +79,8 @@ minibuffer reading a queued prompt.  Falls back to `point-min'."
 Agents only recognize a slash command as the first thing in a message,
 so only whitespace may precede POSITION in the input being composed.
 
-With input \"summarize \" typed at the prompt, POSITION right after the
-space is nil, while POSITION right after the prompt is non-nil."
+With `Claude> summarize ' ending the shell buffer and the input spanning
+30 to 40, returns nil for POSITION 40 and non-nil for POSITION 30."
   (string-blank-p (buffer-substring-no-properties
                    (min (agent-shell-completion--input-start) position)
                    position)))

--- a/agent-shell-completion.el
+++ b/agent-shell-completion.el
@@ -61,8 +61,9 @@ Handles the shell's live comint prompt, the viewport's compose buffer
 and the minibuffer reading a queued prompt.  Falls back to `point-min',
 which includes a stale prompt with agent output streaming below it.
 
-With `Claude> summarize' ending the shell buffer and `summarize'
-spanning 30 to 39, returns 30."
+With the shell buffer ending in `Claude> summarize', where the prompt
+`Claude> ' ends at position 30 and the typed `summarize' occupies 30 to
+39, returns 30."
   (cond
    ((minibufferp)
     (minibuffer-prompt-end))
@@ -77,13 +78,15 @@ spanning 30 to 39, returns 30."
     (point-min))))
 
 (defun agent-shell-completion--command-start-p (position)
-  "Non-nil when POSITION is where a slash command can start.
+  "Non-nil when a / typed at POSITION starts a slash command.
 Agents only recognize a slash command as the very first character of a
 message, so nothing at all may precede POSITION in the input being
 composed.
 
-With `Claude> summarize ' ending the shell buffer and the input spanning
-30 to 40, returns non-nil for POSITION 30 and nil for POSITION 40."
+With the shell buffer ending in `Claude> summarize ', where the typed
+input occupies 30 to 40: a / typed right after the prompt (POSITION 30)
+returns non-nil, while one typed after `summarize ' (POSITION 40)
+returns nil."
   (= position (agent-shell-completion--input-start)))
 
 (defun agent-shell--capf-exit-with-space (_string _status)

--- a/tests/agent-shell-completion-tests.el
+++ b/tests/agent-shell-completion-tests.el
@@ -3,6 +3,7 @@
 (require 'comint)
 (require 'ert)
 (require 'map)
+(require 'agent-shell)
 (require 'agent-shell-completion)
 
 ;;; Code:
@@ -40,22 +41,23 @@
     shell))
 
 (ert-deftest agent-shell-completion-command-at-input-start-test ()
-  "Commands complete at the start of the input, ignoring leading whitespace."
+  "Commands complete when / is the first character of the input."
   (let ((shell (agent-shell-completion-tests--make-shell)))
     (unwind-protect
-        (dolist (input '("/he" "  /he"))
-          (with-temp-buffer
-            (setq-local agent-shell-completion--shell-buffer shell)
-            (insert input)
-            (should (equal (nth 2 (agent-shell--command-completion-at-point))
-                           '("help" "compact")))))
+        (with-temp-buffer
+          (setq-local agent-shell-completion--shell-buffer shell)
+          (insert "/he")
+          (should (equal (nth 2 (agent-shell--command-completion-at-point))
+                         '("help" "compact"))))
       (kill-buffer shell))))
 
 (ert-deftest agent-shell-completion-command-mid-input-test ()
-  "Agents only recognize commands starting a message, so / mid-input is text."
+  "Agents only recognize a command as a message's very first character.
+Anything ahead of the /, including whitespace and earlier lines of a
+multi-line prompt, makes it plain text."
   (let ((shell (agent-shell-completion-tests--make-shell)))
     (unwind-protect
-        (dolist (input '("summarize /he" "summarize\n/he"))
+        (dolist (input '("  /he" "summarize /he" "summarize\n/he"))
           (with-temp-buffer
             (setq-local agent-shell-completion--shell-buffer shell)
             (insert input)
@@ -76,6 +78,24 @@
           (should (equal (nth 2 (agent-shell--command-completion-at-point))
                          '("help" "compact")))
           (insert " now what /he")
+          (should-not (agent-shell--command-completion-at-point)))
+      (kill-buffer shell))))
+
+(ert-deftest agent-shell-completion-command-below-stale-prompt-test ()
+  "A prompt with agent output below it is stale, not an input area.
+`comint-last-prompt' still points at it while output streams, so its end
+is where output begins rather than where typing begins."
+  (let ((shell (agent-shell-completion-tests--make-shell)))
+    (unwind-protect
+        (with-temp-buffer
+          (comint-mode)
+          (setq-local agent-shell-completion--shell-buffer shell)
+          (insert "Fake> ")
+          (setq-local comint-last-prompt (cons (copy-marker (- (point) 6))
+                                               (copy-marker (point))))
+          (save-excursion
+            (insert (propertize "Thinking..." 'field 'output)))
+          (insert "/he")
           (should-not (agent-shell--command-completion-at-point)))
       (kill-buffer shell))))
 

--- a/tests/agent-shell-completion-tests.el
+++ b/tests/agent-shell-completion-tests.el
@@ -1,5 +1,6 @@
 ;;; agent-shell-completion-tests.el --- Tests for agent-shell completion -*- lexical-binding: t; -*-
 
+(require 'comint)
 (require 'ert)
 (require 'map)
 (require 'agent-shell-completion)
@@ -26,6 +27,57 @@
       (should bounds)
       (should (equal (map-elt bounds :start) 3))
       (should (equal (map-elt bounds :end) 7)))))
+
+(defun agent-shell-completion-tests--make-shell ()
+  "Return a buffer offering /help and /compact as available commands."
+  (let ((shell (generate-new-buffer " *agent-shell-completion-test*")))
+    (with-current-buffer shell
+      (setq-local agent-shell--state
+                  '((:available-commands . (((name . "help")
+                                             (description . "Show help"))
+                                            ((name . "compact")
+                                             (description . "Compact history")))))))
+    shell))
+
+(ert-deftest agent-shell-completion-command-at-input-start-test ()
+  "Commands complete at the start of the input, ignoring leading whitespace."
+  (let ((shell (agent-shell-completion-tests--make-shell)))
+    (unwind-protect
+        (dolist (input '("/he" "  /he"))
+          (with-temp-buffer
+            (setq-local agent-shell-completion--shell-buffer shell)
+            (insert input)
+            (should (equal (nth 2 (agent-shell--command-completion-at-point))
+                           '("help" "compact")))))
+      (kill-buffer shell))))
+
+(ert-deftest agent-shell-completion-command-mid-input-test ()
+  "Agents only recognize commands starting a message, so / mid-input is text."
+  (let ((shell (agent-shell-completion-tests--make-shell)))
+    (unwind-protect
+        (dolist (input '("summarize /he" "summarize\n/he"))
+          (with-temp-buffer
+            (setq-local agent-shell-completion--shell-buffer shell)
+            (insert input)
+            (should-not (agent-shell--command-completion-at-point))))
+      (kill-buffer shell))))
+
+(ert-deftest agent-shell-completion-command-after-shell-prompt-test ()
+  "Text above the prompt is not input, so / after the prompt still completes."
+  (let ((shell (agent-shell-completion-tests--make-shell)))
+    (unwind-protect
+        (with-temp-buffer
+          (comint-mode)
+          (setq-local agent-shell-completion--shell-buffer shell)
+          (insert "What time is it?\n\nIt is 5 o'clock.\n\nFake> ")
+          (setq-local comint-last-prompt (cons (copy-marker (- (point) 6))
+                                               (copy-marker (point))))
+          (insert "/he")
+          (should (equal (nth 2 (agent-shell--command-completion-at-point))
+                         '("help" "compact")))
+          (insert " now what /he")
+          (should-not (agent-shell--command-completion-at-point)))
+      (kill-buffer shell))))
 
 (ert-deftest agent-shell-completion-setup-queued-prompt-test ()
   "The queued-prompt hook enables completion for the event's shell.


### PR DESCRIPTION
Agents recognise a slash command as the first thing in a message, so a "/" typed mid-prompt (or on a later line of a multi-line prompt) is plain text and shouldn't pop the command menu.

This behavior is also consistent with all mainstream CLI harnesses (tested with Claude, Codex, and Pi). That said, it’s worth noting that Pi does allow leading whitespace and will still trigger the command menu if / is preceded only by whitespace characters. Happy to do this instead, but it does make the implementation slightly more complex.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
