### PR TITLE
Check dependencies against the Package-Requires floors

### DIFF
--- a/agent-shell.el
+++ b/agent-shell.el
@@ -9,6 +9,15 @@
 
 (defconst agent-shell--version "0.75.3")
 
+;; Minimum dependency versions, as declared in the `Package-Requires'
+;; header above.  Package managers that resolve versions enforce the
+;; header on install; those that only resolve dependency names (straight.el,
+;; for one) leave `agent-shell--start' as the sole check, so keep these two
+;; in sync with it.
+(defconst agent-shell--shell-maker-minimum-version "0.97.3")
+
+(defconst agent-shell--acp-minimum-version "0.15.1")
+
 ;; This package is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)
@@ -4671,10 +4680,12 @@ SESSION-STRATEGY overrides `agent-shell-session-strategy' buffer-locally.
 SESSION-ID resumes an existing session by its id string.
 FORK-SESSION-ID forks an existing session by its id string.
 OUTGOING-REQUEST-DECORATOR is passed through to `acp-make-client'."
-  (unless (version<= "0.91.2" shell-maker-version)
-    (error "Please update shell-maker to version 0.91.2 or newer"))
-  (unless (version<= "0.14.3" acp-package-version)
-    (error "Please update acp.el to version 0.14.3 or newer"))
+  (unless (version<= agent-shell--shell-maker-minimum-version shell-maker-version)
+    (error "Please update shell-maker to version %s or newer"
+           agent-shell--shell-maker-minimum-version))
+  (unless (version<= agent-shell--acp-minimum-version acp-package-version)
+    (error "Please update acp.el to version %s or newer"
+           agent-shell--acp-minimum-version))
   (when (boundp 'agent-shell--transcript-file-path-function)
     (user-error "'agent-shell--transcript-file-path-function is retired.
 

--- a/tests/agent-shell-tests.el
+++ b/tests/agent-shell-tests.el
@@ -6999,5 +6999,22 @@ Then [after](https://after.com/y)
     (agent-shell-previous-item)
     (should (eq (char-after) ?A))))
 
+(ert-deftest agent-shell-dependency-floors-match-package-requires-test ()
+  "Runtime dependency floors match the versions `Package-Requires\' declares.
+
+`agent-shell--start\' refuses to run against a dependency older than its
+floor.  Nothing derives those floors from the header, so this pairs them:
+bumping one and not the other leaves the check accepting a version the
+package declares unsupported."
+  (require 'find-func)
+  (require 'lisp-mnt)
+  (let ((declared (with-temp-buffer
+                    (insert-file-contents (find-library-name "agent-shell"))
+                    (read (string-join (lm-header-multiline "package-requires") " ")))))
+    (should (equal (cadr (assq 'shell-maker declared))
+                   agent-shell--shell-maker-minimum-version))
+    (should (equal (cadr (assq 'acp declared))
+                   agent-shell--acp-minimum-version))))
+
 (provide 'agent-shell-tests)
 ;;; agent-shell-tests.el ends here


### PR DESCRIPTION
`agent-shell--start` checks its dependencies at runtime, but against floors that have drifted from the ones the header declares: it compares shell-maker against 0.91.2 and acp against 0.14.3, while `Package-Requires` says 0.97.3 and 0.15.1. This results in the obvious bug: A dependency whose the header label as unsupported would start a shell anyway, and the feature it lacks surfaces later as an unrelated failure/bug.

Package managers that resolve versions enforce the header on install, so this assert is belt-and-braces there. Package managers that resolve only dependency names — straight.el, for one — never look at versions at all, which leaves this check as the only gate, and a stale gate lets precisely the combination the header forbids through.

This names both floors in defconsts next to the declared versions and reports them in the error message, so bumping the header moves the check with it.

Tests: 680 ert tests, 0 unexpected, same 4 skips as the baseline (Emacs 29.1 path, deps cloned at HEAD as CI does).

**Side story: How this affected me specifically**

Concretely, with agent-shell 0.75.3 and shell-maker 0.97.2 every session restore dies silently: `shell-maker--should-auto-scroll-p` signals `args-out-of-range` when asked under the narrowing `agent-shell--update-fragment` installs for `:above-last-prompt`, so `agent-shell--finalize-session-init` never runs and the replayed history stays buffered in the state's `:pending-restore`. acp.el contains response-handler errors and only logs them when `acp-logging` is on, so nothing is reported at all — the shell just sits at a bare prompt with "Starting agent" never reaching "Ready". shell-maker fixed the signal in 0.97.3 (fe38358), which is exactly why the header requires it; the runtime assert compared against 0.91.2 and waved it through.