### PR TITLE
Add prefix-arg page jumps to viewport paging

### DIFF
--- a/agent-shell-viewport.el
+++ b/agent-shell-viewport.el
@@ -946,22 +946,54 @@ QUOTED-TEXT is inserted as a block quote as part of the reply."
   (insert "continue")
   (agent-shell-viewport-compose-send))
 
-(defun agent-shell-viewport-previous-page ()
-  "Show previous interaction (request / response)."
-  (declare (modes agent-shell-viewport-view-mode))
-  (interactive)
-  (agent-shell-viewport-next-page :backwards t :start-at-top t))
+(defun agent-shell-viewport--restore-compose-snapshot ()
+  "Open the compose page on the parked draft, consuming the snapshot."
+  (let ((snapshot agent-shell-viewport--compose-snapshot))
+    (agent-shell-viewport-edit-mode)
+    (agent-shell-viewport--initialize)
+    (insert (map-elt snapshot :content))
+    (goto-char (map-elt snapshot :location))
+    (setq agent-shell-viewport--compose-snapshot nil)))
 
-(cl-defun agent-shell-viewport-next-page (&key backwards start-at-top)
+(defun agent-shell-viewport--move-pages (backwards n)
+  "Move up to N interactions in the current shell buffer.
+Move backwards when BACKWARDS is non-nil.  Return an alist of
+:interaction, the last interaction reached (nil when none was), and
+:exhausted, non-nil when history ran out before N moves."
+  (let ((remaining n)
+        (interaction nil)
+        (stepped t))
+    (while (and (> remaining 0) stepped)
+      (setq stepped (shell-maker-next-command-and-response backwards :trimmed nil))
+      (when stepped
+        (setq interaction stepped)
+        (setq remaining (1- remaining))))
+    `((:interaction . ,interaction)
+      (:exhausted . ,(> remaining 0)))))
+
+(defun agent-shell-viewport-previous-page (&optional n)
+  "Show previous interaction (request / response).
+
+N (default 1) is how many interactions to move back; a prefix argument
+supplies it."
+  (declare (modes agent-shell-viewport-view-mode))
+  (interactive "p")
+  (agent-shell-viewport-next-page :backwards t :start-at-top t :n n))
+
+(cl-defun agent-shell-viewport-next-page (&key backwards start-at-top n)
   "Show next interaction (request / response).
 
 If BACKWARDS is non-nil, go to previous interaction.
 If START-AT-TOP is non-nil, position at point-min regardless of direction.
+N (default 1) is how many interactions to move; a prefix argument
+supplies it.  Moving forward past the newest interaction restores a
+compose snapshot when one exists, and otherwise stops on the last
+interaction reached.
 
 If there are no more next items and a compose snapshot exists, restore the
 buffer from the snapshot and switch to edit mode."
   (declare (modes agent-shell-viewport-view-mode))
-  (interactive)
+  (interactive (list :n (prefix-numeric-value current-prefix-arg)))
   (unless (derived-mode-p 'agent-shell-viewport-view-mode)
     (error "Not in a viewport buffer"))
   (when (agent-shell-viewport--busy-p)
@@ -973,13 +1005,9 @@ buffer from the snapshot and switch to edit mode."
     (if (and (not backwards) snapshot pos
              (= (map-elt pos :current) (map-elt pos :total)))
         (progn
-          (agent-shell-viewport-edit-mode)
-          (agent-shell-viewport--initialize)
-          (insert (map-elt snapshot :content))
-          (goto-char (map-elt snapshot :location))
-          (setq agent-shell-viewport--compose-snapshot nil)
+          (agent-shell-viewport--restore-compose-snapshot)
           (cl-return-from agent-shell-viewport-next-page))
-      (when-let* ((next (with-current-buffer shell-buffer
+      (when-let* ((move (with-current-buffer shell-buffer
                           (if backwards
                               (progn
                                 ;; Navigate relative to the interaction
@@ -1000,7 +1028,15 @@ buffer from the snapshot and switch to edit mode."
                                       (comint-next-prompt 1)
                                       (= orig-line (point))))
                               (error "No next page")))
-                          (shell-maker-next-command-and-response backwards :trimmed nil))))
+                          (agent-shell-viewport--move-pages
+                           backwards (max 1 (or n 1)))))
+                  (next (map-elt move :interaction)))
+        ;; A jump that ran past the newest interaction carries on into the
+        ;; parked draft, so a prefix argument does what pressing the key
+        ;; that many times does.
+        (when (and (not backwards) snapshot (map-elt move :exhausted))
+          (agent-shell-viewport--restore-compose-snapshot)
+          (cl-return-from agent-shell-viewport-next-page))
         (agent-shell-viewport--initialize
          :prompt (car next) :response (cdr next))
         (goto-char (if start-at-top

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -5200,6 +5200,159 @@ current interaction instead of the previous one."
       (kill-buffer viewport-buffer)
       (kill-buffer shell-buffer))))
 
+(cl-defun agent-shell-viewport-tests--with-page-steps
+    (&key entries position snapshot body)
+  "Run BODY in a view-mode viewport that can step through ENTRIES.
+Each step hands out the next of ENTRIES, a list of (prompt . response),
+and returns nil once they run out, the way
+`shell-maker-next-command-and-response' does at the end of history.
+POSITION is the stubbed `agent-shell-viewport--position' alist, and
+SNAPSHOT the compose snapshot parked before BODY runs.  Returns an alist
+of :steps (how many steps were taken), :directions (the BACKWARDS
+argument each step saw), :initialized (the keyword plist passed to
+`agent-shell-viewport--initialize'), :entered-edit (whether the compose
+page was opened) and :snapshot-after (the snapshot left behind)."
+  (let ((shell-buffer (generate-new-buffer " *agent-shell shell*"))
+        (viewport-buffer (generate-new-buffer " *agent-shell shell* [viewport]"))
+        (remaining entries)
+        (directions nil)
+        (steps 0)
+        (initialized nil)
+        (entered-edit nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer shell-buffer
+            (insert "page one\npage two\npage three\npage four\n")
+            ;; Mid-buffer, so the stubbed comint prompt motion below has
+            ;; somewhere to move in either direction.
+            (goto-char (point-min))
+            (forward-line 2))
+          (with-current-buffer viewport-buffer
+            (cl-letf (((symbol-function 'agent-shell-viewport--update-header)
+                       (lambda () nil)))
+              (agent-shell-viewport-view-mode)))
+          (with-current-buffer viewport-buffer
+            (setq-local agent-shell-viewport--compose-snapshot snapshot)
+            (cl-letf (((symbol-function 'agent-shell-viewport--busy-p)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'agent-shell-viewport--shell-buffer)
+                       (lambda (&rest _) shell-buffer))
+                      ((symbol-function 'agent-shell-viewport--position)
+                       (lambda (&rest _)
+                         (or position '((:current . 2) (:total . 4)))))
+                      ((symbol-function 'shell-maker--prompt-begin-position)
+                       (lambda () (line-beginning-position)))
+                      ((symbol-function 'comint-next-prompt)
+                       (lambda (&rest _) (forward-line 1)))
+                      ((symbol-function 'comint-previous-prompt)
+                       (lambda (&rest _) (forward-line -1)))
+                      ((symbol-function 'shell-maker-next-command-and-response)
+                       (lambda (step-backwards &rest _)
+                         (push step-backwards directions)
+                         (when remaining
+                           (setq steps (1+ steps))
+                           (pop remaining))))
+                      ((symbol-function 'agent-shell-viewport-edit-mode)
+                       (lambda ()
+                         (setq entered-edit t)
+                         ;; Real edit mode makes the buffer writable, which
+                         ;; the snapshot restore below relies on.
+                         (setq-local buffer-read-only nil)))
+                      ((symbol-function 'agent-shell-viewport--initialize)
+                       (lambda (&rest args) (setq initialized args)))
+                      ((symbol-function 'agent-shell-viewport--update-header)
+                       (lambda () nil)))
+              (funcall body)
+              `((:steps . ,steps)
+                (:directions . ,(nreverse directions))
+                (:initialized . ,initialized)
+                (:entered-edit . ,entered-edit)
+                (:snapshot-after . ,agent-shell-viewport--compose-snapshot)))))
+      (kill-buffer viewport-buffer)
+      (kill-buffer shell-buffer))))
+
+(ert-deftest agent-shell-viewport-next-page-jumps-n-pages-test ()
+  "Test `agent-shell-viewport-next-page' moves N interactions.
+
+N=2 takes two forward steps and shows the interaction reached last, not
+the one after a single step."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page three" . "three") ("page four" . "four"))
+                 :body (lambda () (agent-shell-viewport-next-page :n 2)))))
+    (should (equal (map-elt result :steps) 2))
+    (should (equal (map-elt result :directions) '(nil nil)))
+    (should (equal (map-elt result :initialized)
+                   '(:prompt "page four" :response "four")))))
+
+(ert-deftest agent-shell-viewport-previous-page-jumps-n-pages-test ()
+  "Test `agent-shell-viewport-previous-page' moves N interactions back.
+
+N=2 takes two backward steps.  A numeric prefix argument supplies the
+same N."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page two" . "two") ("page one" . "one"))
+                 :body (lambda () (agent-shell-viewport-previous-page 2)))))
+    (should (equal (map-elt result :steps) 2))
+    (should (equal (map-elt result :directions) '(t t)))
+    (should (equal (map-elt result :initialized)
+                   '(:prompt "page one" :response "one"))))
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page two" . "two") ("page one" . "one"))
+                 :body (lambda ()
+                         (let ((current-prefix-arg 2))
+                           (call-interactively
+                            #'agent-shell-viewport-previous-page))))))
+    (should (equal (map-elt result :steps) 2))))
+
+(ert-deftest agent-shell-viewport-next-page-without-n-moves-one-page-test ()
+  "Test paging with no prefix argument still moves a single interaction."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page three" . "three") ("page four" . "four"))
+                 :body (lambda () (agent-shell-viewport-next-page)))))
+    (should (equal (map-elt result :steps) 1))
+    (should (equal (map-elt result :initialized)
+                   '(:prompt "page three" :response "three")))))
+
+(ert-deftest agent-shell-viewport-next-page-n-stops-at-last-reachable-page-test ()
+  "Test an N larger than the remaining history pages as far as it can.
+
+Two interactions remain and N=5, so with no draft parked it stops on
+the last one rather than refusing to move."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page three" . "three") ("page four" . "four"))
+                 :body (lambda () (agent-shell-viewport-next-page :n 5)))))
+    (should (equal (map-elt result :steps) 2))
+    (should-not (map-elt result :entered-edit))
+    (should (equal (map-elt result :initialized)
+                   '(:prompt "page four" :response "four")))))
+
+(ert-deftest agent-shell-viewport-next-page-n-past-last-enters-compose-test ()
+  "Test a prefix jump running past the newest interaction opens the draft.
+
+Pressing the key three times from page 2 of 4 would show pages 3 and 4
+and then restore the parked draft, so C-u 3 must land there too."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page three" . "three") ("page four" . "four"))
+                 :snapshot '((:content . "draft") (:location . 1))
+                 :body (lambda () (agent-shell-viewport-next-page :n 3)))))
+    (should (equal (map-elt result :steps) 2))
+    (should (map-elt result :entered-edit))
+    (should-not (map-elt result :snapshot-after))))
+
+(ert-deftest agent-shell-viewport-next-page-n-from-last-page-enters-compose-test ()
+  "Test a prefix jump from the newest interaction opens the draft.
+
+Already being on the last page, there is nothing to step through, so
+any N restores the parked draft the way a plain step does."
+  (let ((result (agent-shell-viewport-tests--with-page-steps
+                 :entries '(("page three" . "three"))
+                 :position '((:current . 4) (:total . 4))
+                 :snapshot '((:content . "draft") (:location . 1))
+                 :body (lambda () (agent-shell-viewport-next-page :n 3)))))
+    (should (equal (map-elt result :steps) 0))
+    (should (map-elt result :entered-edit))
+    (should-not (map-elt result :snapshot-after))))
+
 (ert-deftest agent-shell-viewport-initialize-rerenders-header-position-test ()
   "Test `agent-shell-viewport--initialize' re-renders the header position.
 


### PR DESCRIPTION
> **Draft note:** description below is a factual first pass to be rewritten in
> my own words before marking this ready for review.

Feature request: #814

## What this does

`C-u N` on `agent-shell-viewport-next-page` / `agent-shell-viewport-previous-page`
(`f` / `b` in the viewport) moves N interactions instead of one.

Paging with no prefix argument takes the same code path as before. The
boundary checks and the compose-snapshot restore for an already-newest page
both still run before the first step.

## Behavior at the ends of history

- Moving forward past the newest interaction restores a parked compose
  snapshot, so `C-u N f` ends where pressing `f` N times would end rather
  than stopping one page short of the draft.
- With no snapshot to restore, an N larger than the remaining history stops
  on the last interaction reached instead of erroring. Pressing `f` that many
  times would have raised `No next page` on the last press; erroring after
  having already moved seemed less useful than stopping.
- Moving backward is unchanged apart from the count: from the first page it
  still raises `No previous page`.

## Implementation

- `agent-shell-viewport--move-pages` loops the existing
  `shell-maker-next-command-and-response` step, returning the last
  interaction reached and whether history ran out.
- `agent-shell-viewport--restore-compose-snapshot` extracts the snapshot
  restore so the pre-step and post-step paths share it.

## Testing

Six tests added under `tests/agent-shell-tests.el`, covering the N jump in
both directions, the prefix argument arriving via `call-interactively`, the
no-prefix single step, and each of the two end-of-history outcomes.

Full suite on this branch: 666 tests, 0 unexpected, 1 skipped
(`agent-shell-restart-preserves-default-directory`, which skips itself).
On `main` at the same commit base: 660 tests, 0 unexpected, 1 skipped.

`checkdoc` reports nothing on `agent-shell-viewport.el`, and
`byte-compile-file` produces the same two warnings as `main`
(`replace-buffer-contents` obsolete in `agent-shell.el`, and
`agent-shell-backward-up-item` not known to be defined), both pre-existing.

## Checklist

- [ ] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [ ] *I've reviewed all code in PR myself and will vouch for its quality*.
- [ ] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [ ] I've filed a feature request/discussion for a new feature.
- [ ] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation where necessary.
- [ ] I've run `M-x checkdoc` and `M-x byte-compile-file`.
