### PR TITLE
Display Pi terminal output in agent-shell.

### DIFF
--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -93,14 +93,48 @@ Examples:
                     agent-shell-pi--terminal-output-snapshots)))
 
 (cl-defun agent-shell-pi--notification-adapter (&key acp-notification)
-  "Adapt Pi terminal metadata into standard ACP tool-call content.
+  "Adapt Pi terminal metadata to standard ACP tool-call content.
 
-Pi's ACP adapter emits terminal output as incremental `data' values in
-`_meta.terminal_output' and signals completion with `_meta.terminal_exit'.
-Accumulate those values by terminal ID and expose the result as regular
-text content for `agent-shell'.
+Pi's current `pi-acp' sequence for a bash call is:
 
-Existing tool-call content is left unchanged.  ACP-NOTIFICATION is returned
+  1. `tool_call' includes general terminal content and `_meta.terminal_info'.
+  2. One or more `tool_call_update' with status `in_progress' and
+     `_meta.terminal_output' with an output since last update in `data'.
+  3. A final `tool_call_update' with status `completed' and the last
+     `_meta.terminal_output' delta together with `_meta.terminal_exit'.
+
+For a terminal ID `call-1', an example flow can look like this:
+
+  `tool_call':
+    (content . [((type . \"terminal\") (terminalId . \"call-1\"))])
+    (_meta (terminal_info (terminal_id . \"call-1\") (cwd . \"/project\")))
+
+  `tool_call_update':
+    (status . \"in_progress\")
+    (_meta (terminal_output (terminal_id . \"call-1\")
+                            (data . \"hello\\\\n\")))
+
+  `tool_call_update':
+    (status . \"completed\")
+    (_meta (terminal_output (terminal_id . \"call-1\") (data . \"world\"))
+           (terminal_exit (terminal_id . \"call-1\") (exit_code . 0)
+                          (signal . nil)))
+
+In this example, the two output deltas, \"hello\\n\" and \"world\", should go to
+`agent-shell' as a text content block containing:
+
+  ```
+  hello
+  world
+  ```
+
+The adapter accumulates output by terminal ID because each update contains a
+delta, and fills in `content' when pi-acp omits it. The current pi-acp version
+sends `terminal_exit' with the final status update; it does not send another
+status-only update afterward. If a status-only update follows an output
+update, the saved output is reused before it is discarded.
+
+Existing tool-call content is left unchanged. ACP-NOTIFICATION is returned
 after adaptation."
   (when-let* ((method (map-elt acp-notification 'method))
               ((equal method "session/update"))
@@ -114,7 +148,11 @@ after adaptation."
                             (map-elt terminal-exit 'terminal_id)
                             (map-elt update 'toolCallId))))
       (when (and (stringp terminal-id)
-                 (or terminal-output terminal-exit))
+                 (or terminal-output
+                     terminal-exit
+                     (alist-get terminal-id
+                                agent-shell-pi--terminal-output-snapshots
+                                nil nil #'equal)))
         (unless (local-variable-p 'agent-shell-pi--terminal-output-snapshots)
           (setq-local agent-shell-pi--terminal-output-snapshots nil))
         (when-let* ((data (map-elt terminal-output 'data)))
@@ -132,7 +170,8 @@ after adaptation."
                            (alist-get 'update
                                       (alist-get 'params acp-notification)))
                 content))
-        (when terminal-exit
+        (when (or terminal-exit
+                  (member (map-elt update 'status) '("completed" "failed")))
           (agent-shell-pi--forget-terminal-output terminal-id)))))
   acp-notification)
 

--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -34,6 +34,8 @@
   (require 'cl-lib))
 (require 'shell-maker)
 (require 'acp)
+(require 'map)
+(require 'seq)
 
 (declare-function agent-shell--indent-string "agent-shell")
 (declare-function agent-shell-make-agent-config "agent-shell")
@@ -67,6 +69,71 @@ Example usage to set custom environment variables:
   :type '(repeat string)
   :group 'agent-shell)
 
+(defvar-local agent-shell-pi--terminal-output-snapshots nil
+  "Alist of Pi terminal IDs and accumulated output for the current buffer.")
+
+(defun agent-shell-pi--terminal-output-content (text)
+  "Return standard ACP content for terminal output TEXT.
+
+Examples:
+
+  (agent-shell-pi--terminal-output-content \"hello\")
+    => (((type . \"content\")
+         (content (type . \"text\") (text . \"```\\nhello\\n```\"))))"
+  (when (and (stringp text) (not (string-empty-p text)))
+    (list `((type . "content")
+            (content (type . "text")
+                     (text . ,(format "```\n%s\n```" text)))))))
+
+(defun agent-shell-pi--forget-terminal-output (terminal-id)
+  "Forget accumulated output for Pi TERMINAL-ID in the current buffer."
+  (setq agent-shell-pi--terminal-output-snapshots
+        (seq-remove (lambda (entry)
+                      (equal (car entry) terminal-id))
+                    agent-shell-pi--terminal-output-snapshots)))
+
+(cl-defun agent-shell-pi--notification-adapter (&key acp-notification)
+  "Adapt Pi terminal metadata into standard ACP tool-call content.
+
+Pi's ACP adapter emits terminal output as incremental `data' values in
+`_meta.terminal_output' and signals completion with `_meta.terminal_exit'.
+Accumulate those values by terminal ID and expose the result as regular
+text content for `agent-shell'.
+
+Existing tool-call content is left unchanged.  ACP-NOTIFICATION is returned
+after adaptation."
+  (when-let* ((method (map-elt acp-notification 'method))
+              ((equal method "session/update"))
+              (update-type (map-nested-elt acp-notification
+                                            '(params update sessionUpdate)))
+              ((equal update-type "tool_call_update")))
+    (let* ((update (map-nested-elt acp-notification '(params update)))
+           (terminal-output (map-nested-elt update '(_meta terminal_output)))
+           (terminal-exit (map-nested-elt update '(_meta terminal_exit)))
+           (terminal-id (or (map-elt terminal-output 'terminal_id)
+                            (map-elt terminal-exit 'terminal_id)
+                            (map-elt update 'toolCallId))))
+      (when (and (stringp terminal-id)
+                 (or terminal-output terminal-exit))
+        (when-let* ((data (map-elt terminal-output 'data)))
+          (when (stringp data)
+            (setf (alist-get terminal-id agent-shell-pi--terminal-output-snapshots
+                             nil nil #'equal)
+                  (concat (alist-get terminal-id agent-shell-pi--terminal-output-snapshots
+                                     "" nil #'equal)
+                          data))))
+        (when-let* ((output (alist-get terminal-id agent-shell-pi--terminal-output-snapshots
+                                      nil nil #'equal))
+                    ((seq-empty-p (map-elt update 'content)))
+                    (content (agent-shell-pi--terminal-output-content output)))
+          (setf (alist-get 'content
+                           (alist-get 'update
+                                      (alist-get 'params acp-notification)))
+                content))
+        (when terminal-exit
+          (agent-shell-pi--forget-terminal-output terminal-id)))))
+  acp-notification)
+
 (defun agent-shell-pi-make-agent-config ()
   "Create a Pi coding agent configuration.
 
@@ -81,6 +148,7 @@ Returns an agent configuration alist using `agent-shell-make-agent-config'."
    :welcome-function #'agent-shell-pi--welcome-message
    :client-maker (lambda (buffer)
                    (agent-shell-pi-make-client :buffer buffer))
+   :notification-adapter #'agent-shell-pi--notification-adapter
    :install-instructions "See https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent for Pi installation.
 Requires pi-acp adapter for ACP integration."))
 

--- a/agent-shell-pi.el
+++ b/agent-shell-pi.el
@@ -115,6 +115,8 @@ after adaptation."
                             (map-elt update 'toolCallId))))
       (when (and (stringp terminal-id)
                  (or terminal-output terminal-exit))
+        (unless (local-variable-p 'agent-shell-pi--terminal-output-snapshots)
+          (setq-local agent-shell-pi--terminal-output-snapshots nil))
         (when-let* ((data (map-elt terminal-output 'data)))
           (when (stringp data)
             (setf (alist-get terminal-id agent-shell-pi--terminal-output-snapshots

--- a/tests/agent-shell-pi-tests.el
+++ b/tests/agent-shell-pi-tests.el
@@ -1,0 +1,91 @@
+;;; agent-shell-pi-tests.el --- Tests for agent-shell-pi -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'agent-shell-pi)
+(require 'map)
+
+;;; Code:
+
+(ert-deftest agent-shell-pi--notification-adapter-terminal-output-test ()
+  "Test `agent-shell-pi--notification-adapter' accumulates terminal output.
+Pi sends terminal output as deltas in `_meta.terminal_output'.  Its current
+final update also includes `_meta.terminal_exit'; a status-only final update
+is accepted as well so it cannot replace the accumulated output with empty
+content."
+  (with-temp-buffer
+    (setq-local agent-shell-pi--terminal-output-snapshots nil)
+    (let ((notification
+           '((method . "session/update")
+             (params
+              (update
+               (sessionUpdate . "tool_call_update")
+               (toolCallId . "call-1")
+               (status . "in_progress")
+               (_meta
+                (terminal_output
+                 (terminal_id . "call-1")
+                 (data . "hello\n"))))))))
+      (agent-shell-pi--notification-adapter :acp-notification notification)
+      (should (equal
+               (map-nested-elt notification '(params update content))
+               '(((type . "content")
+                  (content (type . "text") (text . "```\nhello\n\n```")))))))
+    (let ((notification
+           '((method . "session/update")
+             (params
+              (update
+               (sessionUpdate . "tool_call_update")
+               (toolCallId . "call-1")
+               (status . "completed")
+               (_meta
+                (terminal_output
+                 (terminal_id . "call-1")
+                 (data . "world"))
+                (terminal_exit
+                 (terminal_id . "call-1")
+                 (exit_code . 0)
+                 (signal . nil))))))))
+      (agent-shell-pi--notification-adapter :acp-notification notification)
+      (should (equal
+               (map-nested-elt notification '(params update content))
+               '(((type . "content")
+                  (content (type . "text")
+                           (text . "```\nhello\nworld\n```")))))))
+    (should-not agent-shell-pi--terminal-output-snapshots))
+
+  (with-temp-buffer
+    (setq-local agent-shell-pi--terminal-output-snapshots nil)
+    (let ((notification
+           '((method . "session/update")
+             (params
+              (update
+               (sessionUpdate . "tool_call_update")
+               (toolCallId . "call-2")
+               (status . "in_progress")
+               (_meta
+                (terminal_output
+                 (terminal_id . "call-2")
+                 (data . "kept"))))))))
+      (agent-shell-pi--notification-adapter :acp-notification notification))
+    (let ((notification
+           '((method . "session/update")
+             (params
+              (update
+               (sessionUpdate . "tool_call_update")
+               (toolCallId . "call-2")
+               (status . "completed"))))))
+      (agent-shell-pi--notification-adapter :acp-notification notification)
+      (should (equal
+               (map-nested-elt notification '(params update content))
+               '(((type . "content")
+                  (content (type . "text") (text . "```\nkept\n```")))))))
+    (should-not agent-shell-pi--terminal-output-snapshots)))
+
+(ert-deftest agent-shell-pi-make-agent-config-notification-adapter-test ()
+  "Test Pi's agent configuration installs its notification adapter."
+  (should (eq (map-elt (agent-shell-pi-make-agent-config)
+                       :notification-adapter)
+              #'agent-shell-pi--notification-adapter)))
+
+(provide 'agent-shell-pi-tests)
+;;; agent-shell-pi-tests.el ends here


### PR DESCRIPTION
I am using pi-acp, and it sends terminal output in a custom meta field. This is not against the ACP spec, just a bit unfortunate because now the client needs to do something with it. I am also preparing a PR to pi-acp. However, the maintainer of pi-acp is not super active (judging by the open PRs for other ACP features), so I would like to fix this on the agent-shell side for now if that's ok. The notification-adapter seems like the natural hook for this.

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
