### PR TITLE
Give plain table data rows a face #805

### DIFF
--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -157,8 +157,8 @@
   '((t nil))
   "Face for plain (non-zebra) table data rows.
 Carries no attributes of its own, so default rendering is unchanged.
-It exists so face-remapping setups such as `mixed-pitch-mode' can pin
-every table row to the same font and keep columns aligned."
+Allows face-remapping setups such as `mixed-pitch-mode' to pin every
+table row to the same font, keeping columns aligned."
   :group 'agent-shell-markdown)
 
 (defface agent-shell-markdown-source-block

--- a/agent-shell-markdown.el
+++ b/agent-shell-markdown.el
@@ -153,6 +153,14 @@
   "Face for alternating (zebra) data rows in tables."
   :group 'agent-shell-markdown)
 
+(defface agent-shell-markdown-table-row
+  '((t nil))
+  "Face for plain (non-zebra) table data rows.
+Carries no attributes of its own, so default rendering is unchanged.
+It exists so face-remapping setups such as `mixed-pitch-mode' can pin
+every table row to the same font and keep columns aligned."
+  :group 'agent-shell-markdown)
+
 (defface agent-shell-markdown-source-block
   '((t :inherit org-block :foreground unspecified :extend t))
   "Background face applied to rendered fenced source-block bodies.
@@ -3940,7 +3948,8 @@ prone to a few-pixel drift on emoji-heavy tables."
                               (= (mod data-row-num 2) 1)))
                (row-face (cond
                           (is-header 'agent-shell-markdown-table-header)
-                          (is-zebra 'agent-shell-markdown-table-zebra))))
+                          (is-zebra 'agent-shell-markdown-table-zebra)
+                          (t 'agent-shell-markdown-table-row))))
           (unless (or is-header is-separator)
             (setq data-row-num (1+ data-row-num)))
           (push (if is-separator

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -2626,13 +2626,15 @@ after" nil)))))
 
 (ert-deftest agent-shell-markdown-convert-table-cell-uses-bold ()
   ;; Bold inside a cell is processed by the main pass; the rendered
-  ;; table preserves the bold face on \"Alice\".
+  ;; table keeps the bold face on \"Alice\", stacked over the data
+  ;; row's own face.
   (let* ((s (agent-shell-markdown-convert "| Name | Role |
 |------|------|
 | **Alice** | Engineer |"))
          (alice-pos (string-match "Alice" s)))
     (should alice-pos)
-    (should (eq 'agent-shell-markdown-bold (get-text-property alice-pos 'face s)))))
+    (should (equal '(agent-shell-markdown-bold agent-shell-markdown-table-row)
+                   (get-text-property alice-pos 'face s)))))
 
 (ert-deftest agent-shell-markdown-table-leaves-cell-link-keys-alone ()
   ;; Cells hold whatever the inline passes rendered, links included.  A
@@ -2923,7 +2925,7 @@ after" nil)))))
   ;; smear the first char's `font-lock-face' (a border) across every
   ;; cell.  A fresh render mirrors each cell's `face' to `font-lock-face'
   ;; on its own, so header cells stay `table-header' and plain data
-  ;; cells stay unstyled rather than all going border-grey.
+  ;; cells stay `table-row' rather than all going border-grey.
   (with-temp-buffer
     (insert "| A | B |\n|---|---|\n| 1 | 2 |\n")
     (agent-shell-markdown-replace-markup)
@@ -2942,17 +2944,45 @@ after" nil)))))
        (list (cons :source (prop-match-value region))
              (cons :start (prop-match-beginning region))
              (cons :end (prop-match-end region)))))
-    ;; Header cell recovers its header face; a plain data cell has no
-    ;; border font-lock-face smeared onto it.
+    ;; Header cell recovers its header face; a plain data cell gets its
+    ;; row face back rather than the smeared border face.
     (should (eq (get-text-property
                  (save-excursion (goto-char (point-min))
                                  (1- (search-forward "A")))
                  'font-lock-face)
                 'agent-shell-markdown-table-header))
-    (should (null (get-text-property
-                   (save-excursion (goto-char (point-min))
-                                   (1- (search-forward "1")))
-                   'font-lock-face)))))
+    (should (eq (get-text-property
+                 (save-excursion (goto-char (point-min))
+                                 (1- (search-forward "1")))
+                 'font-lock-face)
+                'agent-shell-markdown-table-row))))
+
+(ert-deftest agent-shell-markdown-table-every-data-row-carries-a-face ()
+  ;; Plain data rows carry `agent-shell-markdown-table-row' and
+  ;; alternating rows `agent-shell-markdown-table-zebra'.  A row with
+  ;; no face at all falls through to `default', which face-remapping
+  ;; setups such as `mixed-pitch-mode' cannot pin to a fixed-pitch
+  ;; font, so that row drifts out of line with the rest of the table.
+  (let ((cell-faces
+         (lambda (markdown)
+           (with-temp-buffer
+             (insert markdown)
+             (agent-shell-markdown-replace-markup)
+             (seq-map (lambda (cell)
+                        (goto-char (point-min))
+                        (search-forward cell)
+                        (get-text-property (1- (point)) 'face))
+                      '("1" "2" "3"))))))
+    (should (equal (funcall cell-faces "| A |\n|---|\n| 1 |\n| 2 |\n| 3 |\n")
+                   '(agent-shell-markdown-table-row
+                     agent-shell-markdown-table-zebra
+                     agent-shell-markdown-table-row)))
+    ;; With striping off, every data row is a plain row.
+    (let ((agent-shell-markdown-table-zebra-stripe nil))
+      (should (equal (funcall cell-faces "| A |\n|---|\n| 1 |\n| 2 |\n| 3 |\n")
+                     '(agent-shell-markdown-table-row
+                       agent-shell-markdown-table-row
+                       agent-shell-markdown-table-row))))))
 
 (ert-deftest agent-shell-markdown-table-sizes-against-destination-window ()
   ;; Regression: column allocation must size against the table's
@@ -3568,9 +3598,9 @@ A " nil)
              ("
 " nil)
              ("│" (agent-shell-markdown-table-border))
-             (" 1 " nil)
+             (" 1 " (agent-shell-markdown-table-row))
              ("│" (agent-shell-markdown-table-border))
-             (" 2 " nil)
+             (" 2 " (agent-shell-markdown-table-row))
              ("│" (agent-shell-markdown-table-border))))))
 
 (ert-deftest agent-shell-markdown-watermark-skips-prefix-on-streamed-append ()

--- a/tests/agent-shell-markdown-tests.el
+++ b/tests/agent-shell-markdown-tests.el
@@ -2958,11 +2958,10 @@ after" nil)))))
                 'agent-shell-markdown-table-row))))
 
 (ert-deftest agent-shell-markdown-table-every-data-row-carries-a-face ()
-  ;; Plain data rows carry `agent-shell-markdown-table-row' and
-  ;; alternating rows `agent-shell-markdown-table-zebra'.  A row with
-  ;; no face at all falls through to `default', which face-remapping
-  ;; setups such as `mixed-pitch-mode' cannot pin to a fixed-pitch
-  ;; font, so that row drifts out of line with the rest of the table.
+  ;; Plain data rows carry the row face and alternating rows the zebra
+  ;; face, so no data row is left unfaced.  `mixed-pitch-mode' and
+  ;; similar remap fonts per face, so an unfaced row can't be kept in
+  ;; the table's font and misaligns.
   (let ((cell-faces
          (lambda (markdown)
            (with-temp-buffer


### PR DESCRIPTION
New face + a small change to ensure that all table text has a face, allowing for non-default styling.

Screenshot with the new face handled by mixed-pitch-mode, resulting in a nicely-aligned table:

<img width="386" height="166" alt="CleanShot 2026-09-11 at 18 44 28@2x" src="https://github.com/user-attachments/assets/c978a6a7-d596-4bb3-9d36-c97cac3b1659" />

## Note

There's a pre-existing issue where tables are not aligned when they contain emojis, even with a regular fixed-pitch font throughout. I didn't touch this because it was a larger scope than you agreed to. My PR didn't make this case worse, and a fix should probably go in a separate PR.

With my change (fixed-pitch font):

<img width="476" height="164" alt="CleanShot 2026-09-11 at 18 44 34@2x" src="https://github.com/user-attachments/assets/c996c13d-3c7f-4a61-8c9d-b799990e421d" />

Without my change (current `main`, 82364bc, fixed-pitch font):

<img width="456" height="262" alt="CleanShot 2026-09-11 at 18 47 27@2x" src="https://github.com/user-attachments/assets/f3e2e1b0-11c9-438d-bd3b-5a7f0e9b5c46" />

## Checklist

- [x] *I agree to communicate (PR description and comments) with the author myself* (not AI-generated).
- [x] *I've reviewed all code in PR myself and will vouch for its quality*.
- [x] I've read and followed the [Contributing](https://github.com/xenodium/agent-shell/blob/main/CONTRIBUTING.org) guidelines.
- [x] I've filed a feature request/discussion for a new feature.
- [x] I'm making visual changes, so I'm including screenshots so you can view and discuss.
- [x] I've added tests where applicable.
- [x] I've updated documentation where necessary.
- [x] I've run `M-x checkdoc` and `M-x byte-compile-file`.
